### PR TITLE
Ogc filter toolbar

### DIFF
--- a/src/demo-app/app/app.component.html
+++ b/src/demo-app/app/app.component.html
@@ -131,7 +131,7 @@
     <mat-card-subtitle>Layer module</mat-card-subtitle>
     <mat-card-title>layer-list.component</mat-card-title>
     <mat-card-content>
-      <igo-layer-list [layers]="map.layers$ | async"></igo-layer-list>
+      <igo-layer-list [ogcFilterInLayerItem]="true" [layers]="map.layers$ | async"></igo-layer-list>
     </mat-card-content>
   </mat-card>
 

--- a/src/demo-app/contexts/_default.json
+++ b/src/demo-app/contexts/_default.json
@@ -77,6 +77,7 @@
     "searchResults",
     "mapDetails",
     "timeAnalysis",
+    "ogcFilter",
     "contextManager",
     "print"
   ],
@@ -85,7 +86,11 @@
       "name": "searchResults"
     },
     {
-      "name": "mapDetails"
+      "name": "mapDetails",
+      "options": {
+        "toggleLegendOnVisibilityChange": true,
+        "ogcFiltersInLayers": true
+      }
     },
     {
       "name": "timeAnalysis"

--- a/src/demo-app/contexts/_default.json
+++ b/src/demo-app/contexts/_default.json
@@ -96,6 +96,9 @@
       "name": "timeAnalysis"
     },
     {
+      "name": "ogcFilter"
+    },
+    {
       "name": "contextManager"
     },
     {

--- a/src/demo-app/contexts/embacle.json
+++ b/src/demo-app/contexts/embacle.json
@@ -90,6 +90,7 @@
   ],
   "toolbar": [
     "timeAnalysis",
+    "ogcFilter",
     "mapDetails",
     "contextManager"
   ],
@@ -97,8 +98,12 @@
     {
       "name": "mapDetails",
       "options": {
-        "toggleLegendOnVisibilityChange": true
+        "toggleLegendOnVisibilityChange": true,
+        "ogcFiltersInLayers": true
       }
+    },
+    {
+      "name": "ogcFilter"
     },
     {
       "name": "timeAnalysis"

--- a/src/demo-app/contexts/wfs_test.json
+++ b/src/demo-app/contexts/wfs_test.json
@@ -130,8 +130,8 @@
         "filtersAreEditable": true,
         "filters": {
           "operator": "PropertyIsEqualTo",
-          "propertyName": "cap_severite",
-          "expression": "Mineure"
+          "propertyName": "certitude",
+          "expression": "Observé"
         }
       }
     },
@@ -201,6 +201,7 @@
     "searchResults",
     "mapDetails",
     "timeAnalysis",
+    "ogcFilter",
     "contextManager",
     "print"
   ],
@@ -209,7 +210,15 @@
       "name": "searchResults"
     },
     {
-      "name": "mapDetails"
+      "name": "mapDetails",
+      "options": {
+        "toggleLegendOnVisibilityChange": true,
+        "excludeBaseLayers": true,
+        "ogcFiltersInLayers": true
+      }
+    },
+    {
+      "name": "ogcFilter"
     },
     {
       "name": "timeAnalysis"

--- a/src/demo-app/contexts/wms_filter.json
+++ b/src/demo-app/contexts/wms_filter.json
@@ -116,6 +116,7 @@
     "toolbar": [
       "searchResults",
       "mapDetails",
+      "ogcFilter",
       "timeAnalysis",
       "contextManager",
       "print"
@@ -124,7 +125,15 @@
         "name": "searchResults"
       },
       {
-        "name": "mapDetails"
+        "name": "mapDetails",
+        "options": {
+          "toggleLegendOnVisibilityChange": true,
+          "excludeBaseLayers": true,
+          "ogcFiltersInLayers": true
+        }
+      },
+      {
+        "name": "ogcFilter"
       },
       {
         "name": "timeAnalysis"

--- a/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
+++ b/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
@@ -206,5 +206,5 @@
       </button>
     </div>
   </div>
-
+  <mat-divider></mat-divider> 
 </mat-list-item>

--- a/src/lib/filter/ogc-filter-form/ogc-filter-form.component.styl
+++ b/src/lib/filter/ogc-filter-form/ogc-filter-form.component.styl
@@ -10,6 +10,15 @@
   height: auto;
 }
 
++media(mobile) {
+  .mat-list-item >>> div.mat-list-item-content {
+    display: inline-table;
+  }
+
+  mat-select {
+    margin-top: 10px;
+  }
+}
 
 .igo-layer-actions-container,
 .igo-layer-legend-container {

--- a/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
+++ b/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
@@ -10,12 +10,12 @@
     </button>
   </span>
 
-  <span *ngIf="datasource.options.download">
+  <!-- <span *ngIf="datasource.options.download">
     <button mat-icon-button tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.download.action' | translate"
       [color]="color" (click)="openDownload()">
       <mat-icon>file_download</mat-icon>
     </button>
-  </span>
+  </span> -->
   <button [disabled]="datasource.options['sourceFields'].length === 0" mat-icon-button tooltip-position="below" matTooltipShowDelay="500"
     [matTooltip]="'igo.filter.addFilter' | translate" [color]="color" (click)="addFilterToSequence()">
     <mat-icon>

--- a/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
+++ b/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
@@ -1,6 +1,4 @@
 <mat-list-item>
-  <!-- //<mat-icon class="igo-chevron" mat-list-avatar igoCollapse [target]="ogcFilters" [collapsed]="false"> 
-  </mat-icon> -->
   <h4 matLine [matTooltip]="datasource.title" matTooltipShowDelay="500"></h4>
 
   <span *ngIf="!datasource.options['disableRefreshFilter'] && layers[0].visible">

--- a/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
+++ b/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
@@ -1,7 +1,7 @@
 <mat-list-item>
-  <mat-icon class="igo-chevron" mat-list-avatar igoCollapse [target]="ogcFilters" [collapsed]="false">
-  </mat-icon>
-  <h4 matLine [matTooltip]="datasource.title" matTooltipShowDelay="500">{{datasource.title}}</h4>
+  <!-- //<mat-icon class="igo-chevron" mat-list-avatar igoCollapse [target]="ogcFilters" [collapsed]="false"> 
+  </mat-icon> -->
+  <h4 matLine [matTooltip]="datasource.title" matTooltipShowDelay="500"></h4>
 
   <span *ngIf="!datasource.options['disableRefreshFilter'] && layers[0].visible">
     <button mat-icon-button tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.filter.refreshFilters' | translate"

--- a/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
+++ b/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
@@ -1,5 +1,8 @@
 <mat-list-item>
-  <h4 matLine [matTooltip]="datasource.title" matTooltipShowDelay="500"></h4>
+  <mat-icon *ngIf="ogcFiltersHeaderShown" class="igo-chevron" mat-list-avatar igoCollapse [target]="ogcFilters" [collapsed]="false">
+  </mat-icon>
+  <h4 *ngIf="ogcFiltersHeaderShown" matLine [matTooltip]="datasource.title" matTooltipShowDelay="500">{{datasource.title}}</h4>
+  <h4 *ngIf="!ogcFiltersHeaderShown" matLine></h4>
 
   <span *ngIf="!datasource.options['disableRefreshFilter'] && layers[0].visible">
     <button mat-icon-button tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.filter.refreshFilters' | translate"
@@ -10,12 +13,12 @@
     </button>
   </span>
 
-  <!-- <span *ngIf="datasource.options.download">
+  <span *ngIf="datasource.options.download && ogcFiltersHeaderShown">
     <button mat-icon-button tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.download.action' | translate"
       [color]="color" (click)="openDownload()">
       <mat-icon>file_download</mat-icon>
     </button>
-  </span> -->
+  </span>
   <button [disabled]="datasource.options['sourceFields'].length === 0" mat-icon-button tooltip-position="below" matTooltipShowDelay="500"
     [matTooltip]="'igo.filter.addFilter' | translate" [color]="color" (click)="addFilterToSequence()">
     <mat-icon>

--- a/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -24,6 +24,13 @@ export class OgcFilterableItemComponent implements OnInit, OnDestroy {
   }
   private _dataSource: OgcFilterableDataSource;
 
+  @Input()
+  get ogcFiltersHeaderShown(): boolean { return this._ogcFiltersHeaderShown; }
+  set ogcFiltersHeaderShown(value: boolean) {
+    this._ogcFiltersHeaderShown = value;
+  }
+  private _ogcFiltersHeaderShown: boolean;
+
   constructor(
     private mapService: MapService,
     private downloadService: DownloadService) { }

--- a/src/lib/filter/ogc-filterable-list/ogc-filterable-list.component.html
+++ b/src/lib/filter/ogc-filterable-list/ogc-filterable-list.component.html
@@ -1,6 +1,6 @@
 <igo-list [navigation]="false" [selection]="false">
   <ng-template ngFor let-datasource [ngForOf]="datasources | filterableDataSource: 'ogc'">
-    <igo-ogc-filterable-item igoListItem [datasource]="datasource"></igo-ogc-filterable-item>
+    <igo-ogc-filterable-item igoListItem [ogcFiltersHeaderShown]="true" [datasource]="datasource"></igo-ogc-filterable-item>
   </ng-template>
   <ng-content></ng-content>
 </igo-list>

--- a/src/lib/layer/layer-item/layer-item.component.html
+++ b/src/lib/layer/layer-item/layer-item.component.html
@@ -10,21 +10,6 @@
   <h4 matLine [matTooltip]="layer.title +' ('+ id +') '" matTooltipShowDelay="500">{{layer.title}}</h4>
 
 
-<button *ngIf="layer.dataSource.options.isOgcFilterable && layer.isInResolutionsRange 
-&& layer.dataSource.options.ogcFilters.filtersAreEditable"
-  mat-icon-button
-  collapsibleButton
-  tooltip-position="below"
-  matTooltipShowDelay="500"
-  [matTooltip]="'igo.ogcFilter' | translate"
-  [color]="layer.visible ? color : 'default'"
-  (click)="toggleOgcFilter()">
-  <mat-icon
-  [ngClass]='{disabled: !layer.isInResolutionsRange}'>
-  filter_list</mat-icon>
-</button>
-
-
 
   <button
     mat-icon-button
@@ -75,6 +60,20 @@
 
   <div class="igo-col igo-col-60 igo-col-100-m">
     <div class="igo-layer-button-group">
+        <button *ngIf="layer.dataSource.options.isOgcFilterable 
+        && layer.isInResolutionsRange 
+        && layer.dataSource.options.ogcFilters.filtersAreEditable && ogcFilterInLayerItem"
+          mat-icon-button
+          collapsibleButton
+          tooltip-position="below"
+          matTooltipShowDelay="500"
+          [matTooltip]="'igo.ogcFilter' | translate"
+          [color]="color"
+          (click)="toggleOgcFilter()">
+          <mat-icon
+          [ngClass]='{disabled: !layer.isInResolutionsRange}'>
+          filter_list</mat-icon>
+        </button>
       <button
         *ngIf="isVectorLayer(layer)"
         mat-icon-button
@@ -147,5 +146,7 @@
   <igo-layer-legend *ngIf="legendLoaded" [layer]="layer"></igo-layer-legend>
 </div>
 <div #ogcFilter class="igo-layer-actions-container">
-  <igo-ogc-filterable-item *ngIf="ogcFilterCollapse && layer.dataSource.options.isOgcFilterable" igoListItem [datasource]="layer.dataSource"></igo-ogc-filterable-item>
+  <igo-ogc-filterable-item *ngIf="ogcFilterCollapse && layer.dataSource.options.isOgcFilterable" igoListItem 
+  [ogcFiltersHeaderShown]="false"
+  [datasource]="layer.dataSource"></igo-ogc-filterable-item>
 </div>

--- a/src/lib/layer/layer-item/layer-item.component.html
+++ b/src/lib/layer/layer-item/layer-item.component.html
@@ -9,17 +9,22 @@
   </mat-icon>
   <h4 matLine [matTooltip]="layer.title +' ('+ id +') '" matTooltipShowDelay="500">{{layer.title}}</h4>
 
-  <button
-    *ngIf="layer.dataSource.options['ogcFiltered']"
-    mat-icon-button
-    collapsibleButton
-    tooltip-position="below"
-    matTooltipShowDelay="500"
-    [matTooltip]="'igo.filter.layerFiltered' | translate"
-    color="gray"
-    disabled = true>
-    <mat-icon> filter_list </mat-icon>
-  </button>
+
+<button *ngIf="layer.dataSource.options.isOgcFilterable && layer.isInResolutionsRange 
+&& layer.dataSource.options.ogcFilters.filtersAreEditable"
+  mat-icon-button
+  collapsibleButton
+  tooltip-position="below"
+  matTooltipShowDelay="500"
+  [matTooltip]="'igo.ogcFilter' | translate"
+  [color]="layer.visible ? color : 'default'"
+  (click)="toggleOgcFilter()">
+  <mat-icon
+  [ngClass]='{disabled: !layer.isInResolutionsRange}'>
+  filter_list</mat-icon>
+</button>
+
+
 
   <button
     mat-icon-button
@@ -140,4 +145,7 @@
 
 <div #legend class="igo-layer-legend-container">
   <igo-layer-legend *ngIf="legendLoaded" [layer]="layer"></igo-layer-legend>
+</div>
+<div #ogcFilter class="igo-layer-actions-container">
+  <igo-ogc-filterable-item *ngIf="ogcFilterCollapse && layer.dataSource.options.isOgcFilterable" igoListItem [datasource]="layer.dataSource"></igo-ogc-filterable-item>
 </div>

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -50,6 +50,17 @@ export class LayerItemComponent implements OnDestroy {
   }
   private _toggleLegendOnVisibilityChange: boolean = false;
 
+  @Input()
+  get ogcFilterInLayerItem() {
+    return this._ogcFilterInLayers;
+  }
+  set ogcFilterInLayerItem(value: boolean) {
+    this._ogcFilterInLayers = value;
+  }
+  private _ogcFilterInLayers: boolean  = false;
+
+
+
   get opacity () {
     return this.layer.opacity * 100;
   }
@@ -92,7 +103,7 @@ export class LayerItemComponent implements OnDestroy {
     if (this.layer.isInResolutionsRange) {
       this.ogcFilterCollapse = !this.ogcFilterCollapse;
     }
-  } 
+  }
 
   openMetadata(metadata: MetadataOptions) {
     this.metadataService.open(metadata);

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -59,8 +59,6 @@ export class LayerItemComponent implements OnDestroy {
   }
   private _ogcFilterInLayers: boolean  = false;
 
-
-
   get opacity () {
     return this.layer.opacity * 100;
   }

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -64,6 +64,7 @@ export class LayerItemComponent implements OnDestroy {
   }
 
   public legendLoaded = false;
+  public ogcFilterCollapse = false;
   private resolution$$: Subscription;
 
   constructor(private cdRef: ChangeDetectorRef,
@@ -87,6 +88,11 @@ export class LayerItemComponent implements OnDestroy {
       this.toggleLegend(!this.layer.visible);
     }
   }
+  toggleOgcFilter() {
+    if (this.layer.isInResolutionsRange) {
+      this.ogcFilterCollapse = !this.ogcFilterCollapse;
+    }
+  } 
 
   openMetadata(metadata: MetadataOptions) {
     this.metadataService.open(metadata);

--- a/src/lib/layer/layer-list/layer-list.component.html
+++ b/src/lib/layer/layer-list/layer-list.component.html
@@ -4,6 +4,7 @@
         igoListItem
         [color]="color"
         [layer]="layer"
+        [ogcFilterInLayerItem]="ogcFilterInLayerItem"
         [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
     </igo-layer-item>
   </ng-template>

--- a/src/lib/layer/layer-list/layer-list.component.ts
+++ b/src/lib/layer/layer-list/layer-list.component.ts
@@ -45,6 +45,16 @@ export class LayerListComponent {
   }
   private _toggleLegendOnVisibilityChange: boolean = false;
 
+  @Input()
+  get ogcFilterInLayerItem() {
+    return this._ogcFilterInLayers;
+  }
+  set ogcFilterInLayerItem(value: boolean) {
+    this._ogcFilterInLayers = value;
+  }
+  private _ogcFilterInLayers: boolean = false;
+
+
   constructor(private cdRef: ChangeDetectorRef) { }
 
 }

--- a/src/lib/layer/module.ts
+++ b/src/lib/layer/module.ts
@@ -1,6 +1,7 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { IgoSharedModule } from '../shared';
+import { IgoFilterModule } from '../filter';
 
 import { LayerService, StyleService } from './shared';
 import { LayerItemComponent } from './layer-item';
@@ -9,7 +10,8 @@ import { LayerListComponent, LayerListBindingDirective } from './layer-list';
 
 @NgModule({
   imports: [
-    IgoSharedModule
+    IgoSharedModule,
+    IgoFilterModule
   ],
   exports: [
     LayerItemComponent,

--- a/src/lib/tool/module.ts
+++ b/src/lib/tool/module.ts
@@ -28,7 +28,8 @@ import { ContextManagerToolComponent,
          SearchResultsToolComponent,
          PrintToolComponent,
          ShareMapToolComponent,
-         TimeAnalysisToolComponent } from './tools';
+         TimeAnalysisToolComponent,
+         OgcFilterToolComponent} from './tools';
 
 const IGO_TOOLS = [
   ContextManagerToolComponent,
@@ -42,7 +43,8 @@ const IGO_TOOLS = [
   SearchResultsToolComponent,
   PrintToolComponent,
   ShareMapToolComponent,
-  TimeAnalysisToolComponent
+  TimeAnalysisToolComponent,
+  OgcFilterToolComponent
 ];
 
 @NgModule({

--- a/src/lib/tool/tools/index.ts
+++ b/src/lib/tool/tools/index.ts
@@ -10,3 +10,4 @@ export * from './print-tool';
 export * from './search-results-tool';
 export * from './share-map-tool';
 export * from './time-analysis-tool';
+export * from './ogc-filter-tool';

--- a/src/lib/tool/tools/map-details-tool/map-details-tool.component.html
+++ b/src/lib/tool/tools/map-details-tool/map-details-tool.component.html
@@ -1,5 +1,6 @@
 <igo-layer-list
   igoLayerListBinding
   [excludeBaseLayers]="excludeBaseLayers"
+  [ogcFilterInLayerItem]="ogcFilterInLayerItem"
   [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 </igo-layer-list>

--- a/src/lib/tool/tools/map-details-tool/map-details-tool.component.ts
+++ b/src/lib/tool/tools/map-details-tool/map-details-tool.component.ts
@@ -30,11 +30,9 @@ export class MapDetailsToolComponent {
   }
 
   get ogcFilterInLayerItem(): boolean {
-    const r = this.options.ogcFiltersInLayers === undefined ?
-    true : this.options.ogcFiltersInLayers;
-    return r;
+    return this.options.ogcFiltersInLayers === undefined ?
+      true : this.options.ogcFiltersInLayers;
   }
-
 
   constructor() { }
 

--- a/src/lib/tool/tools/map-details-tool/map-details-tool.component.ts
+++ b/src/lib/tool/tools/map-details-tool/map-details-tool.component.ts
@@ -29,6 +29,13 @@ export class MapDetailsToolComponent {
       false : this.options.excludeBaseLayers;
   }
 
+  get ogcFilterInLayerItem(): boolean {
+    const r = this.options.ogcFiltersInLayers === undefined ?
+    true : this.options.ogcFiltersInLayers;
+    return r;
+  }
+
+
   constructor() { }
 
 }

--- a/src/lib/tool/tools/map-details-tool/map-details-tool.interface.ts
+++ b/src/lib/tool/tools/map-details-tool/map-details-tool.interface.ts
@@ -1,4 +1,5 @@
 export interface MapDetailsToolOptions {
   toggleLegendOnVisibilityChange?: boolean;
   excludeBaseLayers?: boolean;
+  ogcFiltersInLayers?: boolean;
 }

--- a/src/lib/tool/tools/ogc-filter-tool/index.ts
+++ b/src/lib/tool/tools/ogc-filter-tool/index.ts
@@ -1,0 +1,1 @@
+export * from './ogc-filter-tool.component';

--- a/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.html
+++ b/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.html
@@ -1,0 +1,3 @@
+<igo-ogc-filterable-list igoOgcFilterableListBinding></igo-ogc-filterable-list>
+
+

--- a/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.spec.ts
+++ b/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.spec.ts
@@ -1,0 +1,35 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IgoSharedModule } from '../../../shared';
+import { IgoFilterModule } from '../../../filter';
+import { IgoMapModule } from '../../../map';
+
+import { OgcFilterToolComponent } from './ogc-filter-tool.component';
+
+describe('TimeAnalysisToolComponent', () => {
+  let component: OgcFilterToolComponent;
+  let fixture: ComponentFixture<OgcFilterToolComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        IgoSharedModule,
+        IgoFilterModule.forRoot(),
+        IgoMapModule.forRoot()
+      ],
+      declarations: [
+        OgcFilterToolComponent
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OgcFilterToolComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.ts
+++ b/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+
+import { Register } from '../../shared';
+
+
+@Register({
+  name: 'ogcFilter',
+  title: 'igo.ogcFilter',
+  icon: 'filter_list'
+})
+@Component({
+  selector: 'igo-ogc-filter-tool',
+  templateUrl: './ogc-filter-tool.component.html',
+  styleUrls: ['./ogc-filter-tool.component.styl']
+})
+export class OgcFilterToolComponent {
+
+
+  constructor() { }
+
+}

--- a/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.ts
+++ b/src/lib/tool/tools/ogc-filter-tool/ogc-filter-tool.component.ts
@@ -15,7 +15,6 @@ import { Register } from '../../shared';
 })
 export class OgcFilterToolComponent {
 
-
   constructor() { }
 
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -112,7 +112,7 @@
 		"sourceFields": {
 		  "selectField": "Choose a field"
 		},
-		"ogcFilter": "Filters by (spatial & attributes)",
+		"ogcFilter": "Filter by",
 		"filter": {
 		  "addFilter": "Add an empty filter to the current list",
 		  "removeFilter": "Remove the current filter from the filters's list",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -112,12 +112,14 @@
 		"sourceFields": {
 		  "selectField": "Choose a field"
 		},
+		"ogcFilter": "Filters by (spatial & attributes)",
 		"filter": {
 		  "addFilter": "Add an empty filter to the current list",
 		  "removeFilter": "Remove the current filter from the filters's list",
 		  "toggleFilterState": "Enable/disable the current filter",
 		  "refreshFilters": "Update this datasource with the active filter(s)",
-		  "layerFiltered": "This layer is currently filtered"
+		  "layerFiltered": "This layer is currently filtered",
+		  "layerFilterable": "This layer is filterable"
 		},
 		"spatialSelector": {
 		  "fixedExtent": "Fixed extent",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -112,7 +112,7 @@
 		"sourceFields": {
 		  "selectField": "Choisir un champ"
 		},
-		"ogcFilter": "Filtrer par (géométrie & attributs)",
+		"ogcFilter": "Filtrer par",
 		"filter": {
 		  "addFilter": "Ajouter un filtre vidre à la liste courante",
 		  "removeFilter": "Supprimer le présent filtre à la liste des filtres",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -112,12 +112,14 @@
 		"sourceFields": {
 		  "selectField": "Choisir un champ"
 		},
+		"ogcFilter": "Filtrer par (géométrie & attributs)",
 		"filter": {
 		  "addFilter": "Ajouter un filtre vidre à la liste courante",
 		  "removeFilter": "Supprimer le présent filtre à la liste des filtres",
 		  "toggleFilterState": "Activer/désactiver le présent filtre",
 		  "refreshFilters": "Mettre à jour la source de donnée avec les filtres actifs de la liste",
-		  "layerFiltered": "Cette couche d'information est présentement filtrée."
+		  "layerFiltered": "Cette couche d'information est présentement filtrée.",
+		  "layerFilterable": "Cette couche d'information est filtrable"
 		},	
 		"spatialSelector": {
 		  "fixedExtent": "Étendue fixe",


### PR DESCRIPTION
Adding an ogcFilter-tool in the toolbar.

IF the context.json contain a  
`"toolbar": ["ogcFilter"],`
and  `  "tools": [{"name": "ogcFilter"}]`
User will be able to edit filters. 

Into the mapDetails options, you can control IF the filter will be shown into the layer-list-item section or not.
`{
      "name": "mapDetails",
      "options": {"ogcFiltersInLayers": true }
    },`

See picture bellow.
![image](https://user-images.githubusercontent.com/7397743/39548099-81a61e32-4e27-11e8-842f-5c3a37367a31.png)

ON CLICK GIVE

![image](https://user-images.githubusercontent.com/7397743/39548107-88dc35ba-4e27-11e8-9810-b8a5bae7a033.png)


