### PR TITLE
let the backdrop be shown on any media instead of on mobiles only

### DIFF
--- a/projects/common/src/lib/backdrop/backdrop.component.scss
+++ b/projects/common/src/lib/backdrop/backdrop.component.scss
@@ -12,9 +12,5 @@
 }
 
 :host > div.igo-backdrop-shown {
-  display: none;
-
-  @include mobile {
-    display: block;
-  }
+  display: block;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The backdrop cannot be shown on media other than mobiles.


**What is the new behavior?**
The app is free of showing the backdrop when it wants, on any media.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
