### PR TITLE
feat(*) Prevent zooming on result if already contained in map extent

### DIFF
--- a/demo/src/app/geo/feature/feature.component.ts
+++ b/demo/src/app/geo/feature/feature.component.ts
@@ -106,6 +106,6 @@ export class AppFeatureComponent {
   }
 
   handleFeatureSelect(feature: Feature) {
-    this.overlayService.setFeatures([feature], OverlayAction.zoomIfOutMapExtent);
+    this.overlayService.setFeatures([feature], OverlayAction.ZoomIfOutMapExtent);
   }
 }

--- a/demo/src/app/geo/feature/feature.component.ts
+++ b/demo/src/app/geo/feature/feature.component.ts
@@ -105,6 +105,6 @@ export class AppFeatureComponent {
   }
 
   handleFeatureSelect(feature: Feature) {
-    this.overlayService.setFeatures([feature], 'zoom');
+    this.overlayService.setFeatures([feature], 'zoomif');
   }
 }

--- a/demo/src/app/geo/feature/feature.component.ts
+++ b/demo/src/app/geo/feature/feature.component.ts
@@ -5,6 +5,7 @@ import {
   IgoMap,
   DataSourceService,
   LayerService,
+  OverlayAction,
   OverlayService,
   Feature,
   FeatureType,
@@ -105,6 +106,6 @@ export class AppFeatureComponent {
   }
 
   handleFeatureSelect(feature: Feature) {
-    this.overlayService.setFeatures([feature], 'zoomif');
+    this.overlayService.setFeatures([feature], OverlayAction.zoomIfOutMapExtent);
   }
 }

--- a/demo/src/app/geo/search/search.component.ts
+++ b/demo/src/app/geo/search/search.component.ts
@@ -71,7 +71,7 @@ export class AppSearchComponent {
 
   handleFeatureSelect(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], OverlayAction.zoomIfOutMapExtent);
+      this.overlayService.setFeatures([feature], OverlayAction.ZoomIfOutMapExtent);
     } else if (feature.type === FeatureType.DataSource) {
       this.layerService.createAsyncLayer(feature.layer).subscribe(layer => {
         this.map.addLayer(layer);

--- a/demo/src/app/geo/search/search.component.ts
+++ b/demo/src/app/geo/search/search.component.ts
@@ -9,6 +9,7 @@ import {
   SearchService,
   Feature,
   FeatureType,
+  OverlayAction,
   OverlayService
 } from '@igo2/geo';
 
@@ -70,7 +71,7 @@ export class AppSearchComponent {
 
   handleFeatureSelect(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], 'zoomif');
+      this.overlayService.setFeatures([feature], OverlayAction.zoomIfOutMapExtent);
     } else if (feature.type === FeatureType.DataSource) {
       this.layerService.createAsyncLayer(feature.layer).subscribe(layer => {
         this.map.addLayer(layer);

--- a/demo/src/app/geo/search/search.component.ts
+++ b/demo/src/app/geo/search/search.component.ts
@@ -70,7 +70,7 @@ export class AppSearchComponent {
 
   handleFeatureSelect(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], 'zoom');
+      this.overlayService.setFeatures([feature], 'zoomif');
     } else if (feature.type === FeatureType.DataSource) {
       this.layerService.createAsyncLayer(feature.layer).subscribe(layer => {
         this.map.addLayer(layer);

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -37,7 +37,7 @@ export const environment: Environment = {
         locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         limit: 5,
         locateLimit: 15,
-        enabled: true
+        enabled: false
       },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',

--- a/projects/geo/src/lib/overlay/shared/index.ts
+++ b/projects/geo/src/lib/overlay/shared/index.ts
@@ -1,3 +1,3 @@
 export * from './overlay.directive';
 export * from './overlay.service';
-export * from './overlay.interface';
+export * from './overlay.enum';

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -78,6 +78,10 @@ export class OverlayDirective implements OnInit, OnDestroy {
         this.map.zoomToExtent(extent);
       } else if (action === 'move') {
         this.map.moveToExtent(extent);
+      } else if (action === 'zoomif') {
+        if (!extent.intersects(featureExtent, this.map.getExtent())) {
+          this.map.zoomToExtent(extent);
+        }
       }
     }
   }

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -11,7 +11,7 @@ import { SourceFeatureType } from '../../feature/shared/feature.enum';
 import { Feature } from '../../feature/shared/feature.interface';
 
 import { OverlayService } from '../shared/overlay.service';
-import { OverlayAction } from '../shared/overlay.interface';
+import { OverlayAction } from '../shared/overlay.enum';
 
 @Directive({
   selector: '[igoOverlay]'
@@ -68,17 +68,17 @@ export class OverlayDirective implements OnInit, OnDestroy {
     }, this);
     if (features[0].sourceType === SourceFeatureType.Click) {
       if (olextent.intersects(featureExtent, this.map.getExtent())) {
-        action = 'none';
+        action = OverlayAction.none;
       } else {
-        action = 'move';
+        action = OverlayAction.move;
       }
     }
     if (!olextent.isEmpty(featureExtent)) {
-      if (action === 'zoom') {
+      if (action === OverlayAction.zoom) {
         this.map.zoomToExtent(extent);
-      } else if (action === 'move') {
+      } else if (action === OverlayAction.move) {
         this.map.moveToExtent(extent);
-      } else if (action === 'zoomif') {
+      } else if (action === OverlayAction.zoomIfOutMapExtent) {
         if (!extent.intersects(featureExtent, this.map.getExtent())) {
           this.map.zoomToExtent(extent);
         }

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -68,17 +68,17 @@ export class OverlayDirective implements OnInit, OnDestroy {
     }, this);
     if (features[0].sourceType === SourceFeatureType.Click) {
       if (olextent.intersects(featureExtent, this.map.getExtent())) {
-        action = OverlayAction.none;
+        action = OverlayAction.None;
       } else {
-        action = OverlayAction.move;
+        action = OverlayAction.Move;
       }
     }
     if (!olextent.isEmpty(featureExtent)) {
-      if (action === OverlayAction.zoom) {
+      if (action === OverlayAction.Zoom) {
         this.map.zoomToExtent(extent);
-      } else if (action === OverlayAction.move) {
+      } else if (action === OverlayAction.Move) {
         this.map.moveToExtent(extent);
-      } else if (action === OverlayAction.zoomIfOutMapExtent) {
+      } else if (action === OverlayAction.ZoomIfOutMapExtent) {
         if (!olextent.intersects(featureExtent, this.map.getExtent())) {
           this.map.zoomToExtent(extent);
         }

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -79,7 +79,7 @@ export class OverlayDirective implements OnInit, OnDestroy {
       } else if (action === OverlayAction.move) {
         this.map.moveToExtent(extent);
       } else if (action === OverlayAction.zoomIfOutMapExtent) {
-        if (!extent.intersects(featureExtent, this.map.getExtent())) {
+        if (!olextent.intersects(featureExtent, this.map.getExtent())) {
           this.map.zoomToExtent(extent);
         }
       }

--- a/projects/geo/src/lib/overlay/shared/overlay.enum.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.enum.ts
@@ -1,6 +1,6 @@
 export enum OverlayAction {
-    none,
-    move,
-    zoom,
-    zoomIfOutMapExtent
+    None,
+    Move,
+    Zoom,
+    ZoomIfOutMapExtent
   }

--- a/projects/geo/src/lib/overlay/shared/overlay.enum.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.enum.ts
@@ -1,0 +1,6 @@
+export enum OverlayAction {
+    none,
+    move,
+    zoom,
+    zoomIfOutMapExtent
+  }

--- a/projects/geo/src/lib/overlay/shared/overlay.interface.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.interface.ts
@@ -1,1 +1,0 @@
-export type OverlayAction = 'none' | 'move' | 'zoom' | 'zoomif' ;

--- a/projects/geo/src/lib/overlay/shared/overlay.interface.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.interface.ts
@@ -1,1 +1,1 @@
-export type OverlayAction = 'none' | 'move' | 'zoom';
+export type OverlayAction = 'none' | 'move' | 'zoom' | 'zoomif' ;

--- a/projects/geo/src/lib/overlay/shared/overlay.service.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject } from 'rxjs';
 
 import { Feature } from '../../feature/shared/feature.interface';
 
-import { OverlayAction } from './overlay.interface';
+import { OverlayAction } from './overlay.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -16,11 +16,11 @@ export class OverlayService {
 
   constructor() {}
 
-  setFeatures(features: Feature[], action: OverlayAction = 'none') {
+  setFeatures(features: Feature[], action: OverlayAction = OverlayAction.none) {
     this.features$.next([features, action]);
   }
 
   clear() {
-    this.features$.next([[], 'none']);
+    this.features$.next([[], OverlayAction.none]);
   }
 }

--- a/projects/geo/src/lib/overlay/shared/overlay.service.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.service.ts
@@ -16,11 +16,11 @@ export class OverlayService {
 
   constructor() {}
 
-  setFeatures(features: Feature[], action: OverlayAction = OverlayAction.none) {
+  setFeatures(features: Feature[], action: OverlayAction = OverlayAction.None) {
     this.features$.next([features, action]);
   }
 
   clear() {
-    this.features$.next([[], OverlayAction.none]);
+    this.features$.next([[], OverlayAction.None]);
   }
 }

--- a/projects/tools/src/lib/search-results-tool/search-results-tool.component.ts
+++ b/projects/tools/src/lib/search-results-tool/search-results-tool.component.ts
@@ -32,13 +32,13 @@ export class SearchResultsToolComponent {
 
   handleFeatureFocus(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], OverlayAction.move);
+      this.overlayService.setFeatures([feature], OverlayAction.Move);
     }
   }
 
   handleFeatureSelect(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], OverlayAction.zoomIfOutMapExtent);
+      this.overlayService.setFeatures([feature], OverlayAction.ZoomIfOutMapExtent);
     } else if (feature.type === FeatureType.DataSource) {
       const map = this.mapService.getMap();
 

--- a/projects/tools/src/lib/search-results-tool/search-results-tool.component.ts
+++ b/projects/tools/src/lib/search-results-tool/search-results-tool.component.ts
@@ -6,6 +6,7 @@ import {
   MapService,
   LayerService,
   OverlayService,
+  OverlayAction,
   Feature,
   FeatureType,
   AnyDataSourceOptions,
@@ -31,13 +32,13 @@ export class SearchResultsToolComponent {
 
   handleFeatureFocus(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], 'move');
+      this.overlayService.setFeatures([feature], OverlayAction.move);
     }
   }
 
   handleFeatureSelect(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], 'zoomif');
+      this.overlayService.setFeatures([feature], OverlayAction.zoomIfOutMapExtent);
     } else if (feature.type === FeatureType.DataSource) {
       const map = this.mapService.getMap();
 

--- a/projects/tools/src/lib/search-results-tool/search-results-tool.component.ts
+++ b/projects/tools/src/lib/search-results-tool/search-results-tool.component.ts
@@ -37,7 +37,7 @@ export class SearchResultsToolComponent {
 
   handleFeatureSelect(feature: Feature) {
     if (feature.type === FeatureType.Feature) {
-      this.overlayService.setFeatures([feature], 'zoom');
+      this.overlayService.setFeatures([feature], 'zoomif');
     } else if (feature.type === FeatureType.DataSource) {
       const map = this.mapService.getMap();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
On click on results, the current behavior is to zoom to the feature, despite if the feature is already contained in map extent...


**What is the new behavior?**
Prevent zoom on if feature extent is in map. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
