### PR TITLE
feat(panel): make it possible to create a igo-panel without a header

### DIFF
--- a/projects/common/src/lib/panel/panel.component.html
+++ b/projects/common/src/lib/panel/panel.component.html
@@ -1,4 +1,4 @@
-<div class="igo-panel-header" title="">
+<div *ngIf="withHeader" class="igo-panel-header" title="">
   <h3>
     <ng-content select="[panelLeftButton]"></ng-content>
     <div class="igo-panel-title">

--- a/projects/common/src/lib/panel/panel.component.scss
+++ b/projects/common/src/lib/panel/panel.component.scss
@@ -26,8 +26,19 @@
 }
 
 .igo-panel-content {
-  height: calc(100% - #{$igo-panel-header-height});
   overflow: auto;
+}
+
+:host.igo-panel-with-header {
+  .igo-panel-content {
+    height: calc(100% - #{$igo-panel-header-height});
+  }
+}
+
+:host:not(.igo-panel-with-header) {
+  .igo-panel-content {
+    height: 100%;
+  }
 }
 
 .igo-panel-title {

--- a/projects/common/src/lib/panel/panel.component.ts
+++ b/projects/common/src/lib/panel/panel.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  Input,
+  ChangeDetectionStrategy,
+  HostBinding
+} from '@angular/core';
 
 @Component({
   selector: 'igo-panel',
@@ -7,6 +12,7 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PanelComponent {
+
   @Input()
   get title() {
     return this._title;
@@ -15,6 +21,16 @@ export class PanelComponent {
     this._title = value;
   }
   private _title: string;
+
+  @Input()
+  @HostBinding('class.igo-panel-with-header')
+  get withHeader(): boolean {
+    return this._withHeader;
+  }
+  set withHeader(value: boolean) {
+    this._withHeader = value;
+  }
+  private _withHeader = true;
 
   constructor() {}
 }

--- a/projects/common/src/lib/panel/panel.module.ts
+++ b/projects/common/src/lib/panel/panel.module.ts
@@ -1,16 +1,16 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { PanelComponent } from './panel.component';
 
 @NgModule({
-  imports: [],
-  declarations: [PanelComponent],
-  exports: [PanelComponent]
+  imports: [
+    CommonModule
+  ],
+  exports: [
+    PanelComponent
+  ],
+  declarations: [
+    PanelComponent
+  ]
 })
-export class IgoPanelModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: IgoPanelModule,
-      providers: []
-    };
-  }
-}
+export class IgoPanelModule {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
There is no way to create a panel withtout a header


**What is the new behavior?**
With the input "withHeader" set to false, the panel will have no header.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
