### PR TITLE
Query layers and directions

### DIFF
--- a/projects/geo/src/lib/query/shared/query.directive.ts
+++ b/projects/geo/src/lib/query/shared/query.directive.ts
@@ -31,7 +31,6 @@ import { QueryService } from './query.service';
   selector: '[igoQuery]'
 })
 export class QueryDirective implements AfterViewInit, OnDestroy {
-  // private queryLayers: Layer[];
   private queryLayers$$: Subscription;
   private queries$$: Subscription[] = [];
 

--- a/projects/geo/src/lib/query/shared/query.directive.ts
+++ b/projects/geo/src/lib/query/shared/query.directive.ts
@@ -31,7 +31,7 @@ import { QueryService } from './query.service';
   selector: '[igoQuery]'
 })
 export class QueryDirective implements AfterViewInit, OnDestroy {
-  private queryLayers: Layer[];
+  // private queryLayers: Layer[];
   private queryLayers$$: Subscription;
   private queries$$: Subscription[] = [];
 
@@ -91,7 +91,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
       }
     });
 
-    this.queryLayers = queryLayers;
+    this.queryService.queryLayers = queryLayers;
   }
 
   private manageFeatureByClick(
@@ -171,7 +171,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
       delete element.properties['clickedTitle'];
     });
     const view = this.map.ol.getView();
-    const queries$ = this.queryService.query(this.queryLayers, {
+    const queries$ = this.queryService.query(this.queryService.queryLayers, {
       coordinates: event.coordinate,
       projection: this.map.projection,
       resolution: view.getResolution()

--- a/projects/geo/src/lib/query/shared/query.service.ts
+++ b/projects/geo/src/lib/query/shared/query.service.ts
@@ -33,6 +33,7 @@ import { QueryOptions, QueryableDataSource } from './query.interface';
   providedIn: 'root'
 })
 export class QueryService {
+  public queryLayers: Layer[];
   constructor(
     private http: HttpClient,
     private featureService: FeatureService

--- a/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
+++ b/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
@@ -31,6 +31,8 @@ import { Routing } from '../shared/routing.interface';
 import { RoutingService } from '../shared/routing.service';
 import { RoutingFormService } from './routing-form.service';
 
+import { QueryService } from '../../query/shared/query.service';
+
 @Component({
   selector: 'igo-routing-form',
   templateUrl: './routing-form.component.html',
@@ -57,6 +59,8 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   private focusOnStop = false;
   public initialStopsCoords;
   private browserLanguage;
+
+  private queryLayersOnInit;
 
   // https://stackoverflow.com/questions/46364852/create-input-fields-dynamically-in-angular-2
 
@@ -104,7 +108,8 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
     private messageService: MessageService,
     private searchService: SearchService,
     // private shareMapService: ShareMapService
-    private routingFormService: RoutingFormService
+    private routingFormService: RoutingFormService,
+    private queryService: QueryService,
   ) {}
 
   changeRoute(selectedRoute: Routing) {
@@ -112,6 +117,8 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    console.log('ngOnDestroy', this.queryLayersOnInit);
+    this.queryService.queryLayers = this.queryLayersOnInit;
     const stopCoordinates = [];
     let emptyCoord = false;
     this.stops.value.forEach(stop => {
@@ -144,6 +151,8 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
+    this.queryLayersOnInit = this.queryService.queryLayers;
+    this.queryService.queryLayers = [];
     this.focusOnStop = false;
     const stopsLayer = new VectorLayer({
       title: 'routingStopOverlay',

--- a/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
+++ b/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
@@ -117,7 +117,6 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    console.log('ngOnDestroy', this.queryLayersOnInit);
     this.queryService.queryLayers = this.queryLayersOnInit;
     const stopCoordinates = [];
     let emptyCoord = false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When the direction component is activated, when the user fire a click, the query directive is called and focus on results. 


**What is the new behavior?**
Moving the queryLayers to service allow another component to control the active queryLayers. In this case, in the routing (direction) component, the query on layers is not activated. When the user leave the component, the layers become queryable again

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
