### PR TITLE
Proper way to control queries from another component

### DIFF
--- a/projects/geo/src/lib/query/shared/query.directive.ts
+++ b/projects/geo/src/lib/query/shared/query.directive.ts
@@ -98,9 +98,6 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
     featureOL: olFeature,
     layerOL: olLayer
   ): Feature {
-    if (!this.queryService.allowQueryExecution) {
-      return;
-    }
     if (layerOL.getZIndex() !== 999) {
       let title;
       if (layerOL.get('title') !== undefined) {
@@ -128,7 +125,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
 
   private handleMapClick(event: olMapBrowserEvent) {
     this.unsubscribeQueries();
-    if (!this.queryService.allowQueryExecution) {
+    if (!this.queryService.queryEnabled) {
       return;
     }
     const clickedFeatures: olFeature[] = [];

--- a/projects/geo/src/lib/query/shared/query.directive.ts
+++ b/projects/geo/src/lib/query/shared/query.directive.ts
@@ -31,6 +31,7 @@ import { QueryService } from './query.service';
   selector: '[igoQuery]'
 })
 export class QueryDirective implements AfterViewInit, OnDestroy {
+  private queryLayers: Layer[];
   private queryLayers$$: Subscription;
   private queries$$: Subscription[] = [];
 
@@ -90,13 +91,16 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
       }
     });
 
-    this.queryService.queryLayers = queryLayers;
+    this.queryLayers = queryLayers;
   }
 
   private manageFeatureByClick(
     featureOL: olFeature,
     layerOL: olLayer
   ): Feature {
+    if (!this.queryService.allowQueryExecution) {
+      return;
+    }
     if (layerOL.getZIndex() !== 999) {
       let title;
       if (layerOL.get('title') !== undefined) {
@@ -124,6 +128,9 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
 
   private handleMapClick(event: olMapBrowserEvent) {
     this.unsubscribeQueries();
+    if (!this.queryService.allowQueryExecution) {
+      return;
+    }
     const clickedFeatures: olFeature[] = [];
     const format = new olFormatGeoJSON();
     const mapProjection = this.map.projection;
@@ -173,7 +180,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
       delete element.properties['clickedTitle'];
     });
     const view = this.map.ol.getView();
-    const queries$ = this.queryService.query(this.queryService.queryLayers, {
+    const queries$ = this.queryService.query(this.queryLayers, {
       coordinates: event.coordinate,
       projection: this.map.projection,
       resolution: view.getResolution()

--- a/projects/geo/src/lib/query/shared/query.service.ts
+++ b/projects/geo/src/lib/query/shared/query.service.ts
@@ -33,7 +33,7 @@ import { QueryOptions, QueryableDataSource } from './query.interface';
   providedIn: 'root'
 })
 export class QueryService {
-  public queryLayers: Layer[];
+  public allowQueryExecution = true;
   constructor(
     private http: HttpClient,
     private featureService: FeatureService

--- a/projects/geo/src/lib/query/shared/query.service.ts
+++ b/projects/geo/src/lib/query/shared/query.service.ts
@@ -33,7 +33,7 @@ import { QueryOptions, QueryableDataSource } from './query.interface';
   providedIn: 'root'
 })
 export class QueryService {
-  public allowQueryExecution = true;
+  public queryEnabled = true;
   constructor(
     private http: HttpClient,
     private featureService: FeatureService

--- a/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
+++ b/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
@@ -117,7 +117,7 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.queryService.allowQueryExecution = true;
+    this.queryService.queryEnabled = true;
     const stopCoordinates = [];
 
     this.stops.value.forEach(stop => {
@@ -146,7 +146,7 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.queryService.allowQueryExecution = false;
+    this.queryService.queryEnabled = false;
     this.focusOnStop = false;
     const stopsLayer = new VectorLayer({
       title: 'routingStopOverlay',

--- a/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
+++ b/projects/geo/src/lib/routing/routing-form/routing-form.component.ts
@@ -61,7 +61,6 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   public initialStopsCoords;
   private browserLanguage;
 
-  private queryLayersOnInit;
 
   // https://stackoverflow.com/questions/46364852/create-input-fields-dynamically-in-angular-2
 
@@ -118,7 +117,7 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.queryService.queryLayers = this.queryLayersOnInit;
+    this.queryService.allowQueryExecution = true;
     const stopCoordinates = [];
 
     this.stops.value.forEach(stop => {
@@ -147,8 +146,7 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.queryLayersOnInit = this.queryService.queryLayers;
-    this.queryService.queryLayers = [];
+    this.queryService.allowQueryExecution = false;
     this.focusOnStop = false;
     const stopsLayer = new VectorLayer({
       title: 'routingStopOverlay',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The way to control query was to remove layer from the queryLayers array.
The side effect was that the wms layers where not queryable, but the vector sources (files or service based i.e. wfs) where still queryable. 
The main effect was on start/stop digitizing (by click on map) in the routing component, the querydirective was fired on vector sources.

**What is the new behavior?**
On opening the routing component, the query service will store a param blocking the querydirective to be executed. Non destroy, the layers become now queryable.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
