### PR TITLE
feat(wms-datasources) a way to bypass info_format given for getinfo

### DIFF
--- a/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -47,6 +47,10 @@ export class WMSDataSource extends DataSource {
       sourceParams.VERSION = sourceParams.version;
     }
 
+    if (sourceParams && sourceParams.INFO_FORMAT) {
+      sourceParams.info_format = sourceParams.INFO_FORMAT;
+    }
+
     if (options.refreshIntervalSec && options.refreshIntervalSec > 0) {
       setInterval(() => {
         this.ol.updateParams({ igoRefresh: Math.random() });

--- a/projects/geo/src/lib/query/shared/query.service.ts
+++ b/projects/geo/src/lib/query/shared/query.service.ts
@@ -313,7 +313,7 @@ export class QueryService {
           options.resolution,
           options.projection,
           {
-            INFO_FORMAT: this.getMimeInfoFormat(datasource.options.queryFormat),
+            INFO_FORMAT: wmsDatasource.params.info_format || this.getMimeInfoFormat(datasource.options.queryFormat),
             QUERY_LAYERS: wmsDatasource.params.layers,
             FEATURE_COUNT: wmsDatasource.params.feature_count || '5'
           }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

if queryFormat format is set (` "queryFormat": "html"` ) there is no way to change the info_format used into the url for GetfeatureInfo (wms sources)



**What is the new behavior?**

for wms-datasources, into the params section, if a info format is provided, this format will be used to query the service. 
This new way do not remplace the way to parse the returned format, only the way to call the service. If you want to parse a new format, you must make a PR.... 

This PR is done to provide a way to call a service into a html format, but with a non-standard name.

Ex: Called Format = html, Called Format Name = text/html2.

Same thing probably applyable for gml2 with non standard name.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
