### PR TITLE
Npm package change

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -37,13 +37,12 @@
       "prefix": "demo",
       "mobile": true,
       "styles": [
-        "../../node_modules/openlayers/dist/ol.css",
+        "../../node_modules/ol/ol.css",
         "../themes/deeppurple-amber.styl",
         "../style/igo.styl",
         "style/main.styl"
       ],
       "scripts": [
-        "../../node_modules/openlayers/dist/ol.js",
         "../../node_modules/jspdf/dist/jspdf.min.js"
       ],
       "environmentSource": "environments/environment.ts",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,6 @@ module.exports = function (config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     files: [
-      './node_modules/openlayers/dist/ol.js',
       {
         pattern: './src/locale/*.json',
         watched: false,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "hammerjs": "^2.0.8",
     "jspdf": "^1.3.5",
     "jwt-decode": "^2.2.0",
-    "openlayers": "^4.6.5",
+    "ol": "^4.6.5",
     "rxjs": "^5.5.2",
     "ts-md5": "^1.2.0",
     "zone.js": "^0.8.19"
@@ -72,6 +72,7 @@
     "@types/jasminewd2": "~2.0.2",
     "@types/jspdf": "^1.1.31",
     "@types/node": "^6.0.68",
+    "@types/ol": "^4.6.2",
     "@types/openlayers": "^4.6.5",
     "@types/yargs": "^10.0.1",
     "angular2-template-loader": "^0.6.2",

--- a/src/demo-app/contexts/_contexts.json
+++ b/src/demo-app/contexts/_contexts.json
@@ -14,5 +14,9 @@
   {
     "uri": "embacle",
     "title": "Embâcle (analyse temporelle)"
+  },
+  {
+    "uri": "various_sources",
+    "title": "Various datasources"
   }
 ]

--- a/src/demo-app/contexts/various_sources.json
+++ b/src/demo-app/contexts/various_sources.json
@@ -24,7 +24,7 @@
         "type" : "osm"
       },
       {
-        "title": "Vector geojson (feature-datasource)",
+        "title": "feature-datasource geojson",
         "type" : "vector",
         "formatType": "geojson",
         "source":{
@@ -32,7 +32,7 @@
         }
       },
       {
-        "title": "Vector kml (white-colored) (feature-datasource)",
+        "title": "feature-datasource kml (white-colored)",
         "type" : "vector",
         "formatType": "kml",
         "source":{

--- a/src/demo-app/contexts/various_sources.json
+++ b/src/demo-app/contexts/various_sources.json
@@ -1,0 +1,108 @@
+{
+    "uri": "various_datasources",
+    "title": "Various datasources",
+    "map": {
+      "view": {
+        "projection": "EPSG:3857",
+        "center": [-72, 50],
+        "zoom": 5,
+        "geolocate": true
+      }
+    },
+    "layers": [
+      
+      {
+        "title": "xyz-datasource",
+        "type": "xyz",
+        "source": {
+          "url": "https://geoegl.msp.gouv.qc.ca/carto/tms/1.0.0/carte_gouv_qc_ro@EPSG_3857/{z}/{x}/{-y}.png"
+        }
+      },
+      {
+        "visible": false,
+        "title" : "OSM-datasource",
+        "type" : "osm"
+      },
+      {
+        "title": "Vector geojson (feature-datasource)",
+        "type" : "vector",
+        "formatType": "geojson",
+        "source":{
+            "url" : "https://geoegl.msp.gouv.qc.ca/ws/adnInternetV2.fcgi?outputformat=geojson&service=WFS&version=1.1.0&request=GetFeature&typename=adn_bassin_n1_simplify_500&srsname=EPSG:3857"
+        }
+      },
+      {
+        "title": "Vector kml (white-colored) (feature-datasource)",
+        "type" : "vector",
+        "formatType": "kml",
+        "source":{
+            "url" : "https://ahocevar.com/geoserver/wms?service=wfs&request=GetFeature&version=1.1.0&typename=water_areas&srsname=EPSG:3857&maxFeatures=10000&outputformat=application/vnd.google-earth.kml+xml"
+        }
+      },
+      {
+        "title": "WMS-datasource",
+        "type": "wms",
+        "visible": true,
+        "optionsFromCapabilities": true,
+        "metadata": {
+            "extern": true
+        },
+        "source": {
+            "url": "https://geoegl.msp.gouv.qc.ca/ws/adnInternetV2.fcgi",
+            "params": {
+                "layers": "adn_reg_admin_public_v",
+                "version": "1.3.0"
+            }
+        }
+      },
+      {
+        "visible": true,
+        "title": "WFS-datasource",
+        "type": "wfs",
+        "source": {
+          "url": "https://ws.mapserver.transports.gouv.qc.ca/swtq",
+          "featureTypes": "bgr_v_centr_servc_geomt_act",
+          "fieldNameGeometry": "geometry",
+          "maxFeatures": 10000,
+          "version": "2.0.0",
+          "outputFormat": "geojson",
+          "outputFormatDownload": "shp"
+        }
+      }
+        
+
+    ],
+    "toolbar": [
+      "searchResults",
+      "mapDetails",
+      "timeAnalysis",
+      "ogcFilter",
+      "contextManager",
+      "print"
+    ],
+    "tools": [
+      {
+        "name": "searchResults"
+      },
+      {
+        "name": "mapDetails",
+        "options": {
+          "toggleLegendOnVisibilityChange": true,
+          "ogcFiltersInLayers": true
+        }
+      },
+      {
+        "name": "timeAnalysis"
+      },
+      {
+        "name": "ogcFilter"
+      },
+      {
+        "name": "contextManager"
+      },
+      {
+        "name": "print"
+      }
+    ]
+  }
+  

--- a/src/lib/context/shared/context.service.ts
+++ b/src/lib/context/shared/context.service.ts
@@ -8,7 +8,7 @@ import { tap } from 'rxjs/operators/tap';
 import { catchError } from 'rxjs/operators/catchError';
 import { debounceTime } from 'rxjs/operators/debounceTime';
 
-import * as ol from 'openlayers';
+import Point from 'ol/geom/polygon';
 
 import { uuid } from '../../utils/uuid';
 import { ConfigService, RouteService,
@@ -303,7 +303,7 @@ deletePermissionAssociation(contextId: string, permissionId: string): Observable
   getContextFromMap(igoMap: IgoMap): DetailedContext {
     const view = igoMap.ol.getView();
     const proj = view.getProjection().getCode();
-    const center: any = new ol.geom.Point(view.getCenter()).transform(proj, 'EPSG:4326');
+    const center: any = new Point(view.getCenter() as any).transform(proj, 'EPSG:4326');
 
     const context = {
       uri: uuid(),

--- a/src/lib/datasource/shared/capabilities.service.ts
+++ b/src/lib/datasource/shared/capabilities.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
-import * as ol from 'openlayers';
+import WMSCapabilities from 'ol/format/wmscapabilities';
+import WMTSCapabilities from 'ol/format/wmtscapabilities';
+import WMTS from 'ol/source/wmts';
 
 import { ObjectUtils } from '../../utils';
 import { TimeFilterOptions } from '../../filter';
@@ -15,8 +17,8 @@ export class CapabilitiesService {
 
   private capabilitiesStore: any[] = [];
   private parsers = {
-    'wms': new ol.format.WMSCapabilities(),
-    'wmts': new ol.format.WMTSCapabilities()
+    'wms': new WMSCapabilities(),
+    'wmts': new WMTSCapabilities()
   };
 
   constructor(private http: HttpClient) { }
@@ -112,7 +114,7 @@ export class CapabilitiesService {
 
   private parseWMTSOptions(baseOptions: WMTSDataSourceOptions,
                            capabilities: any): WMTSDataSourceOptions {
-    const options = ol.source.WMTS.optionsFromCapabilities(
+    const options = WMTS.optionsFromCapabilities(
       capabilities, baseOptions);
 
     return Object.assign(options, baseOptions);

--- a/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 
 import { TimeFilterOptions, OgcFiltersOptions } from '../../../filter';
 import { QueryFormat, QueryOptions } from '../../../query';

--- a/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import { DataSourceOptions, DataSourceContext } from './datasource.interface';
 
 export interface FeatureDataSourceOptions extends DataSourceOptions, ol.olx.source.VectorOptions {

--- a/src/lib/datasource/shared/datasources/feature-datasource.ts
+++ b/src/lib/datasource/shared/datasources/feature-datasource.ts
@@ -33,7 +33,7 @@ export class FeatureDataSource extends DataSource {
     let olFormatCls;
     const formatType =
     options.formatType === undefined ? undefined : options.formatType.toLowerCase();
-    // Only geojson supported
+    // Only geojson & kml supported
     if (formatType) {
       switch (formatType) {
         case 'geojson':

--- a/src/lib/datasource/shared/datasources/feature-datasource.ts
+++ b/src/lib/datasource/shared/datasources/feature-datasource.ts
@@ -1,4 +1,6 @@
-import * as ol from 'openlayers';
+import Vector from 'ol/source/vector';
+import GeoJSON from 'ol/format/geojson';
+
 import { Md5 } from 'ts-md5/dist/md5';
 
 import { uuid } from '../../../utils';
@@ -9,14 +11,14 @@ import { FeatureDataSourceOptions } from './feature-datasource.interface';
 export class FeatureDataSource extends DataSource {
 
   public options: FeatureDataSourceOptions;
-  public ol: ol.source.Vector;
+  public ol: Vector;
 
-  protected createOlSource(): ol.source.Vector {
+  protected createOlSource(): Vector {
     const sourceOptions = {
       format: this.getSourceFormatFromOptions(this.options)
     };
 
-    return new ol.source.Vector(Object.assign(sourceOptions, this.options));
+    return new Vector(Object.assign(sourceOptions, this.options));
   }
 
   protected generateId() {
@@ -31,14 +33,13 @@ export class FeatureDataSource extends DataSource {
     let olFormatCls;
     const formatType = options.formatType;
     if (!formatType) {
-      olFormatCls = ol.format.GeoJSON;
-    } else {
+      olFormatCls = GeoJSON;
+    } /*else {
       olFormatCls = ol.format[formatType];
       if (olFormatCls === undefined) {
         throw new Error('Invalid vector source format ${formatType}.');
       }
-    }
-
+    }*/
     const formatOptions = options.formatOptions;
     let format;
     if (formatOptions) {

--- a/src/lib/datasource/shared/datasources/feature-datasource.ts
+++ b/src/lib/datasource/shared/datasources/feature-datasource.ts
@@ -1,6 +1,6 @@
 import Vector from 'ol/source/vector';
 import GeoJSON from 'ol/format/geojson';
-
+import KML from 'ol/format/kml';
 import { Md5 } from 'ts-md5/dist/md5';
 
 import { uuid } from '../../../utils';
@@ -31,15 +31,25 @@ export class FeatureDataSource extends DataSource {
 
   private getSourceFormatFromOptions(options: FeatureDataSourceOptions) {
     let olFormatCls;
-    const formatType = options.formatType;
-    if (!formatType) {
-      olFormatCls = GeoJSON;
-    } /*else {
-      olFormatCls = ol.format[formatType];
-      if (olFormatCls === undefined) {
-        throw new Error('Invalid vector source format ${formatType}.');
-      }
-    }*/
+    const formatType =
+    options.formatType === undefined ? undefined : options.formatType.toLowerCase();
+    // Only geojson supported
+    if (formatType) {
+      switch (formatType) {
+        case 'geojson':
+          olFormatCls = GeoJSON;
+          break;
+        case 'kml':
+          olFormatCls = KML;
+          break;
+        default:
+          console.log('Invalid vector source format.');
+          break;
+        }
+       } else {
+          return;
+        }
+
     const formatOptions = options.formatOptions;
     let format;
     if (formatOptions) {

--- a/src/lib/datasource/shared/datasources/osm-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/osm-datasource.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import { DataSourceOptions, DataSourceContext } from './datasource.interface';
 
 export interface OSMDataSourceOptions extends DataSourceOptions, ol.olx.source.OSMOptions {}

--- a/src/lib/datasource/shared/datasources/osm-datasource.ts
+++ b/src/lib/datasource/shared/datasources/osm-datasource.ts
@@ -1,5 +1,5 @@
-import * as ol from 'openlayers';
 
+import OSM from 'ol/source/osm';
 import { DataSource } from './datasource';
 import { OSMDataSourceOptions } from './osm-datasource.interface';
 
@@ -7,10 +7,10 @@ import { OSMDataSourceOptions } from './osm-datasource.interface';
 export class OSMDataSource extends DataSource {
 
   public options: OSMDataSourceOptions;
-  public ol: ol.source.OSM;
+  public ol: OSM;
 
   protected createOlSource(): ol.source.OSM {
-   return new ol.source.OSM(this.options);
+   return new OSM(this.options);
   }
 
   protected generateId() {

--- a/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import {
   DataSourceOptions,
   DataSourceContext,

--- a/src/lib/datasource/shared/datasources/wfs-datasource.service.ts
+++ b/src/lib/datasource/shared/datasources/wfs-datasource.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
-import * as ol from 'openlayers';
+import GeoJSON from 'ol/format/geojson';
+import WFS from 'ol/format/wfs';
 
 import { OgcFiltersOptions } from '../../../filter/shared';
 import { WFSDataSourceOptions } from './wfs-datasource.interface';
@@ -28,10 +29,10 @@ export class WFSDataSourceService extends DataService {
     const patternGeojson = new RegExp('.*?json.*?');
 
     if (patternGeojson.test(outputFormat)) {
-      olFormatCls = ol.format.GeoJSON;
+      olFormatCls = GeoJSON;
     }
     if (patternGml3.test(outputFormat)) {
-      olFormatCls = ol.format.WFS;
+      olFormatCls = WFS;
     }
 
     return new olFormatCls();
@@ -168,9 +169,9 @@ export class WFSDataSourceService extends DataService {
     let olFormats;
     const patternGml3 = /gml/gi;
     if (wfsDataSourceOptions.outputFormat.match(patternGml3)) {
-      olFormats = ol.format.WFS;
+      olFormats = WFS;
     } else {
-      olFormats = ol.format.GeoJSON;
+      olFormats = GeoJSON;
     }
     if (wfsDataSourceOptions['wfsCapabilities']['GetPropertyValue']) {
       this.wfsGetFeature(wfsDataSourceOptions, 1).subscribe((oneFeature) => {

--- a/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
-import * as ol from 'openlayers';
 
+import Vector from 'ol/source/vector';
+import loadingstrategy from 'ol/loadingstrategy';
 import { uuid } from '../../../utils';
 import {
   IgoOgcFilterObject, OgcFilter, WFSWriteGetFeatureOptions,
@@ -72,12 +73,12 @@ export class WFSDataSource extends DataSource implements OgcFilterableDataSource
     return uuid();
   }
 
-  protected createOlSource(): ol.source.Vector {
+  protected createOlSource(): Vector {
     const wfsOptions: WFSDataSourceOptions = this.options
 
     this.dataSourceService.checkWfsOptions(wfsOptions);
 
-    return new ol.source.Vector({
+    return new Vector({
       format: this.dataSourceService.getFormatFromOptions(wfsOptions),
       overlaps: false,
       url: function(extent: ol.Extent, resolution, proj) {
@@ -121,7 +122,7 @@ export class WFSDataSource extends DataSource implements OgcFilterableDataSource
           this.options['download'], { 'dynamicUrl': baseUrl });
         return baseUrl;
       }.bind(this),
-      strategy: ol.loadingstrategy.bbox
+      strategy: loadingstrategy.bbox
     });
 
   }

--- a/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+
 import { DataSourceContext,
   TimeFilterableDataSourceOptions,
   QueryableDataSourceOptions, OgcFilterableDataSourceOptions } from './datasource.interface';

--- a/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
@@ -1,4 +1,3 @@
-
 import { DataSourceContext,
   TimeFilterableDataSourceOptions,
   QueryableDataSourceOptions, OgcFilterableDataSourceOptions } from './datasource.interface';

--- a/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+import ImageWMS from 'ol/source/imagewms';
 import { Md5 } from 'ts-md5/dist/md5';
 
 import { QueryFormat, QueryOptions } from '../../../query';
@@ -206,7 +206,7 @@ export class WMSDataSource extends DataSource
   }
 
   protected createOlSource(): ol.source.ImageWMS {
-    return new ol.source.ImageWMS(this.options);
+    return new ImageWMS(this.options);
   }
 
   protected generateId() {

--- a/src/lib/datasource/shared/datasources/wmts-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/wmts-datasource.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import { DataSourceOptions, DataSourceContext } from './datasource.interface';
 
 export interface WMTSDataSourceOptions extends DataSourceOptions, ol.olx.source.WMTSOptions {

--- a/src/lib/datasource/shared/datasources/wmts-datasource.ts
+++ b/src/lib/datasource/shared/datasources/wmts-datasource.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+import WMTS from 'ol/source/wmts';
 import { Md5 } from 'ts-md5/dist/md5';
 
 import { createDefaultTileGrid } from '../../../utils/tilegrid';
@@ -15,12 +15,12 @@ export class WMTSDataSource extends DataSource {
     super(options);
   }
 
-  protected createOlSource(): ol.source.WMTS {
+  protected createOlSource(): WMTS {
     const sourceOptions = Object.assign({
       tileGrid: createDefaultTileGrid(this.options.projection as string)
     }, this.options);
 
-    return new ol.source.WMTS(sourceOptions);
+    return new WMTS(sourceOptions);
   }
 
   protected generateId() {

--- a/src/lib/datasource/shared/datasources/xyz-datasource.interface.ts
+++ b/src/lib/datasource/shared/datasources/xyz-datasource.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import { DataSourceOptions, DataSourceContext } from './datasource.interface';
 
 export interface XYZDataSourceOptions extends DataSourceOptions, ol.olx.source.XYZOptions {}

--- a/src/lib/datasource/shared/datasources/xyz-datasource.ts
+++ b/src/lib/datasource/shared/datasources/xyz-datasource.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+import XYZ from 'ol/source/xyz';
 import { Md5 } from 'ts-md5/dist/md5';
 
 import { DataSource } from './datasource';
@@ -8,10 +8,10 @@ import { XYZDataSourceOptions } from './xyz-datasource.interface';
 export class XYZDataSource extends DataSource {
 
   public options: XYZDataSourceOptions;
-  public ol: ol.source.XYZ;
+  public ol: XYZ;
 
-  protected createOlSource(): ol.source.XYZ {
-    return new ol.source.XYZ(this.options);
+  protected createOlSource(): XYZ {
+    return new XYZ(this.options);
   }
 
   protected generateId() {

--- a/src/lib/download/shared/download.service.ts
+++ b/src/lib/download/shared/download.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import * as ol from 'openlayers';
+import Projection from 'ol/proj/projection';
 
 import { Layer } from '../../layer/shared';
 import { MessageService, LanguageService } from '../../core';
@@ -45,7 +45,7 @@ export class DownloadService {
         const rebuildFilter = this.ogcFilterWriter.buildFilter(
           layer.dataSource.options['ogcFilters']['filters'],
           layer.map.getExtent(),
-          new ol.proj.Projection({ code: layer.map.projection }),
+          new Projection({ code: layer.map.projection }),
           wfsOptions['fieldNameGeometry']);
         window.open(`${baseurl}&${rebuildFilter}&${outputFormatDownload}`, '_blank');
       } else if (layer.dataSource.options.download) {

--- a/src/lib/filter/shared/ogc-filter.interface.ts
+++ b/src/lib/filter/shared/ogc-filter.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import { Md5 } from 'ts-md5';
 
 export interface OgcFilter extends ol.format.filter.Filter {}

--- a/src/lib/filter/shared/ogc-filter.ts
+++ b/src/lib/filter/shared/ogc-filter.ts
@@ -1,4 +1,6 @@
-import * as ol from 'openlayers';
+import filter from 'ol/format/filter';
+import WKT from 'ol/format/wkt';
+import WFS from 'ol/format/wfs';
 
 import { uuid } from '../../utils';
 import { OgcFilter, IgoOgcFilterObject, WFSWriteGetFeatureOptions,
@@ -28,7 +30,7 @@ public buildFilter(
     extent?: ol.Extent, proj? ,
     fieldNameGeometry?: string): string {
 
-  const f = ol.format.filter;
+  const f = filter;
   let bboxFilter;
   let enableBbox: boolean;
   if (/intersects|contains|within/gi.test(JSON.stringify(filters))) {
@@ -65,7 +67,7 @@ public buildFilter(
                 geometryName: fieldNameGeometry
   }
 
-  const query = new ol.format.WFS().writeGetFeature(wfsOptions);
+  const query = new WFS().writeGetFeature(wfsOptions);
   const str = new XMLSerializer().serializeToString(query);
   const regexp1 = /typenames *=|typename *=\"featureTypes\" *>/gi;
   const regexp2 = /<\/Query><\/GetFeature>/gi;
@@ -95,7 +97,7 @@ if (filterObject instanceof Array) {
 private createFilter(filterOptions): OgcFilter {
   const operator = filterOptions.operator;
   const logical_array = filterOptions.logical_array;
-  const f = ol.format.filter;
+  const f = filter;
 
   const wfs_propertyName = filterOptions.propertyName;
   const wfs_pattern = filterOptions.pattern;
@@ -121,7 +123,7 @@ private createFilter(filterOptions): OgcFilter {
 
   let geometry: ol.geom.Geometry;
   if (wfs_wkt_geometry) {
-  const wkt = new ol.format.WKT();
+  const wkt = new WKT();
   geometry = wkt.readGeometry(wfs_wkt_geometry, {
     dataProjection: wfs_srsName,
     featureProjection: 'EPSG:3857'

--- a/src/lib/form/fields/map-field/map-field.component.ts
+++ b/src/lib/form/fields/map-field/map-field.component.ts
@@ -2,7 +2,9 @@ import { Component, Input, forwardRef,
          AfterViewInit, OnDestroy } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import * as ol from 'openlayers';
+import proj from 'ol/proj';
+import Point from 'ol/geom/point';
+import Feature from 'ol/feature';
 
 import { IgoMap, MapViewOptions } from '../../../map';
 import { Layer } from '../../../layer';
@@ -125,7 +127,7 @@ export class MapFieldComponent
   }
 
   private handleMapClick(event: ol.MapBrowserEvent) {
-    this.value = ol.proj.transform(
+    this.value = proj.transform(
       event.coordinate, this.map.projection, this.projection);
   }
 
@@ -143,10 +145,10 @@ export class MapFieldComponent
   }
 
   private addOverlay(coordinates: [number, number]) {
-    const geometry = new ol.geom.Point(
-      ol.proj.transform(coordinates, this.projection, this.map.projection));
+    const geometry = new Point(
+      proj.transform(coordinates, this.projection, this.map.projection));
     const extent = geometry.getExtent();
-    const feature = new ol.Feature({geometry: geometry});
+    const feature = new Feature({geometry: geometry});
 
     this.map.moveToExtent(extent);
     this.map.addOverlay(feature);

--- a/src/lib/import-export/shared/import-export.service.ts
+++ b/src/lib/import-export/shared/import-export.service.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
-import * as ol from 'openlayers';
+import GML from 'ol/format/gml';
+import KML from 'ol/format/kml';
+import GeoJSON from 'ol/format/geojson';
+import Stroke from 'ol/style/stroke';
+import Fill from 'ol/style/fill';
+import Style from 'ol/style/style';
+import Circle from 'ol/style/circle';
 
 import { ConfigService, MessageService, LanguageService } from '../../core';
 import { MapService } from '../../map/shared/map.service';
@@ -67,10 +73,25 @@ export class ImportExportService {
     const layer = map.getLayerById(data.layer);
     const source: any = layer.ol.getSource();
 
-    const formatStr: any = data.format;
-    const format = data.format === 'shapefile' ?
-                   new ol.format.GeoJSON() :
-                   new ol.format[formatStr]();
+    let format;
+
+    switch (data.format) {
+      case 'shapefile':
+        format =  new GeoJSON();
+        break;
+      case 'GML':
+        format =  new GML();
+        break;
+      case 'KML':
+        format =  new KML();
+        break;
+      case 'GeoJSON':
+        format =  new GeoJSON();
+        break;
+      default:
+        format =  new GeoJSON();
+        break;
+    }
 
     const featuresText = format.writeFeatures(source.getFeatures(), {
       dataProjection: 'EPSG:4326',
@@ -135,11 +156,11 @@ export class ImportExportService {
       title: title
     });
 
-    let format: any = new ol.format.GeoJSON();
+    let format: any = new GeoJSON();
     if (mimeType === 'application/vnd.google-earth.kml+xml') {
-      format = new ol.format.KML();
+      format = new KML();
     } else if (mimeType === 'application/gml+xml') {
-      format = new ol.format.GML();
+      format = new GML();
     }
 
     const olFeature = format.readFeatures(text, {
@@ -151,20 +172,20 @@ export class ImportExportService {
     const r = Math.floor(Math.random() * 255);
     const g = Math.floor(Math.random() * 255);
     const b = Math.floor(Math.random() * 255);
-    const stroke = new ol.style.Stroke({
+    const stroke = new Stroke({
       color: [r, g, b, 1],
       width: 2
     });
 
-    const fill = new ol.style.Fill({
+    const fill = new Fill({
       color: [r, g, b, 0.40]
     });
 
     const layer = new VectorLayer(overlayDataSource, {
-      style: new ol.style.Style({
+      style: new Style({
           stroke: stroke,
           fill: fill,
-          image: new ol.style.Circle({
+          image: new Circle({
             radius: 5,
             stroke: stroke,
             fill: fill

--- a/src/lib/layer/layer-item/layer-item.component.ts
+++ b/src/lib/layer/layer-item/layer-item.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import * as ol from 'openlayers';
+import GeoJSON from 'ol/format/geojson';
 
 import { MapService } from '../../map/shared/map.service';
 import { FeatureService } from '../../feature';
@@ -135,7 +135,7 @@ export class LayerItemComponent implements OnDestroy {
     const map = this.mapService.getMap();
     const featuresOL = (layer.dataSource.ol as any).getFeatures();
 
-    const format = new ol.format.GeoJSON();
+    const format = new GeoJSON();
     const featuresGeoJSON = JSON.parse(
       format.writeFeatures(featuresOL, {
         dataProjection: 'EPSG:4326',

--- a/src/lib/layer/shared/layers/image-layer.interface.ts
+++ b/src/lib/layer/shared/layers/image-layer.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 import { LayerOptions, LayerContext } from './layer.interface';
 
 export interface ImageLayerOptions extends LayerOptions {

--- a/src/lib/layer/shared/layers/image-layer.ts
+++ b/src/lib/layer/shared/layers/image-layer.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+import Image from 'ol/layer/image';
 import { DataSource } from '../../../datasource';
 
 import { ImageWatcher } from '../../utils';
@@ -30,7 +30,7 @@ export class ImageLayer extends Layer {
       source: this.dataSource.ol as ol.source.Image
     });
 
-    const image = new ol.layer.Image(olOptions);
+    const image = new Image(olOptions);
     const token = this.options.token;
     if (token) {
       const self = this;

--- a/src/lib/layer/shared/layers/layer.interface.ts
+++ b/src/lib/layer/shared/layers/layer.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 
 export interface LayerOptions extends ol.olx.layer.BaseOptions {
   title?: string;

--- a/src/lib/layer/shared/layers/layer.interface.ts
+++ b/src/lib/layer/shared/layers/layer.interface.ts
@@ -1,4 +1,3 @@
-
 export interface LayerOptions extends ol.olx.layer.BaseOptions {
   title?: string;
   zIndex?: number;

--- a/src/lib/layer/shared/layers/tile-layer.interface.ts
+++ b/src/lib/layer/shared/layers/tile-layer.interface.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+
 import { LayerOptions, LayerContext } from './layer.interface';
 
 export interface TileLayerOptions extends LayerOptions {

--- a/src/lib/layer/shared/layers/tile-layer.ts
+++ b/src/lib/layer/shared/layers/tile-layer.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+import Tile from 'ol/layer/tile';
 import { DataSource } from '../../../datasource';
 
 import { TileWatcher } from '../../utils';
@@ -28,7 +28,7 @@ export class TileLayer extends Layer {
       source: this.dataSource.ol as ol.source.TileImage
     });
 
-    return new ol.layer.Tile(olOptions);
+    return new Tile(olOptions);
   }
 
   public add(map: IgoMap) {

--- a/src/lib/layer/shared/layers/vector-layer.interface.ts
+++ b/src/lib/layer/shared/layers/vector-layer.interface.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+
 import { LayerOptions, LayerContext } from './layer.interface';
 
 export interface VectorLayerOptions extends LayerOptions {

--- a/src/lib/layer/shared/layers/vector-layer.interface.ts
+++ b/src/lib/layer/shared/layers/vector-layer.interface.ts
@@ -1,4 +1,3 @@
-
 import { LayerOptions, LayerContext } from './layer.interface';
 
 export interface VectorLayerOptions extends LayerOptions {

--- a/src/lib/layer/shared/layers/vector-layer.ts
+++ b/src/lib/layer/shared/layers/vector-layer.ts
@@ -1,4 +1,4 @@
-import * as ol from 'openlayers';
+import Vector from 'ol/layer/vector';
 
 import { DataSource } from '../../../datasource';
 
@@ -20,7 +20,7 @@ export class VectorLayer extends Layer {
       source: this.dataSource.ol as ol.source.Vector
     });
 
-    return new ol.layer.Vector(olOptions);
+    return new Vector(olOptions);
   }
 
 }

--- a/src/lib/layer/shared/style.service.ts
+++ b/src/lib/layer/shared/style.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core';
-import * as ol from 'openlayers';
+import RegularShape from 'ol/style/regularshape';
+import Icon from 'ol/style/icon';
+import Circle from 'ol/style/circle';
+import Stroke from 'ol/style/stroke';
+import Fill from 'ol/style/fill';
+import Style from 'ol/style/style';
+import Image from 'ol/style/image';
 
 
 @Injectable()
@@ -45,20 +51,29 @@ export class StyleService {
     let olCls;
     switch (key) {
       case 'fill':
-      case 'image':
-      case 'stroke':
-      case 'style':
-      case 'text':
-        olCls = ol.style[key.charAt(0).toUpperCase() + key.slice(1)];
+        olCls = Fill;
         break;
+      case 'image':
+        olCls = Image;
+        break;
+      case 'stroke':
+        olCls = Stroke;
+        break;
+      case 'style':
+        olCls = Style;
+        break;
+      case 'text':
+        // FOR VALIDATION olCls = ol.style[key.charAt(0).toUpperCase() + key.slice(1)];
+        olCls = this.getOlCls(key.charAt(0).toUpperCase() + key.slice(1))
+       break;
       case 'circle':
-        olCls = ol.style.Circle;
+        olCls = Circle;
         break;
       case 'regularshape':
-        olCls = ol.style.RegularShape;
+        olCls = RegularShape;
         break;
       case 'icon':
-        olCls = ol.style.Icon;
+        olCls = Icon;
         break;
       default:
         break;

--- a/src/lib/map/poi-button/poi-button.component.ts
+++ b/src/lib/map/poi-button/poi-button.component.ts
@@ -2,7 +2,9 @@ import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Subscription } from 'rxjs/Subscription';
 
-import * as ol from 'openlayers';
+import proj from 'ol/proj';
+import easing from 'ol/easing';
+import Point from 'ol/geom/point';
 
 import { MessageService, LanguageService } from '../../core';
 import { ConfirmDialogService } from '../../shared';
@@ -97,8 +99,8 @@ export class PoiButtonComponent implements OnInit, OnDestroy {
 
   createPoi() {
     const view = this.map.ol.getView();
-    const proj = view.getProjection().getCode();
-    const center: any = new ol.geom.Point(view.getCenter()).transform(proj, 'EPSG:4326');
+    const projlocal = view.getProjection().getCode();
+    const center: any = new Point(view.getCenter()).transform(projlocal, 'EPSG:4326');
 
     const poi: Poi = {
       title: '',
@@ -134,13 +136,13 @@ export class PoiButtonComponent implements OnInit, OnDestroy {
   zoomOnPoi(id) {
     const poi = this.pois.find((p) => p.id === id);
 
-    const center = ol.proj.fromLonLat([Number(poi.x), Number(poi.y)], this.map.projection);
+    const center = proj.fromLonLat([Number(poi.x), Number(poi.y)], this.map.projection);
 
     this.map.ol.getView().animate({
       center: center,
       zoom: poi.zoom,
       duration: 500,
-      easing: ol.easing.easeOut
+      easing: easing.easeOut
     });
   }
 

--- a/src/lib/map/shared/map.interface.ts
+++ b/src/lib/map/shared/map.interface.ts
@@ -1,4 +1,3 @@
-import * as ol from 'openlayers';
 
 export interface MapViewOptions extends ol.olx.ViewOptions {
   projection?: string;

--- a/src/lib/map/shared/map.ts
+++ b/src/lib/map/shared/map.ts
@@ -1,4 +1,17 @@
-import * as ol from 'openlayers';
+import Map from 'ol/map';
+import View from 'ol/view';
+import proj from 'ol/proj';
+import easing from 'ol/easing';
+import Stroke from 'ol/style/stroke';
+import Fill from 'ol/style/fill';
+import Style from 'ol/style/style';
+import Circle from 'ol/style/circle';
+import Icon from 'ol/style/icon';
+import Attribution from 'ol/control/attribution';
+import ScaleLine from 'ol/control/scaleline';
+import Interaction from 'ol/interaction';
+import Feature from 'ol/feature';
+import Geolocation from 'ol/geolocation';
 
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subject } from 'rxjs/Subject';
@@ -14,15 +27,15 @@ import { MapViewOptions, MapOptions } from './map.interface';
 
 export class IgoMap {
 
-  public ol: ol.Map;
+  public ol: Map;
   public layers$ = new BehaviorSubject<Layer[]>([]);
   public layers: Layer[] = [];
   public status$: Subject<SubjectStatus>;
   public resolution$ = new BehaviorSubject<Number>(undefined);
   public geolocation$ = new BehaviorSubject<ol.Geolocation>(undefined);
 
-  public overlayMarkerStyle: ol.style.Style;
-  public overlayStyle: ol.style.Style;
+  public overlayMarkerStyle: Style;
+  public overlayStyle: Style;
   private overlayDataSource: FeatureDataSource;
 
   private layerWatcher: LayerWatcher;
@@ -57,12 +70,12 @@ export class IgoMap {
       if (this.options.controls.attribution) {
         const attributionOpt = (this.options.controls.attribution === true ?
           {} : this.options.controls.attribution) as ol.olx.control.AttributionOptions;
-        controls.push(new ol.control.Attribution(attributionOpt));
+        controls.push(new Attribution(attributionOpt));
       }
       if (this.options.controls.scaleLine) {
         const scaleLineOpt = (this.options.controls.scaleLine === true ?
           {} : this.options.controls.scaleLine) as ol.olx.control.ScaleLineOptions;
-        controls.push(new ol.control.ScaleLine(scaleLineOpt));
+        controls.push(new ScaleLine(scaleLineOpt));
       }
     }
     let interactions = {};
@@ -79,8 +92,8 @@ export class IgoMap {
       };
     }
 
-    this.ol = new ol.Map({
-      interactions: ol.interaction.defaults(interactions),
+    this.ol = new Map({
+      interactions: Interaction.defaults(interactions),
       controls: controls
     });
 
@@ -91,8 +104,8 @@ export class IgoMap {
     });
 
     if (this.options.overlay) {
-      this.overlayMarkerStyle = new ol.style.Style({
-        image: new ol.style.Icon({
+      this.overlayMarkerStyle = new Style({
+        image: new Icon({
           src: './assets/igo2/icons/place_blue_36px.svg',
           imgSize: [36, 36], // for ie
           anchor: [0.5, 1]
@@ -103,19 +116,19 @@ export class IgoMap {
         title: 'Overlay'
       });
 
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: [0, 161, 222, 1],
         width: 2
       });
 
-      const fill = new ol.style.Fill({
+      const fill = new Fill({
         color: [0, 161, 222, 0.15]
       });
 
-      this.overlayStyle = new ol.style.Style({
+      this.overlayStyle = new Style({
         stroke: stroke,
         fill: fill,
-        image: new ol.style.Circle({
+        image: new Circle({
           radius: 5,
           stroke: stroke,
           fill: fill
@@ -149,13 +162,13 @@ export class IgoMap {
   }
 
   setView(options: MapViewOptions) {
-    const view = new ol.View(options);
+    const view = new View(options);
     this.ol.setView(view);
 
     this.unsubscribeGeolocate();
     if (options) {
       if (options.center) {
-        const center = ol.proj.fromLonLat(options.center, this.projection);
+        const center = proj.fromLonLat(options.center, this.projection);
         view.setCenter(center);
       }
 
@@ -168,7 +181,7 @@ export class IgoMap {
   getCenter(projection?): [number, number] {
     let center = this.ol.getView().getCenter();
     if (projection && center) {
-      center = ol.proj.transform(center, this.projection, projection);
+      center = proj.transform(center, this.projection, projection);
     }
     return center;
   }
@@ -176,7 +189,7 @@ export class IgoMap {
   getExtent(projection?): [number, number, number, number] {
     let ext = this.ol.getView().calculateExtent(this.ol.getSize());
     if (projection && ext) {
-      ext = ol.proj.transformExtent(ext, this.projection, projection);
+      ext = proj.transformExtent(ext, this.projection, projection);
     }
     return ext;
   }
@@ -197,7 +210,7 @@ export class IgoMap {
     this.ol.getView().animate({
       zoom: zoom,
       duration: 250,
-      easing: ol.easing.easeOut
+      easing: easing.easeOut
     });
   }
 
@@ -356,7 +369,7 @@ export class IgoMap {
 
           this.overlayDataSource.ol.removeFeature(this.geolocationFeature);
         }
-        this.geolocationFeature = new ol.Feature({geometry: geometry});
+        this.geolocationFeature = new Feature({geometry: geometry});
         this.geolocationFeature.setId('geolocationFeature');
         this.addOverlay(this.geolocationFeature);
         if (first) {
@@ -385,7 +398,7 @@ export class IgoMap {
 
   private startGeolocation() {
     if (!this.geolocation) {
-      this.geolocation = new ol.Geolocation({
+      this.geolocation = new Geolocation({
         projection: this.projection,
         tracking: true
       });

--- a/src/lib/query/shared/query.directive.ts
+++ b/src/lib/query/shared/query.directive.ts
@@ -12,7 +12,9 @@ import { Subscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 
-import * as ol from 'openlayers';
+import DragBox from 'ol/interaction/dragbox';
+import condition from 'ol/events/condition';
+import GeoJSON from 'ol/format/geojson';
 
 import { LanguageService } from '../../core';
 import { IgoMap } from '../../map/shared';
@@ -30,8 +32,8 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
   private queryLayers$$: Subscription;
   private queries$$: Subscription[] = [];
 
-  public dragBox = new ol.interaction.DragBox({
-    condition: ol.events.condition.platformModifierKeyOnly
+  public dragBox = new DragBox({
+    condition: condition.platformModifierKeyOnly
   });
 
   get map(): IgoMap {
@@ -65,8 +67,8 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
     );
 
     this.map.ol.on('singleclick', this.handleMapClick, this);
-    this.dragBox = new ol.interaction.DragBox({
-      condition: ol.events.condition.platformModifierKeyOnly
+    this.dragBox = new DragBox({
+      condition: condition.platformModifierKeyOnly
     });
     this.map.ol.addInteraction(this.dragBox);
     this.dragBox.on('boxend', this.handleMapClick, this);
@@ -114,7 +116,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
   private handleMapClick(event: ol.MapBrowserEvent) {
     this.unsubscribeQueries();
     const clickedFeatures: ol.Feature[] = [];
-    const format = new ol.format.GeoJSON();
+    const format = new GeoJSON();
     const mapProjection = this.map.projection;
     if (event.type === 'singleclick') {
       this.map.ol.forEachFeatureAtPixel(

--- a/src/lib/query/shared/query.service.ts
+++ b/src/lib/query/shared/query.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
-import * as ol from 'openlayers';
+import GML2 from 'ol/format/gml2';
+import GML3 from 'ol/format/gml3';
+import WMSGetFeatureInfo from 'ol/format/wmsgetfeatureinfo';
+import WKT from 'ol/format/wkt';
 
 import { uuid } from '../../utils/uuid';
 import { Feature, FeatureType, FeatureFormat, SourceFeatureType,
@@ -80,12 +83,12 @@ export class QueryService {
   }
 
   private extractGML2Data(res, zIndex) {
-    let parser = new ol.format.GML2();
+    let parser = new GML2();
     let features = parser.readFeatures(res);
 
     // Handle non standard GML output (MapServer)
     if (features.length === 0) {
-      parser = new ol.format.WMSGetFeatureInfo();
+      parser = new WMSGetFeatureInfo();
       features = parser.readFeatures(res);
     }
 
@@ -93,7 +96,7 @@ export class QueryService {
   }
 
   private extractGML3Data(res, zIndex) {
-    const parser = new ol.format.GML3();
+    const parser = new GML3();
     const features = parser.readFeatures(res);
 
     return features.map(feature => this.featureToResult(feature, zIndex));
@@ -152,7 +155,7 @@ export class QueryService {
                 ', ' + clickx + ' ' + clicky + '))';
 
 
-    const format = new ol.format.WKT();
+    const format = new WKT();
     const tenPercentWidthGeom = format.readFeature(wktPoly);
     const f = (tenPercentWidthGeom.getGeometry() as any);
 

--- a/src/lib/utils/tilegrid.ts
+++ b/src/lib/utils/tilegrid.ts
@@ -1,9 +1,12 @@
-import * as ol from 'openlayers';
+import WMTS from 'ol/tilegrid/wmts';
+import proj from 'ol/proj';
+import extent from 'ol/extent';
 
-export function createDefaultTileGrid(epsg?: string): ol.tilegrid.WMTS {
-  const projection = epsg ? ol.proj.get(epsg) : ol.proj.get('EPSG:3857');
+
+export function createDefaultTileGrid(epsg?: string): WMTS {
+  const projection = epsg ? proj.get(epsg) : proj.get('EPSG:3857');
   const projectionExtent = projection.getExtent();
-  const size = ol.extent.getWidth(projectionExtent) / 256;
+  const size = extent.getWidth(projectionExtent) / 256;
   const resolutions = new Array(20);
   const matrixIds = new Array(20);
   for (let z = 0; z < 20; ++z) {
@@ -11,8 +14,8 @@ export function createDefaultTileGrid(epsg?: string): ol.tilegrid.WMTS {
     matrixIds[z] = z;
   }
 
-  return new ol.tilegrid.WMTS({
-    origin: ol.extent.getTopLeft(projectionExtent),
+  return new WMTS({
+    origin: extent.getTopLeft(projectionExtent),
     resolutions: resolutions,
     matrixIds: matrixIds
   });

--- a/src/lib/wkt/shared/wkt.service.ts
+++ b/src/lib/wkt/shared/wkt.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
-import * as ol from 'openlayers';
+import proj from 'ol/proj';
+import WKT from 'ol/format/wkt';
+import Polygon from 'ol/geom/polygon';
 
 import { MapService } from '../../map';
 
@@ -10,17 +12,17 @@ export class WktService {
   constructor(private mapService: MapService) { }
 
   public mapExtentToWKT(epsgTO = this.mapService.getMap().projection) {
-    let extent = ol.proj.transformExtent(
+    let extent = proj.transformExtent(
       this.mapService.getMap().getExtent(),
       this.mapService.getMap().projection,
       epsgTO);
     extent = this.roundCoordinateArray(extent, epsgTO, 0);
-    const wkt = new ol.format.WKT().writeGeometry(ol.geom.Polygon.fromExtent(extent));
+    const wkt = new WKT().writeGeometry(Polygon.fromExtent(extent));
     return wkt;
   }
 
   private roundCoordinateArray(coordinateArray, projection, decimal = 0) {
-    const lproj = ol.proj.get(projection);
+    const lproj = proj.get(projection);
     const units = lproj.getUnits();
     const olUnits = ['ft', 'm', 'us-ft'];
     if (olUnits.indexOf(units) !== -1) {
@@ -169,10 +171,10 @@ export class WktService {
       coord['ur'] = [coord['ul'][0], coord['ul'][1] - unitPerType_SN];
       coord['ll'] = [coord['ul'][0] + unitPerType_EW, coord['ul'][1]];
 
-      coord.ul = ol.proj.transform([coord.ul[0], coord.ul[1]], 'EPSG:4326', epsgTO);
-      coord['lr'] = ol.proj.transform([coord['lr'][0], coord['lr'][1]], 'EPSG:4326', epsgTO);
-      coord['ur'] = ol.proj.transform([coord['ur'][0], coord['ur'][1]], 'EPSG:4326', epsgTO);
-      coord['ll'] = ol.proj.transform([coord['ll'][0], coord['ll'][1]], 'EPSG:4326', epsgTO);
+      coord.ul = proj.transform([coord.ul[0], coord.ul[1]], 'EPSG:4326', epsgTO);
+      coord['lr'] = proj.transform([coord['lr'][0], coord['lr'][1]], 'EPSG:4326', epsgTO);
+      coord['ur'] = proj.transform([coord['ur'][0], coord['ur'][1]], 'EPSG:4326', epsgTO);
+      coord['ll'] = proj.transform([coord['ll'][0], coord['ll'][1]], 'EPSG:4326', epsgTO);
 
       // Rounded coordinate to shorten url in get
       coord['ul'] = this.roundCoordinateArray(coord['ul'], epsgTO, 0);

--- a/src/tsconfig.demo.json
+++ b/src/tsconfig.demo.json
@@ -5,7 +5,7 @@
     "module": "es2015",
     "baseUrl": "",
     "types": [
-      "openlayers"
+      "ol"
     ]
   },
   "exclude": [

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -8,7 +8,7 @@
     "module": "es2015",
     "baseUrl": "",
     "types": [
-      "openlayers"
+      "ol"
     ]
   },
   "files": [

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -8,7 +8,7 @@
     "types": [
       "jasmine",
       "node",
-      "openlayers"
+      "ol"
     ]
   },
   "files": [


### PR DESCRIPTION
Moving from NPM openlayers (deprecated) to ol.

Modyfing mainly the import methods, types and dependencies. 

Info :

1. [comment from ahocevar commented on Jul 14, 2017](https://github.com/openlayers/closure-util/issues/76) : Not sure what your build environment looks like. But if you're not relying on the Closure Compiler, you should consider using the ol package instead of the openlayers one. That switch will allow you to use mainstream bundlers and minifiers in a hassle free way.
2. Deprecated [package](https://www.npmjs.com/package/openlayers)
3. ol package [package](https://www.npmjs.com/package/ol)
