### PR TITLE
feat(map): map browser binding directive

### DIFF
--- a/src/demo-app/app/app.component.html
+++ b/src/demo-app/app/app.component.html
@@ -86,6 +86,7 @@
         igoOverlay
         igoMapContext
         igoLayerContext
+        igoMapBrowserBinding
         [map]="map">
         <igo-zoom [map]="map" color="primary"></igo-zoom>
       </igo-map-browser>

--- a/src/lib/map/map-browser/index.ts
+++ b/src/lib/map/map-browser/index.ts
@@ -1,1 +1,2 @@
 export * from './map-browser.component';
+export * from './map-browser-binding.directive';

--- a/src/lib/map/map-browser/map-browser-binding.directive.ts
+++ b/src/lib/map/map-browser/map-browser-binding.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, Self, OnInit, OnDestroy } from '@angular/core';
+
+import { MapService } from '../shared';
+import { MapBrowserComponent } from './map-browser.component';
+
+
+@Directive({
+  selector: '[igoMapBrowserBinding]'
+})
+export class MapBrowserBindingDirective implements OnInit, OnDestroy {
+
+  private component: MapBrowserComponent;
+
+  constructor(@Self() component: MapBrowserComponent,
+              private mapService: MapService) {
+    this.component = component;
+  }
+
+  ngOnInit() {
+    if (this.mapService.getMap() !== undefined) {
+      throw new Error('No more than one map be binded to the map service.');
+    }
+
+    this.mapService.setMap(this.component.map);
+  }
+
+  ngOnDestroy() {
+    this.mapService.setMap(undefined);
+  }
+
+}

--- a/src/lib/map/map-browser/map-browser-binding.spec.ts
+++ b/src/lib/map/map-browser/map-browser-binding.spec.ts
@@ -1,0 +1,14 @@
+import { TestBed } from '@angular/core/testing';
+
+describe('MapBrowserBindingDirective', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: []
+    });
+  });
+
+  it('should create an instance', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/src/lib/map/map-browser/map-browser.component.spec.ts
+++ b/src/lib/map/map-browser/map-browser.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { IgoMap, MapService } from '../shared';
+import { IgoMap } from '../shared';
 import { MapBrowserComponent } from './map-browser.component';
 
 
@@ -13,9 +13,6 @@ describe('MapBrowserComponent', () => {
       imports: [],
       declarations: [
         MapBrowserComponent
-      ],
-      providers: [
-        MapService
       ]
     })
     .compileComponents();

--- a/src/lib/map/map-browser/map-browser.component.ts
+++ b/src/lib/map/map-browser/map-browser.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, AfterViewInit } from '@angular/core';
 
-import { IgoMap, MapViewOptions, MapService } from '../shared';
+import { IgoMap, MapViewOptions } from '../shared';
 
 @Component({
   selector: 'igo-map-browser',
@@ -26,10 +26,9 @@ export class MapBrowserComponent implements AfterViewInit {
 
   public id: string = 'igo-map-target';
 
-  constructor(private mapService: MapService) {}
+  constructor() {}
 
   ngAfterViewInit(): any {
     this.map.olMap.setTarget(this.id);
-    this.mapService.setMap(this.map);
   }
 }

--- a/src/lib/map/module.ts
+++ b/src/lib/map/module.ts
@@ -3,7 +3,7 @@ import { NgModule, ModuleWithProviders } from '@angular/core';
 import { IgoSharedModule } from '../shared';
 
 import { MapService } from './shared';
-import { MapBrowserComponent } from './map-browser';
+import { MapBrowserComponent, MapBrowserBindingDirective } from './map-browser';
 import { ZoomComponent } from './zoom';
 
 
@@ -13,10 +13,12 @@ import { ZoomComponent } from './zoom';
   ],
   exports: [
     MapBrowserComponent,
+    MapBrowserBindingDirective,
     ZoomComponent
   ],
   declarations: [
     MapBrowserComponent,
+    MapBrowserBindingDirective,
     ZoomComponent
   ]
 })


### PR DESCRIPTION
- Directive to allow binding a map browser to the map service. This allows for multiple map browser but only one can be binded to the map service at once.