### PR TITLE
Reseau transport quebec

### DIFF
--- a/demo/src/app/geo/search/search.module.ts
+++ b/demo/src/app/geo/search/search.module.ts
@@ -17,7 +17,8 @@ import {
   IgoFeatureModule,
   IgoOverlayModule,
   provideIChercheSearchSource,
-  provideDataSourceSearchSource
+  provideDataSourceSearchSource,
+  provideReseauTransportsQuebecSearchSource
 } from '@igo2/geo';
 
 import { AppSearchComponent } from './search.component';
@@ -40,6 +41,9 @@ import { AppSearchRoutingModule } from './search-routing.module';
     IgoOverlayModule
   ],
   exports: [AppSearchComponent],
-  providers: [provideIChercheSearchSource(), provideDataSourceSearchSource()]
+  providers: [
+    provideIChercheSearchSource(),
+    provideDataSourceSearchSource(),
+    provideReseauTransportsQuebecSearchSource()]
 })
 export class AppSearchModule {}

--- a/demo/src/app/geo/search/search.module.ts
+++ b/demo/src/app/geo/search/search.module.ts
@@ -17,8 +17,7 @@ import {
   IgoFeatureModule,
   IgoOverlayModule,
   provideIChercheSearchSource,
-  provideDataSourceSearchSource,
-  provideReseauTransportsQuebecSearchSource
+  provideDataSourceSearchSource
 } from '@igo2/geo';
 
 import { AppSearchComponent } from './search.component';
@@ -43,7 +42,6 @@ import { AppSearchRoutingModule } from './search-routing.module';
   exports: [AppSearchComponent],
   providers: [
     provideIChercheSearchSource(),
-    provideDataSourceSearchSource(),
-    provideReseauTransportsQuebecSearchSource()]
+    provideDataSourceSearchSource()]
 })
 export class AppSearchModule {}

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -34,7 +34,7 @@ export const environment: Environment = {
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
-        enabled: false
+        enabled: true
       },
       datasource: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/igo2/api/layers/search'

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -26,6 +26,11 @@ export const environment: Environment = {
       nominatim: {
         enabled: true
       },
+      reseautq: {
+        searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        enabled: true
+      },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -27,11 +27,12 @@ export const environment: Environment = {
         enabled: true
       },
       icherche: {
-        url: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
+        searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
+        locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
         enabled: false
       },
       datasource: {
-        url: 'https://geoegl.msp.gouv.qc.ca/igo2/api/layers/search'
+        searchUrl: 'https://geoegl.msp.gouv.qc.ca/igo2/api/layers/search'
       }
     }
   }

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -33,13 +33,15 @@ export const environment: Environment = {
         enabled: false
       },
       reseautq: {
-        searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
-        locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca//swtq',
+        locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca//swtq',
+        limit: 5,
+        locateLimit: 15,
         enabled: true
       },
       icherche: {
-        searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
-        locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
+        searchUrl: '/icherche/geocode',
+        locateUrl: '/icherche/xy',
         enabled: true
       },
       datasource: {

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -32,6 +32,11 @@ export const environment: Environment = {
       nominatim: {
         enabled: false
       },
+      reseautq: {
+        searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        enabled: true
+      },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -33,8 +33,8 @@ export const environment: Environment = {
         enabled: false
       },
       reseautq: {
-        searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca//swtq',
-        locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca//swtq',
+        searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         limit: 5,
         locateLimit: 15,
         enabled: true

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -33,10 +33,13 @@ export const environment: Environment = {
         enabled: false
       },
       icherche: {
-        url: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode'
+        searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
+        locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
+        enabled: true
       },
       datasource: {
-        url: 'https://geoegl.msp.gouv.qc.ca/igo2/api/layers/search'
+        searchUrl: 'https://geoegl.msp.gouv.qc.ca/igo2/api/layers/search',
+        enabled: false
       }
     }
   }

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -40,8 +40,8 @@ export const environment: Environment = {
         enabled: true
       },
       icherche: {
-        searchUrl: '/icherche/geocode',
-        locateUrl: '/icherche/xy',
+        searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
+        locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
         enabled: true
       },
       datasource: {

--- a/projects/core/src/lib/request/logging.interceptor.ts
+++ b/projects/core/src/lib/request/logging.interceptor.ts
@@ -33,7 +33,7 @@ export class LoggingInterceptor implements HttpInterceptor {
         const msg = `${req.method} "${req.urlWithParams}"
              ${ok} in ${elapsed} ms.`;
 
-        console.log(msg);
+        // console.log(msg);
       })
     );
   }

--- a/projects/core/src/lib/request/logging.interceptor.ts
+++ b/projects/core/src/lib/request/logging.interceptor.ts
@@ -33,7 +33,7 @@ export class LoggingInterceptor implements HttpInterceptor {
         const msg = `${req.method} "${req.urlWithParams}"
              ${ok} in ${elapsed} ms.`;
 
-        // console.log(msg);
+        console.log(msg);
       })
     );
   }

--- a/projects/geo/src/lib/search/search-bar/search-bar.component.ts
+++ b/projects/geo/src/lib/search/search-bar/search-bar.component.ts
@@ -99,7 +99,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   set length(value: number) {
     this._length = value;
   }
-  private _length = 3;
+  private _length = 2;
 
   @Input()
   get searchIcon() {

--- a/projects/geo/src/lib/search/search-sources/datasource-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/datasource-search-source.ts
@@ -36,7 +36,7 @@ export class DataSourceSearchSource extends SearchSource {
     super();
 
     this.options = this.config.getConfig('searchSources.datasource') || {};
-    this.searchUrl = this.options.url || this.searchUrl;
+    this.searchUrl = this.options.searchUrl || this.searchUrl;
   }
 
   getName(): string {

--- a/projects/geo/src/lib/search/search-sources/icherche-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/icherche-search-source.ts
@@ -34,7 +34,7 @@ export class IChercheSearchSource extends SearchSource {
     super();
 
     this.options = this.config.getConfig('searchSources.icherche') || {};
-    this.searchUrl = this.options.url || this.searchUrl;
+    this.searchUrl = this.options.searchUrl || this.searchUrl;
     this.locateUrl = this.options.locateUrl || this.locateUrl;
   }
 

--- a/projects/geo/src/lib/search/search-sources/index.ts
+++ b/projects/geo/src/lib/search/search-sources/index.ts
@@ -3,3 +3,4 @@ export * from './search-source.interface';
 export * from './nominatim-search-source';
 export * from './icherche-search-source';
 export * from './datasource-search-source';
+export * from './reseau-transport-quebec-search-source';

--- a/projects/geo/src/lib/search/search-sources/nominatim-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/nominatim-search-source.ts
@@ -34,7 +34,7 @@ export class NominatimSearchSource extends SearchSource {
     super();
 
     this.options = this.config.getConfig('searchSources.nominatim') || {};
-    this.searchUrl = this.options.url || this.searchUrl;
+    this.searchUrl = this.options.searchUrl || this.searchUrl;
     this.locateUrl = this.options.locateUrl || this.locateUrl;
   }
 

--- a/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
@@ -1,0 +1,220 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ConfigService } from '@igo2/core';
+import { map } from 'rxjs/operators';
+import {
+  Feature,
+  FeatureType,
+  FeatureFormat,
+  SourceFeatureType
+} from '../../feature';
+
+import { SearchSource } from './search-source';
+import { SearchSourceOptions } from './search-source.interface';
+
+
+@Injectable()
+export class ReseauTransportsQuebecSearchSource extends SearchSource {
+  get enabled(): boolean {
+    return this.options.enabled !== false;
+  }
+  set enabled(value: boolean) {
+    this.options.enabled = value;
+  }
+
+  static _name = 'Réseau routier Transport Québec ';
+
+  private searchUrl = 'https://ws.mapserver.transports.gouv.qc.ca/swtq';
+  private locateUrl = 'https://ws.mapserver.transports.gouv.qc.ca/swtq';
+  private searchlimit = 5;
+  private locatelimit = this.searchlimit * 2;
+  private options: SearchSourceOptions;
+
+  constructor(private http: HttpClient, private config: ConfigService) {
+    super();
+
+    this.options = this.config.getConfig('searchSources.reseautq') || {};
+    this.searchUrl = this.options.searchUrl || this.searchUrl;
+    this.locateUrl = this.options.locateUrl || this.locateUrl;
+    this.searchlimit = this.options.limit || this.searchlimit;
+    this.locatelimit = this.options.locateLimit || this.locatelimit;
+  }
+
+  getName(): string {
+    return ReseauTransportsQuebecSearchSource._name;
+  }
+
+  leftPad0(num: string, size: number): string {
+    let s = num + '';
+    while (s.length < size) {
+      s = '0' + s;
+    }
+    return s;
+}
+
+
+  search(term?: string): Observable<Feature[]> {
+    term = term.replace(/auto|routes|route|km| |high|ways|way|roads|road|#|a-|-/gi, '');
+    let chainage = '';
+
+
+    if (term.search(/\+/gi ) !== -1) {
+      const split_term = term.split(/\+/gi);
+      term = split_term[0];
+      chainage = split_term[1];
+    }
+
+
+    let nb_char = term.length;
+    let searchTerm: any = term;
+    if (!isNaN(Number(term))) {
+      searchTerm = parseInt(term, 10);
+      nb_char = String(searchTerm).length;
+    }
+
+    let typename = '';
+    let filterParams;
+
+    if (searchTerm === 0) {
+      typename = 'a_num_route';
+      // tslint:disable-next-line:max-line-length
+      filterParams = `FILTER=${'FILTER=<Filter xmlns="http://www.opengis.net/ogc"><PropertyIsEqualTo matchCase="false"><PropertyName>recherche</PropertyName><Literal>' + searchTerm + '</Literal></PropertyIsEqualTo></Filter>'}`;
+    }
+
+    if (((nb_char >= 2 && nb_char <= 5) || searchTerm === 5) && chainage === '') {
+      typename = 'a_num_route';
+      // tslint:disable-next-line:max-line-length
+      filterParams = `FILTER=${'FILTER=<Filter xmlns="http://www.opengis.net/ogc"><PropertyIsEqualTo matchCase="false"><PropertyName>recherche</PropertyName><Literal>' + searchTerm + '</Literal></PropertyIsEqualTo></Filter>'}`;
+    }
+    if (((nb_char >= 2 && nb_char <= 5) || searchTerm === 5) && chainage !== '') {
+      typename = 'repere_km';
+      searchTerm = this.leftPad0(searchTerm, 5);
+      // tslint:disable-next-line:max-line-length
+      filterParams = `FILTER=${'<Filter xmlns="http://www.opengis.net/ogc"><And><PropertyIsEqualTo matchCase="false"><PropertyName>norte</PropertyName><Literal>' + searchTerm + '</Literal></PropertyIsEqualTo><PropertyIsLike wildCard="*" singleChar="." escapeChar="!" matchCase="false"><PropertyName>affichkm</PropertyName><Literal>km ' + chainage.replace('.', ',') + '</Literal></PropertyIsLike></And></Filter>'}`;
+          }
+    if (nb_char >= 4 && nb_char <= 7 && chainage === '') {
+      typename = 'b_num_tronc';
+      // tslint:disable-next-line:max-line-length
+      filterParams = `FILTER=${'FILTER=<Filter xmlns="http://www.opengis.net/ogc"><PropertyIsEqualTo matchCase="false"><PropertyName>recherche</PropertyName><Literal>' + searchTerm + '</Literal></PropertyIsEqualTo></Filter>'}`;
+    }
+    if (nb_char >= 7 && nb_char <= 10 && chainage === '') {
+      typename = 'c_num_sectn';
+      // tslint:disable-next-line:max-line-length
+      filterParams = `FILTER=${'FILTER=<Filter xmlns="http://www.opengis.net/ogc"><PropertyIsEqualTo matchCase="false"><PropertyName>recherche</PropertyName><Literal>' + searchTerm + '</Literal></PropertyIsEqualTo></Filter>'}`;
+
+    }
+    if (nb_char >= 11 && nb_char <= 14 && chainage === '') {
+      typename = 'd_num_rts';
+      searchTerm =  this.leftPad0(searchTerm, 14).toUpperCase();
+      // tslint:disable-next-line:max-line-length
+      filterParams = `FILTER=${'FILTER=<Filter xmlns="http://www.opengis.net/ogc"><PropertyIsEqualTo matchCase="false"><PropertyName>recherche</PropertyName><Literal>' + searchTerm + '</Literal></PropertyIsEqualTo></Filter>'}`;
+      }
+
+  if (nb_char >= 11 && nb_char <= 25 && chainage !== '') {
+      typename = 'e_rtss_c';
+      searchTerm =  this.leftPad0(searchTerm, 14).toUpperCase();
+      filterParams =   `rtss=${searchTerm}&chainage=${Number(chainage)}`;
+    }
+
+
+    const params = [
+      'REQUEST=GetFeature',
+      'SERVICE=WFS',
+      'FORMAT=image/png',
+      'SLD_VERSION=1.1.0',
+      'VERSION=2.0.0',
+      'SRSNAME=EPSG:4326',
+      'OUTPUTFORMAT=geojson',
+      `COUNT=${this.searchlimit}`,
+      `TYPENAMES=${typename}`,
+      filterParams
+        ];
+
+    if (typename === '') {
+      return;
+    }
+
+    return this.http
+      .get(`${this.searchUrl}?${params.join('&')}`)
+      .pipe(map(res => this.extractSearchData(res)));
+  }
+
+  locate(coordinate?: [number, number]): Observable<Feature[]>  {
+    const threshold = 0.008333333 / 2;
+    const lat1 = coordinate[1] - threshold;
+    const long1 = coordinate[0] - threshold;
+    const lat2 = coordinate[1] + threshold;
+    const long2 = coordinate[0] + threshold;
+
+    const params = [
+      'REQUEST=GetFeature',
+      'SERVICE=WFS',
+      'FORMAT=image/png',
+      'VERSION=2.0.0',
+      'SRSNAME=EPSG:4326',
+      'OUTPUTFORMAT=geojson',
+      `COUNT=${this.locatelimit}`,
+      `TYPENAMES=a_num_route`,
+      'bbox=' + lat1 + ',' + long1 + ',' + lat2 + ',' + long2 + ',EPSG:4326'
+
+        ];
+
+    return this.http
+    .get(`${this.locateUrl}?${params.join('&')}`)
+    .pipe(map(res => this.extractSearchData(res)));
+}
+
+
+  private extractSearchData(response): Feature[] {
+    return response.features.map(this.formatSearchResult);
+  }
+
+  private formatSearchResult(result: any): Feature {
+    const properties = Object.assign(
+      {
+        type: result.type
+      },
+      result.properties
+    );
+
+    const allowedProperties = ['title', 'etiquette', 'nommun'];
+
+    if (properties.hasOwnProperty('norte') && properties.hasOwnProperty('affichkm')) {
+      properties.title = '# ' + Number(properties.norte) + '+' + properties.affichkm;
+
+    }
+
+   for (const key in properties) {
+        if (properties.hasOwnProperty(key)) {
+            if (allowedProperties.indexOf(key) === -1) {
+              delete properties[key];
+            }
+        }
+    }
+
+    const id = properties.id;
+
+    delete properties.id;
+    delete properties.recherche;
+    delete properties.type;
+    delete properties.coord_x;
+    delete properties.coord_y;
+    delete properties.cote;
+    return {
+      id: id,
+      source: ReseauTransportsQuebecSearchSource._name,
+      sourceType: SourceFeatureType.Search,
+      order: 1,
+      type: FeatureType.Feature,
+      format: FeatureFormat.GeoJSON,
+      title: properties.title,
+      title_html: properties.etiquette,
+      icon: 'timeline',
+      projection: 'EPSG:4326',
+      properties: properties,
+      geometry: result.geometry,
+      extent: result.bbox
+    };
+  }
+}

--- a/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
@@ -53,18 +53,15 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
     return s;
 }
 
-
   search(term?: string): Observable<Feature[]> {
     term = term.replace(/auto|routes|route|km| |high|ways|way|roads|road|#|a-|-/gi, '');
     let chainage = '';
-
 
     if (term.search(/\+/gi ) !== -1) {
       const split_term = term.split(/\+/gi);
       term = split_term[0];
       chainage = split_term[1];
     }
-
 
     let nb_char = term.length;
     let searchTerm: any = term;
@@ -117,7 +114,6 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
       filterParams =   `rtss=${searchTerm}&chainage=${Number(chainage)}`;
     }
 
-
     const params = [
       'REQUEST=GetFeature',
       'SERVICE=WFS',
@@ -165,7 +161,6 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
     .pipe(map(res => this.extractSearchData(res)));
 }
 
-
   private extractSearchData(response): Feature[] {
     return response.features.map(this.formatSearchResult);
   }
@@ -194,7 +189,6 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
     }
 
     const id = properties.id;
-
     delete properties.id;
     delete properties.recherche;
     delete properties.type;

--- a/projects/geo/src/lib/search/search-sources/search-source.interface.ts
+++ b/projects/geo/src/lib/search/search-sources/search-source.interface.ts
@@ -2,6 +2,7 @@ export interface SearchSourceOptions {
   searchUrl?: string;
   locateUrl?: string;
   limit?: number;
+  locateLimit?: number;
   enabled?: boolean;
   type?: string;
   distance?: number;

--- a/projects/geo/src/lib/search/search-sources/search-source.interface.ts
+++ b/projects/geo/src/lib/search/search-sources/search-source.interface.ts
@@ -1,5 +1,5 @@
 export interface SearchSourceOptions {
-  url?: string;
+  searchUrl?: string;
   locateUrl?: string;
   limit?: number;
   enabled?: boolean;

--- a/projects/geo/src/lib/search/search-sources/search-source.provider.ts
+++ b/projects/geo/src/lib/search/search-sources/search-source.provider.ts
@@ -6,6 +6,20 @@ import { SearchSource } from './search-source';
 import { NominatimSearchSource } from './nominatim-search-source';
 import { IChercheSearchSource } from './icherche-search-source';
 import { DataSourceSearchSource } from './datasource-search-source';
+import { ReseauTransportsQuebecSearchSource } from './reseau-transport-quebec-search-source';
+
+export function reseauTransportsQuebecSearchSourceSearchSourcesFactory(http: HttpClient, config: ConfigService) {
+  return new ReseauTransportsQuebecSearchSource(http, config);
+}
+
+export function provideReseauTransportsQuebecSearchSource() {
+  return {
+    provide: SearchSource,
+    useFactory: (reseauTransportsQuebecSearchSourceSearchSourcesFactory),
+    multi: true,
+    deps: [HttpClient, ConfigService]
+  };
+}
 
 export function nominatimSearchSourcesFactory(
   http: HttpClient,

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -22,7 +22,6 @@
   "/swtq": {
     "target": "https://ws.mapserver.transports.gouv.qc.ca",
     "changeOrigin": true,
-    "secure": false,
-    "logLevel": "debug"
+    "secure": false
     }
 }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -18,5 +18,11 @@
     "target": "https://geoegl.msp.gouv.qc.ca",
     "secure": false,
     "changeOrigin": true
-  }
+  },
+  "/swtq": {
+    "target": "https://ws.mapserver.transports.gouv.qc.ca",
+    "changeOrigin": true,
+    "secure": false,
+    "logLevel": "debug"
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Adding new search sources for the Quebec Provincial road network (municipal network excluded).

- a-5 will return the complete linestring for highway # 5
- 20  will return the complete linestring for highway # 20
- 138+700 will return a point on road 138, a the specific KM (km 700) This is note interpolation, the position represent physical signs on the road.
- -71.292469,46.748107 will propose you some roads around this coordinate.

For expert user:
- 2006 or 0002006 will return the complete linestring for highway # 20, segment 06
- 2006051 or 0002006051 will return the complete linestring for highway # 20, segment 06, section # 051
- 20060513BA0 or 00020060513BA0 will return the complete linestring for highway # 20, segment 06, section # 051, sub-route 3BA0
- 20060513BA0+500 or 00020060513BA0+500  will return a point on highway # 20, segment 06, section # 051, sub-route 3BA0 at the 500th meter of this linear referencing system.

Every of these words/characters will not be used into the query & case insensitive. Based on this regex
(/auto|routes|route|km| |high|ways|way|roads|road|#|a-|-/gi, '')



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
