### PR TITLE
Feature zoom if not in extent based on feature geometry. 

### DIFF
--- a/demo/src/app/geo/search/search.module.ts
+++ b/demo/src/app/geo/search/search.module.ts
@@ -17,7 +17,7 @@ import {
   IgoFeatureModule,
   IgoOverlayModule,
   provideIChercheSearchSource,
-  provideDataSourceSearchSource
+  provideNominatimSearchSource
 } from '@igo2/geo';
 
 import { AppSearchComponent } from './search.component';
@@ -42,6 +42,6 @@ import { AppSearchRoutingModule } from './search-routing.module';
   exports: [AppSearchComponent],
   providers: [
     provideIChercheSearchSource(),
-    provideDataSourceSearchSource()]
+    provideNominatimSearchSource()]
 })
 export class AppSearchModule {}

--- a/demo/src/app/geo/search/search.module.ts
+++ b/demo/src/app/geo/search/search.module.ts
@@ -17,6 +17,7 @@ import {
   IgoFeatureModule,
   IgoOverlayModule,
   provideIChercheSearchSource,
+  provideDataSourceSearchSource,
   provideNominatimSearchSource
 } from '@igo2/geo';
 
@@ -42,6 +43,7 @@ import { AppSearchRoutingModule } from './search-routing.module';
   exports: [AppSearchComponent],
   providers: [
     provideIChercheSearchSource(),
+    provideDataSourceSearchSource(),
     provideNominatimSearchSource()]
 })
 export class AppSearchModule {}

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -29,11 +29,13 @@ export const environment: Environment = {
       reseautq: {
         searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+        zoomLevelTriggerFeatureZoom: 8,
         enabled: true
       },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
+        zoomLevelTriggerFeatureZoom: 10,
         enabled: true
       },
       datasource: {

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -29,13 +29,13 @@ export const environment: Environment = {
       reseautq: {
         searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
-        zoomLevelTriggerFeatureZoom: 8,
+        zoomMaxOnSelect: 8,
         enabled: true
       },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
-        zoomLevelTriggerFeatureZoom: 10,
+        zoomMaxOnSelect: 10,
         enabled: true
       },
       datasource: {

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -37,13 +37,13 @@ export const environment: Environment = {
         locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         limit: 5,
         locateLimit: 15,
-        zoomLevelTriggerFeatureZoom: 8,
+        zoomMaxOnSelect: 8,
         enabled: false
       },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
-        zoomLevelTriggerFeatureZoom: 10,
+        zoomMaxOnSelect: 10,
         enabled: true
       },
       datasource: {

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -30,18 +30,20 @@ export const environment: Environment = {
     },
     searchSources: {
       nominatim: {
-        enabled: false
+        enabled: true
       },
       reseautq: {
         searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         locateUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
         limit: 5,
         locateLimit: 15,
+        zoomLevelTriggerFeatureZoom: 8,
         enabled: false
       },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
         locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
+        zoomLevelTriggerFeatureZoom: 10,
         enabled: true
       },
       datasource: {

--- a/projects/context/src/lib/sidenav/sidenav.component.html
+++ b/projects/context/src/lib/sidenav/sidenav.component.html
@@ -72,7 +72,7 @@
             panelRightButton
             class="igo-icon-button"
             (click)="zoomToFeatureExtent()"
-            *ngIf="media !== 'mobile'">
+            *ngIf="feature.geometry">
             <mat-icon>zoom_in</mat-icon>
           </button>
 

--- a/projects/context/src/lib/sidenav/sidenav.component.html
+++ b/projects/context/src/lib/sidenav/sidenav.component.html
@@ -71,8 +71,9 @@
             mat-icon-button
             panelRightButton
             class="igo-icon-button"
+            (click)="zoomToFeatureExtent()"
             *ngIf="media !== 'mobile'">
-            <mat-icon>open_in_new</mat-icon>
+            <mat-icon>zoom_in</mat-icon>
           </button>
 
           <igo-feature-details

--- a/projects/context/src/lib/sidenav/sidenav.component.ts
+++ b/projects/context/src/lib/sidenav/sidenav.component.ts
@@ -64,11 +64,13 @@ export class SidenavComponent {
   constructor(public toolService: ToolService) {}
 
   zoomToFeatureExtent() {
-    const olFeature = this.format.readFeature(this.feature, {
-      dataProjection: this.feature.projection,
-      featureProjection: this.map.projection
-    });
-    this.map.zoomToFeature(olFeature);
+    if (this.feature.geometry) {
+      const olFeature = this.format.readFeature(this.feature, {
+        dataProjection: this.feature.projection,
+        featureProjection: this.map.projection
+      });
+      this.map.zoomToFeature(olFeature);
+    }
   }
 
   toggleTopPanel() {

--- a/projects/context/src/lib/sidenav/sidenav.component.ts
+++ b/projects/context/src/lib/sidenav/sidenav.component.ts
@@ -2,9 +2,11 @@ import { Component, Input } from '@angular/core';
 
 import { Media } from '@igo2/core';
 import { FlexibleState } from '@igo2/common';
-import { Feature } from '@igo2/geo';
+import { Feature, IgoMap } from '@igo2/geo';
 import { Tool } from '../tool/shared/tool.interface';
 import { ToolService } from '../tool/shared/tool.service';
+
+import olFormatGeoJSON from 'ol/format/GeoJSON';
 
 @Component({
   selector: 'igo-sidenav',
@@ -12,6 +14,15 @@ import { ToolService } from '../tool/shared/tool.service';
   styleUrls: ['./sidenav.component.scss']
 })
 export class SidenavComponent {
+  private format = new olFormatGeoJSON();
+  @Input()
+  get map(): IgoMap {
+    return this._map;
+  }
+  set map(value: IgoMap) {
+    this._map = value;
+  }
+  private _map: IgoMap;
   @Input()
   get opened(): boolean {
     return this._opened;
@@ -51,6 +62,14 @@ export class SidenavComponent {
   public topPanelState: FlexibleState = 'initial';
 
   constructor(public toolService: ToolService) {}
+
+  zoomToFeatureExtent() {
+    const olFeature = this.format.readFeature(this.feature, {
+      dataProjection: this.feature.projection,
+      featureProjection: this.map.projection
+    });
+    this.map.zoomToFeature(olFeature);
+  }
 
   toggleTopPanel() {
     if (this.topPanelState === 'initial') {

--- a/projects/geo/src/lib/feature/shared/feature.interface.ts
+++ b/projects/geo/src/lib/feature/shared/feature.interface.ts
@@ -12,6 +12,7 @@ export interface Feature {
   title: string;
   format?: FeatureFormat;
   title_html?: string;
+  zoomLevelTriggerFeatureZoom?: number;
   icon?: string;
 
   projection?: string;

--- a/projects/geo/src/lib/feature/shared/feature.interface.ts
+++ b/projects/geo/src/lib/feature/shared/feature.interface.ts
@@ -12,7 +12,7 @@ export interface Feature {
   title: string;
   format?: FeatureFormat;
   title_html?: string;
-  zoomLevelTriggerFeatureZoom?: number;
+  zoomMaxOnSelect?: number;
   icon?: string;
 
   projection?: string;

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -69,8 +69,9 @@ export class OverlayDirective implements OnInit, OnDestroy {
     }, this);
     const mapExtent = this.map.getExtent();
     const mapExtentHeight = olextent.getHeight(mapExtent);
+    const mapExtentWithInnerBuffer = olextent.buffer(mapExtent, mapExtentHeight * 0.05 * -1);
     if (features[0].sourceType === SourceFeatureType.Click) {
-      if (olextent.containsCoordinate(mapExtent, featureFlatCoordinates)) {
+      if (olextent.intersects(featureExtent, mapExtentWithInnerBuffer)) {
         action = OverlayAction.None;
       } else {
         action = OverlayAction.Move;
@@ -83,7 +84,7 @@ export class OverlayDirective implements OnInit, OnDestroy {
 
     let cntOverlapExtent = 0;
     for (let i = 0; i < featureFlatCoordinates.length; i += 2) {
-      if (olextent.containsCoordinate(olextent.buffer(mapExtent, mapExtentHeight * 0.05 * -1),
+      if (olextent.containsCoordinate(mapExtentWithInnerBuffer,
        [featureFlatCoordinates[i], featureFlatCoordinates[i + 1]])) {
         cntOverlapExtent += 1;
       }

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -54,7 +54,7 @@ export class OverlayDirective implements OnInit, OnDestroy {
         dataProjection: feature.projection,
         featureProjection: this.map.projection
       });
-      featureZoomLevelTrigger = feature.zoomLevelTriggerFeatureZoom;
+      featureZoomLevelTrigger = feature.zoomMaxOnSelect;
       geometry = olFeature.getGeometry();
       featureExtent = this.getFeatureExtent(feature);
       if (olextent.isEmpty(featureExtent)) {

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -48,7 +48,7 @@ export class OverlayDirective implements OnInit, OnDestroy {
 
     const extent = olextent.createEmpty();
 
-    let featureExtent, geometry;
+    let featureExtent, geometry, featureFlatCoordinates;
     features.forEach((feature: Feature) => {
       const olFeature = this.format.readFeature(feature, {
         dataProjection: feature.projection,
@@ -56,6 +56,7 @@ export class OverlayDirective implements OnInit, OnDestroy {
       });
 
       geometry = olFeature.getGeometry();
+      featureFlatCoordinates = geometry.getFlatCoordinates();
       featureExtent = this.getFeatureExtent(feature);
       if (olextent.isEmpty(featureExtent)) {
         if (geometry !== null) {
@@ -67,7 +68,7 @@ export class OverlayDirective implements OnInit, OnDestroy {
       this.map.addOverlay(olFeature);
     }, this);
     if (features[0].sourceType === SourceFeatureType.Click) {
-      if (olextent.intersects(featureExtent, this.map.getExtent())) {
+      if (olextent.containsCoordinate(this.map.getExtent(), featureFlatCoordinates)) {
         action = OverlayAction.None;
       } else {
         action = OverlayAction.Move;
@@ -79,8 +80,8 @@ export class OverlayDirective implements OnInit, OnDestroy {
       } else if (action === OverlayAction.Move) {
         this.map.moveToExtent(extent);
       } else if (action === OverlayAction.ZoomIfOutMapExtent) {
-        if (!olextent.intersects(featureExtent, this.map.getExtent())) {
-          this.map.zoomToExtent(extent);
+        if (!olextent.containsCoordinate(this.map.getExtent(), featureFlatCoordinates)) {
+                    this.map.zoomToExtent(extent);
         }
       }
     }

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -60,11 +60,13 @@ export class OverlayDirective implements OnInit, OnDestroy {
       if (olextent.isEmpty(featureExtent)) {
         if (geometry !== null) {
           featureExtent = geometry.getExtent();
-          featureFlatCoordinates = geometry.simplify(100).getFlatCoordinates();
         }
       }
       olextent.extend(extent, featureExtent);
 
+      if (geometry !== null) {
+        featureFlatCoordinates = geometry.simplify(100).getFlatCoordinates();
+      }
       this.map.addOverlay(olFeature);
     }, this);
     const mapExtent = this.map.getExtent();

--- a/projects/geo/src/lib/overlay/shared/overlay.directive.ts
+++ b/projects/geo/src/lib/overlay/shared/overlay.directive.ts
@@ -56,11 +56,11 @@ export class OverlayDirective implements OnInit, OnDestroy {
       });
       featureZoomLevelTrigger = feature.zoomLevelTriggerFeatureZoom;
       geometry = olFeature.getGeometry();
-      featureFlatCoordinates = geometry.simplify(100).getFlatCoordinates();
       featureExtent = this.getFeatureExtent(feature);
       if (olextent.isEmpty(featureExtent)) {
         if (geometry !== null) {
           featureExtent = geometry.getExtent();
+          featureFlatCoordinates = geometry.simplify(100).getFlatCoordinates();
         }
       }
       olextent.extend(extent, featureExtent);
@@ -83,10 +83,12 @@ export class OverlayDirective implements OnInit, OnDestroy {
     }
 
     let cntOverlapExtent = 0;
-    for (let i = 0; i < featureFlatCoordinates.length; i += 2) {
-      if (olextent.containsCoordinate(mapExtentWithInnerBuffer,
-       [featureFlatCoordinates[i], featureFlatCoordinates[i + 1]])) {
-        cntOverlapExtent += 1;
+    if (featureFlatCoordinates) {
+      for (let i = 0; i < featureFlatCoordinates.length; i += 2) {
+        if (olextent.containsCoordinate(mapExtentWithInnerBuffer,
+          [featureFlatCoordinates[i], featureFlatCoordinates[i + 1]])) {
+          cntOverlapExtent += 1;
+        }
       }
     }
     if (!olextent.isEmpty(featureExtent)) {

--- a/projects/geo/src/lib/search/search-sources/icherche-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/icherche-search-source.ts
@@ -28,7 +28,7 @@ export class IChercheSearchSource extends SearchSource {
 
   private searchUrl = 'https://geoegl.msp.gouv.qc.ca/icherche/geocode';
   private locateUrl = 'https://geoegl.msp.gouv.qc.ca/icherche/xy';
-  private zoomLevelTriggerFeatureZoom;
+  private zoomMaxOnSelect;
   private options: SearchSourceOptions;
 
   constructor(private http: HttpClient, private config: ConfigService) {
@@ -37,7 +37,7 @@ export class IChercheSearchSource extends SearchSource {
     this.options = this.config.getConfig('searchSources.icherche') || {};
     this.searchUrl = this.options.searchUrl || this.searchUrl;
     this.locateUrl = this.options.locateUrl || this.locateUrl;
-    this.zoomLevelTriggerFeatureZoom = this.options.zoomLevelTriggerFeatureZoom || this.zoomLevelTriggerFeatureZoom;
+    this.zoomMaxOnSelect = this.options.zoomMaxOnSelect || this.zoomMaxOnSelect;
   }
 
   getName(): string {
@@ -73,11 +73,11 @@ export class IChercheSearchSource extends SearchSource {
   }
 
   private extractSearchData(response): Feature[] {
-    return response.features.map(res => this.formatSearchResult(res, this.zoomLevelTriggerFeatureZoom));
+    return response.features.map(res => this.formatSearchResult(res, this.zoomMaxOnSelect));
   }
 
   private extractLocateData(response): Feature[] {
-    return response.features.map(res => this.formatLocateResult(res, this.zoomLevelTriggerFeatureZoom));
+    return response.features.map(res => this.formatLocateResult(res, this.zoomMaxOnSelect));
   }
 
   private getSearchParams(term: string): HttpParams {
@@ -118,7 +118,7 @@ export class IChercheSearchSource extends SearchSource {
     });
   }
 
-  private formatSearchResult(result: any, zoomLevelTriggerFeatureZoom: number): Feature {
+  private formatSearchResult(result: any, zoomMaxOnSelect: number): Feature {
     const properties = Object.assign(
       {
         type: result.doc_type
@@ -136,7 +136,7 @@ export class IChercheSearchSource extends SearchSource {
       source: IChercheSearchSource._name,
       sourceType: SourceFeatureType.Search,
       order: 1,
-      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
+      zoomMaxOnSelect: zoomMaxOnSelect,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: result.properties.recherche,
@@ -149,7 +149,7 @@ export class IChercheSearchSource extends SearchSource {
     };
   }
 
-  private formatLocateResult(result: any, zoomLevelTriggerFeatureZoom: number): Feature {
+  private formatLocateResult(result: any, zoomMaxOnSelect: number): Feature {
     const properties = Object.assign(
       {
         type: result.properties.doc_type
@@ -162,7 +162,7 @@ export class IChercheSearchSource extends SearchSource {
       source: IChercheSearchSource._name,
       sourceType: SourceFeatureType.LocateXY,
       order: 1,
-      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
+      zoomMaxOnSelect: zoomMaxOnSelect,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: result.properties.nom,

--- a/projects/geo/src/lib/search/search-sources/icherche-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/icherche-search-source.ts
@@ -28,6 +28,7 @@ export class IChercheSearchSource extends SearchSource {
 
   private searchUrl = 'https://geoegl.msp.gouv.qc.ca/icherche/geocode';
   private locateUrl = 'https://geoegl.msp.gouv.qc.ca/icherche/xy';
+  private zoomLevelTriggerFeatureZoom;
   private options: SearchSourceOptions;
 
   constructor(private http: HttpClient, private config: ConfigService) {
@@ -36,6 +37,7 @@ export class IChercheSearchSource extends SearchSource {
     this.options = this.config.getConfig('searchSources.icherche') || {};
     this.searchUrl = this.options.searchUrl || this.searchUrl;
     this.locateUrl = this.options.locateUrl || this.locateUrl;
+    this.zoomLevelTriggerFeatureZoom = this.options.zoomLevelTriggerFeatureZoom || this.zoomLevelTriggerFeatureZoom;
   }
 
   getName(): string {
@@ -71,11 +73,11 @@ export class IChercheSearchSource extends SearchSource {
   }
 
   private extractSearchData(response): Feature[] {
-    return response.features.map(this.formatSearchResult);
+    return response.features.map(res => this.formatSearchResult(res, this.zoomLevelTriggerFeatureZoom));
   }
 
   private extractLocateData(response): Feature[] {
-    return response.features.map(this.formatLocateResult);
+    return response.features.map(res => this.formatLocateResult(res, this.zoomLevelTriggerFeatureZoom));
   }
 
   private getSearchParams(term: string): HttpParams {
@@ -116,7 +118,7 @@ export class IChercheSearchSource extends SearchSource {
     });
   }
 
-  private formatSearchResult(result: any): Feature {
+  private formatSearchResult(result: any, zoomLevelTriggerFeatureZoom: number): Feature {
     const properties = Object.assign(
       {
         type: result.doc_type
@@ -134,6 +136,7 @@ export class IChercheSearchSource extends SearchSource {
       source: IChercheSearchSource._name,
       sourceType: SourceFeatureType.Search,
       order: 1,
+      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: result.properties.recherche,
@@ -146,7 +149,7 @@ export class IChercheSearchSource extends SearchSource {
     };
   }
 
-  private formatLocateResult(result: any): Feature {
+  private formatLocateResult(result: any, zoomLevelTriggerFeatureZoom: number): Feature {
     const properties = Object.assign(
       {
         type: result.properties.doc_type
@@ -159,6 +162,7 @@ export class IChercheSearchSource extends SearchSource {
       source: IChercheSearchSource._name,
       sourceType: SourceFeatureType.LocateXY,
       order: 1,
+      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: result.properties.nom,

--- a/projects/geo/src/lib/search/search-sources/nominatim-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/nominatim-search-source.ts
@@ -28,7 +28,7 @@ export class NominatimSearchSource extends SearchSource {
 
   private searchUrl = 'https://nominatim.openstreetmap.org/search';
   private locateUrl = 'https://nominatim.openstreetmap.org/reverse';
-  private zoomLevelTriggerFeatureZoom;
+  private zoomMaxOnSelect;
   private options: SearchSourceOptions;
 
   constructor(private http: HttpClient, private config: ConfigService) {
@@ -37,7 +37,7 @@ export class NominatimSearchSource extends SearchSource {
     this.options = this.config.getConfig('searchSources.nominatim') || {};
     this.searchUrl = this.options.searchUrl || this.searchUrl;
     this.locateUrl = this.options.locateUrl || this.locateUrl;
-    this.zoomLevelTriggerFeatureZoom = this.options.zoomLevelTriggerFeatureZoom || this.zoomLevelTriggerFeatureZoom;
+    this.zoomMaxOnSelect = this.options.zoomMaxOnSelect || this.zoomMaxOnSelect;
   }
 
   getName(): string {
@@ -63,7 +63,7 @@ export class NominatimSearchSource extends SearchSource {
     if (response[0] && response[0].error) {
       return [];
     }
-    return response.map(res => this.formatResult(res, resultType, this.zoomLevelTriggerFeatureZoom));
+    return response.map(res => this.formatResult(res, resultType, this.zoomMaxOnSelect));
   }
 
   private getSearchParams(term: string): HttpParams {
@@ -93,13 +93,13 @@ export class NominatimSearchSource extends SearchSource {
     });
   }
 
-  private formatResult(result: any, resultType, zoomLevelTriggerFeatureZoom: number): Feature {
+  private formatResult(result: any, resultType, zoomMaxOnSelect: number): Feature {
     return {
       id: result.place_id,
       source: NominatimSearchSource._name,
       sourceType: resultType,
       order: 0,
-      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
+      zoomMaxOnSelect: zoomMaxOnSelect,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: result.display_name,

--- a/projects/geo/src/lib/search/search-sources/nominatim-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/nominatim-search-source.ts
@@ -28,6 +28,7 @@ export class NominatimSearchSource extends SearchSource {
 
   private searchUrl = 'https://nominatim.openstreetmap.org/search';
   private locateUrl = 'https://nominatim.openstreetmap.org/reverse';
+  private zoomLevelTriggerFeatureZoom;
   private options: SearchSourceOptions;
 
   constructor(private http: HttpClient, private config: ConfigService) {
@@ -36,6 +37,7 @@ export class NominatimSearchSource extends SearchSource {
     this.options = this.config.getConfig('searchSources.nominatim') || {};
     this.searchUrl = this.options.searchUrl || this.searchUrl;
     this.locateUrl = this.options.locateUrl || this.locateUrl;
+    this.zoomLevelTriggerFeatureZoom = this.options.zoomLevelTriggerFeatureZoom || this.zoomLevelTriggerFeatureZoom;
   }
 
   getName(): string {
@@ -61,7 +63,7 @@ export class NominatimSearchSource extends SearchSource {
     if (response[0] && response[0].error) {
       return [];
     }
-    return response.map(res => this.formatResult(res, resultType));
+    return response.map(res => this.formatResult(res, resultType, this.zoomLevelTriggerFeatureZoom));
   }
 
   private getSearchParams(term: string): HttpParams {
@@ -91,12 +93,13 @@ export class NominatimSearchSource extends SearchSource {
     });
   }
 
-  private formatResult(result: any, resultType): Feature {
+  private formatResult(result: any, resultType, zoomLevelTriggerFeatureZoom: number): Feature {
     return {
       id: result.place_id,
       source: NominatimSearchSource._name,
       sourceType: resultType,
       order: 0,
+      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: result.display_name,

--- a/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
@@ -27,6 +27,7 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
 
   private searchUrl = 'https://ws.mapserver.transports.gouv.qc.ca/swtq';
   private locateUrl = 'https://ws.mapserver.transports.gouv.qc.ca/swtq';
+  private zoomLevelTriggerFeatureZoom;
   private searchlimit = 5;
   private locatelimit = this.searchlimit * 2;
   private options: SearchSourceOptions;
@@ -39,6 +40,7 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
     this.locateUrl = this.options.locateUrl || this.locateUrl;
     this.searchlimit = this.options.limit || this.searchlimit;
     this.locatelimit = this.options.locateLimit || this.locatelimit;
+    this.zoomLevelTriggerFeatureZoom = this.options.zoomLevelTriggerFeatureZoom || this.zoomLevelTriggerFeatureZoom;
   }
 
   getName(): string {
@@ -162,10 +164,11 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
 }
 
   private extractSearchData(response): Feature[] {
-    return response.features.map(this.formatSearchResult);
+    // return response.features.map(this.formatSearchResult);
+    return response.features.map(res => this.formatSearchResult(res, this.zoomLevelTriggerFeatureZoom));
   }
 
-  private formatSearchResult(result: any): Feature {
+  private formatSearchResult(result: any, zoomLevelTriggerFeatureZoom: number): Feature {
     const properties = Object.assign(
       {
         type: result.type
@@ -200,6 +203,7 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
       source: ReseauTransportsQuebecSearchSource._name,
       sourceType: SourceFeatureType.Search,
       order: 1,
+      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: properties.title,

--- a/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
+++ b/projects/geo/src/lib/search/search-sources/reseau-transport-quebec-search-source.ts
@@ -27,7 +27,7 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
 
   private searchUrl = 'https://ws.mapserver.transports.gouv.qc.ca/swtq';
   private locateUrl = 'https://ws.mapserver.transports.gouv.qc.ca/swtq';
-  private zoomLevelTriggerFeatureZoom;
+  private zoomMaxOnSelect;
   private searchlimit = 5;
   private locatelimit = this.searchlimit * 2;
   private options: SearchSourceOptions;
@@ -40,7 +40,7 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
     this.locateUrl = this.options.locateUrl || this.locateUrl;
     this.searchlimit = this.options.limit || this.searchlimit;
     this.locatelimit = this.options.locateLimit || this.locatelimit;
-    this.zoomLevelTriggerFeatureZoom = this.options.zoomLevelTriggerFeatureZoom || this.zoomLevelTriggerFeatureZoom;
+    this.zoomMaxOnSelect = this.options.zoomMaxOnSelect || this.zoomMaxOnSelect;
   }
 
   getName(): string {
@@ -165,10 +165,10 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
 
   private extractSearchData(response): Feature[] {
     // return response.features.map(this.formatSearchResult);
-    return response.features.map(res => this.formatSearchResult(res, this.zoomLevelTriggerFeatureZoom));
+    return response.features.map(res => this.formatSearchResult(res, this.zoomMaxOnSelect));
   }
 
-  private formatSearchResult(result: any, zoomLevelTriggerFeatureZoom: number): Feature {
+  private formatSearchResult(result: any, zoomMaxOnSelect: number): Feature {
     const properties = Object.assign(
       {
         type: result.type
@@ -203,7 +203,7 @@ export class ReseauTransportsQuebecSearchSource extends SearchSource {
       source: ReseauTransportsQuebecSearchSource._name,
       sourceType: SourceFeatureType.Search,
       order: 1,
-      zoomLevelTriggerFeatureZoom: zoomLevelTriggerFeatureZoom,
+      zoomMaxOnSelect: zoomMaxOnSelect,
       type: FeatureType.Feature,
       format: FeatureFormat.GeoJSON,
       title: properties.title,

--- a/projects/geo/src/lib/search/search-sources/search-source.interface.ts
+++ b/projects/geo/src/lib/search/search-sources/search-source.interface.ts
@@ -6,6 +6,7 @@ export interface SearchSourceOptions {
   enabled?: boolean;
   type?: string;
   distance?: number;
+  zoomLevelTriggerFeatureZoom?: number;
 }
 
 export interface SearchSourcesOptions {

--- a/projects/geo/src/lib/search/search-sources/search-source.interface.ts
+++ b/projects/geo/src/lib/search/search-sources/search-source.interface.ts
@@ -6,7 +6,7 @@ export interface SearchSourceOptions {
   enabled?: boolean;
   type?: string;
   distance?: number;
-  zoomLevelTriggerFeatureZoom?: number;
+  zoomMaxOnSelect?: number;
 }
 
 export interface SearchSourcesOptions {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**
Cleaner zoom behavior on search or query
Previously (pr #193), the zoom behavior was based on feature extent. This way to check intersection was incorrect. In the case a small map extent was covered by a large feature (large extent), extents were intersecting but not the geometry. This PR fix it. 

**Now** 
if the geometry do not overlap map extent = Zoom
if the number of vertice intersecting the geometry / Total vertices  is under or equal to 5%, = zoom out.
e.g. 5 vertices are intersecting the map extent / 200 (total geometry vertices), =2.5% then Zoom Out

These can be overridden by a searchSources configuration. For each search source, you can now provide a zoom Level Threshold where you want the app to allway zoom on features when you select a feature in the result's list.  In the example above, if the current map zoom is under or equal to 10, the selection of a feature will trigger a Zoom. If above, default behavior.
`  icherche: {
        searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',
        locateUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/xy',
        zoomLevelTriggerFeatureZoom: 10,
        enabled: true
      },`

Adding a Zoom button for each feature. User can now trigger zoom if geometry is present.
![image](https://user-images.githubusercontent.com/7397743/46681373-1bc3b880-cbb9-11e8-8ae0-d16bcb852575.png)




**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
