### PR TITLE
Adding route param invisiblelayers and visiblelayers

### DIFF
--- a/src/lib/core/route/route.interface.ts
+++ b/src/lib/core/route/route.interface.ts
@@ -4,4 +4,6 @@ export interface RouteServiceOptions {
   projectionKey?: boolean | string;
   contextKey?: boolean | string;
   searchKey?: boolean | string;
+  visibleOnLayersKey?: boolean | string;
+  visibleOffLayersKey?: boolean | string;
 }

--- a/src/lib/core/route/route.service.ts
+++ b/src/lib/core/route/route.service.ts
@@ -27,7 +27,9 @@ export class RouteService {
       zoomKey: 'zoom',
       projectionKey: 'projection',
       contextKey: 'context',
-      searchKey: 'search'
+      searchKey: 'search',
+      visibleOnLayersKey: 'visiblelayers',
+      visibleOffLayersKey: 'invisiblelayers'
     };
     this.options = Object.assign({}, defaultOptions, options);
   }

--- a/src/lib/datasource/shared/datasources/feature-datasource.ts
+++ b/src/lib/datasource/shared/datasources/feature-datasource.ts
@@ -1,6 +1,6 @@
 import { DataSource } from './datasource';
 import { FeatureDataSourceOptions } from './feature-datasource.interface';
-
+import { Md5 } from 'ts-md5/dist/md5';
 
 export class FeatureDataSource extends DataSource {
 
@@ -16,7 +16,8 @@ export class FeatureDataSource extends DataSource {
   }
 
   protected generateId() {
-    return undefined;
+    const chain = 'feature' + this.options.url;
+    return Md5.hashStr(chain) as string;
   }
 
   private getSourceFormatFromOptions(options: FeatureDataSourceOptions) {

--- a/src/lib/layer/layer-item/layer-item.component.html
+++ b/src/lib/layer/layer-item/layer-item.component.html
@@ -7,7 +7,7 @@
     [collapsed]="layer.collapsed"
     (toggle)="toggleLegend($event)">
   </md-icon>
-  <h4 mdLine [md-tooltip]="layer.title" mdTooltipShowDelay="500">{{layer.title}}</h4>
+  <h4 mdLine [md-tooltip]="layer.title +' ('+ this.getCurrentLayerId()+') '" mdTooltipShowDelay="500">{{layer.title}}</h4>
 
   <button
     md-icon-button

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, OnDestroy, ChangeDetectorRef,
-         ChangeDetectionStrategy } from '@angular/core';
+         ChangeDetectionStrategy, Optional, OnInit} from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
 import { MetadataService, MetadataOptions } from '../../metadata';
 import { Layer } from '../shared/layers/layer';
-
+import { ContextService } from '../../context/shared';
+import { RouteService } from '../../core';
 
 @Component({
   selector: 'igo-layer-item',
@@ -56,10 +57,63 @@ export class LayerItemComponent implements OnDestroy {
   private resolution$$: Subscription;
 
   constructor(private cdRef: ChangeDetectorRef,
-              private metadataService: MetadataService) {}
+              private metadataService: MetadataService,
+              private contextService: ContextService,
+              @Optional() private route: RouteService) {}
 
   ngOnDestroy() {
     this.resolution$$.unsubscribe();
+  }
+  getCurrentLayerId(): any {
+    return this.layer.dataSource.options['id'] ?
+    this.layer.dataSource.options['id'] : this.layer.id;
+  }
+  OnInit() {
+    this.getLayerParamVisibilityUrl();
+   }
+
+   private getLayerParamVisibilityUrl() {
+    const current_context = this.contextService.context$.value['uri'];
+    const current_layerid: string = this.getCurrentLayerId();
+    if (this.route && this.route.options.visibleOnLayersKey &&
+      this.route.options.visibleOffLayersKey &&
+      this.route.options.contextKey ) {
+      this.route.queryParams.subscribe(params => {
+              const contextParams =  params[this.route.options.contextKey as string];
+              if (contextParams === current_context || current_context === '_default' ) {
+                let visibleOnLayersParams = '';
+                let visibleOffLayersParams = '';
+                let visiblelayers: string[] = [];
+                let invisiblelayers: string[] = [];
+
+                if (this.route.options.visibleOnLayersKey &&
+                  params[this.route.options.visibleOnLayersKey as string]) {
+                  visibleOnLayersParams = params[this.route.options.visibleOnLayersKey as string];
+                }
+                if (this.route.options.visibleOffLayersKey &&
+                  params[this.route.options.visibleOffLayersKey as string]) {
+                  visibleOffLayersParams = params[this.route.options.visibleOffLayersKey as string];
+                }
+                /* This order is important because to control whichever
+                the order of * param. First whe open and close everything.*/
+                if (visibleOnLayersParams === '*') {
+                  this.layer.visible = true;
+                }
+                if (visibleOffLayersParams === '*') {
+                  this.layer.visible = false;
+                }
+                // After, managing named layer by id (context.json OR id from datasource)
+                visiblelayers =  visibleOnLayersParams.split(',');
+                invisiblelayers =  visibleOffLayersParams.split(',');
+                if (visiblelayers.indexOf(current_layerid) > -1) {
+                  this.layer.visible = true;
+                }
+                if (invisiblelayers.indexOf(current_layerid) > -1) {
+                  this.layer.visible = false;
+                }
+              }
+      });
+    }
   }
 
   toggleLegend(collapsed: boolean) {

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnDestroy, ChangeDetectorRef,
-         ChangeDetectionStrategy, Optional, OnInit} from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, ChangeDetectorRef,
+         ChangeDetectionStrategy, Optional} from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
 import { MetadataService, MetadataOptions } from '../../metadata';
@@ -13,7 +13,7 @@ import { RouteService } from '../../core';
   styleUrls: ['./layer-item.component.styl'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class LayerItemComponent implements OnDestroy {
+export class LayerItemComponent implements OnInit, OnDestroy {
 
   @Input()
   get layer(): Layer { return this._layer; }
@@ -68,7 +68,7 @@ export class LayerItemComponent implements OnDestroy {
     return this.layer.dataSource.options['id'] ?
     this.layer.dataSource.options['id'] : this.layer.id;
   }
-  OnInit() {
+  ngOnInit() {
     this.getLayerParamVisibilityUrl();
    }
 

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit, ChangeDetectorRef,
-         ChangeDetectionStrategy, Optional} from '@angular/core';
+         ChangeDetectionStrategy, Optional } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
 import { MetadataService, MetadataOptions } from '../../metadata';


### PR DESCRIPTION
If a param named "id" is specified into the context.json user can refer to this value into the url to toggle visibility over pre-defined values into the context. If there is no id defined into the context.json, user can use a pre-generated key (Md5.hashStr(..)).  User can refer to the layer's tooltip to grab the id's value. No "cut and paste" behavior at this time on the tool-tip.

Allowed values are
-  =* (star) for everything         
- comma-separated list : ex =id1,id2
Note that * values are interpreted before named id controls. 

ex: 
http://url/igo2/?context=mtq&invisiblelayers=*&visiblelayers=id1,id2
http://url/igo2/?context=mtq&invisiblelayers=id1,id2&visiblelayers=*
http://url/igo2/?context=mtq&invisiblelayers=id1&visiblelayers=id2

