### PR TITLE
Layer list toolbar

### DIFF
--- a/projects/context/src/lib/share-map/share-map/share-map-binding.directive.ts
+++ b/projects/context/src/lib/share-map/share-map/share-map-binding.directive.ts
@@ -21,6 +21,10 @@ export class ShareMapBindingDirective implements OnInit {
 
   ngOnInit() {
     this.component.map = this.mapService.getMap();
+    this.initRoutes();
+  }
+
+  private initRoutes() {
     if (
       this.route &&
       (this.route.options.llcKKey || this.route.options.llcAKey ||

--- a/projects/context/src/lib/share-map/share-map/share-map-binding.directive.ts
+++ b/projects/context/src/lib/share-map/share-map/share-map-binding.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Self, OnInit/*, AfterViewInit*/, Optional } from '@angular/core';
+import { Directive, Self, OnInit, Optional } from '@angular/core';
 
 import { MapService, LayerListService } from '@igo2/geo';
 import { ShareMapComponent } from './share-map.component';
@@ -7,7 +7,7 @@ import { RouteService } from '@igo2/core';
 @Directive({
   selector: '[igoShareMapBinding]'
 })
-export class ShareMapBindingDirective implements OnInit/*, AfterViewInit*/ {
+export class ShareMapBindingDirective implements OnInit {
   private component: ShareMapComponent;
 
   constructor(
@@ -21,9 +21,6 @@ export class ShareMapBindingDirective implements OnInit/*, AfterViewInit*/ {
 
   ngOnInit() {
     this.component.map = this.mapService.getMap();
- /* }
-
-  ngAfterViewInit(): void {*/
     if (
       this.route &&
       (this.route.options.llcKKey || this.route.options.llcAKey ||

--- a/projects/context/src/lib/share-map/share-map/share-map-binding.directive.ts
+++ b/projects/context/src/lib/share-map/share-map/share-map-binding.directive.ts
@@ -1,22 +1,57 @@
-import { Directive, Self, OnInit } from '@angular/core';
+import { Directive, Self, OnInit/*, AfterViewInit*/, Optional } from '@angular/core';
 
-import { MapService } from '@igo2/geo';
+import { MapService, LayerListService } from '@igo2/geo';
 import { ShareMapComponent } from './share-map.component';
+import { RouteService } from '@igo2/core';
 
 @Directive({
   selector: '[igoShareMapBinding]'
 })
-export class ShareMapBindingDirective implements OnInit {
+export class ShareMapBindingDirective implements OnInit/*, AfterViewInit*/ {
   private component: ShareMapComponent;
 
   constructor(
     @Self() component: ShareMapComponent,
-    private mapService: MapService
+    private mapService: MapService,
+    private layerListService: LayerListService,
+    @Optional() private route: RouteService
   ) {
     this.component = component;
   }
 
   ngOnInit() {
     this.component.map = this.mapService.getMap();
+ /* }
+
+  ngAfterViewInit(): void {*/
+    if (
+      this.route &&
+      (this.route.options.llcKKey || this.route.options.llcAKey ||
+        this.route.options.llcVKey || this.route.options.llcVKey)) {
+      this.route.queryParams.subscribe(params => {
+
+        const keywordFromUrl = params[this.route.options.llcKKey as string];
+        const sortedAplhaFromUrl = params[this.route.options.llcAKey as string];
+        const onlyVisibleFromUrl = params[this.route.options.llcVKey as string];
+        const onlyInRangeFromUrl = params[this.route.options.llcRKey as string];
+        if (keywordFromUrl && !this.layerListService.keywordInitializated) {
+          this.layerListService.keyword = keywordFromUrl;
+          this.layerListService.keywordInitializated = true;
+        }
+        if (sortedAplhaFromUrl && !this.layerListService.sortedAlphaInitializated) {
+          this.layerListService.sortedAlpha = sortedAplhaFromUrl === '1' ? true : false;
+          this.layerListService.sortedAlphaInitializated = true;
+        }
+        if (onlyVisibleFromUrl && !this.layerListService.onlyVisibleInitializated) {
+          this.layerListService.onlyVisible = onlyVisibleFromUrl === '1' ? true : false;
+          this.layerListService.onlyVisibleInitializated = true;
+        }
+        if (onlyInRangeFromUrl && !this.layerListService.onlyInRangeInitializated) {
+          this.layerListService.onlyInRange = onlyInRangeFromUrl === '1' ? true : false;
+          this.layerListService.onlyInRangeInitializated = true;
+        }
+        this.component.resetUrl();
+      });
+    }
   }
 }

--- a/projects/context/src/lib/share-map/shared/share-map.service.ts
+++ b/projects/context/src/lib/share-map/shared/share-map.service.ts
@@ -21,11 +21,11 @@ export class ShareMapService {
     this.urlApi = this.config.getConfig('context.url');
   }
 
-  getUrl(map: IgoMap, formValues) {
+  getUrl(map: IgoMap, formValues, publicShareOption) {
     if (this.urlApi) {
       return this.getUrlWithApi(map, formValues);
     }
-    return this.getUrlWithoutApi(map);
+    return this.getUrlWithoutApi(map, publicShareOption);
   }
 
   getUrlWithApi(map: IgoMap, formValues) {
@@ -43,7 +43,7 @@ export class ShareMapService {
     return `${location.origin + location.pathname}?context=${formValues.uri}`;
   }
 
-  getUrlWithoutApi(map: IgoMap) {
+  getUrlWithoutApi(map: IgoMap, publicShareOption) {
     if (
       !this.route ||
       !this.route.options.visibleOnLayersKey ||
@@ -52,6 +52,7 @@ export class ShareMapService {
     ) {
       return;
     }
+    const llc = publicShareOption.layerlistControls.querystring;
 
     const visibleKey = this.route.options.visibleOnLayersKey;
     const invisibleKey = this.route.options.visibleOffLayersKey;
@@ -103,6 +104,6 @@ export class ShareMapService {
 
     return `${location.origin}${
       location.pathname
-    }?${context}&${zoom}&${center}&${layersUrl}&${routingUrl}`;
+    }?${context}&${zoom}&${center}&${layersUrl}&${llc}&${routingUrl}`.replace(/&&/g, '&');
   }
 }

--- a/projects/core/src/lib/route/route.interface.ts
+++ b/projects/core/src/lib/route/route.interface.ts
@@ -8,4 +8,8 @@ export interface RouteServiceOptions {
   visibleOffLayersKey?: boolean | string;
   routingCoordKey?: boolean | string;
   toolKey?: boolean | string;
+  llcKKey?: boolean | string;
+  llcAKey?: boolean | string;
+  llcVKey?: boolean | string;
+  llcRKey?: boolean | string;
 }

--- a/projects/core/src/lib/route/route.service.ts
+++ b/projects/core/src/lib/route/route.service.ts
@@ -36,7 +36,11 @@ export class RouteService {
       visibleOnLayersKey: 'visiblelayers',
       visibleOffLayersKey: 'invisiblelayers',
       routingCoordKey: 'routing',
-      toolKey: 'tool'
+      toolKey: 'tool',
+      llcKKey: 'llck',
+      llcAKey: 'llca',
+      llcVKey: 'llcv',
+      llcRKey: 'llcr'
     };
     this.options = Object.assign({}, defaultOptions, options);
   }

--- a/projects/geo/src/lib/layer/layer-list/index.ts
+++ b/projects/geo/src/lib/layer/layer-list/index.ts
@@ -1,2 +1,4 @@
 export * from './layer-list.component';
 export * from './layer-list-binding.directive';
+export * from './layer-list.enum';
+export * from './layer-list.service';

--- a/projects/geo/src/lib/layer/layer-list/layer-list-binding.directive.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list-binding.directive.ts
@@ -54,11 +54,15 @@ export class LayerListBindingDirective implements OnInit, AfterViewInit, OnDestr
           this.layerListService.sortedAlpha = sortedAplhaFromUrl === '1' ? true : false;
           this.layerListService.sortedAlphaInitializated = true;
         }
-        if (onlyVisibleFromUrl && !this.layerListService.onlyVisibleInitializated && this.layersVisibilityStatus) {
+        if (onlyVisibleFromUrl &&
+          !this.layerListService.onlyVisibleInitializated &&
+          this.component.hasLayerNotVisible) {
           this.layerListService.onlyVisible = onlyVisibleFromUrl === '1' ? true : false;
           this.layerListService.onlyVisibleInitializated = true;
         }
-        if (onlyInRangeFromUrl && !this.layerListService.onlyInRangeInitializated && this.layersRangeStatus) {
+        if (onlyInRangeFromUrl &&
+          !this.layerListService.onlyInRangeInitializated &&
+          this.component.hasLayerOutOfRange) {
           this.layerListService.onlyInRange = onlyInRangeFromUrl === '1' ? true : false;
           this.layerListService.onlyInRangeInitializated = true;
         }
@@ -68,21 +72,6 @@ export class LayerListBindingDirective implements OnInit, AfterViewInit, OnDestr
 
   ngOnDestroy() {
     this.layers$$.unsubscribe();
-  }
-
-  private layersVisibilityStatus(): boolean  {
-    if (this.component.layers.filter(f => f.visible === false).length >= 1) {
-      return true;
-    } else {
-      return true;
-    }
-  }
-  private layersRangeStatus(): boolean {
-    if (this.component.layers.filter(f => f.isInResolutionsRange === false).length >= 1) {
-      return true;
-    } else {
-      return false;
-    }
   }
 
 }

--- a/projects/geo/src/lib/layer/layer-list/layer-list-binding.directive.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list-binding.directive.ts
@@ -1,19 +1,23 @@
-import { Directive, Self, OnInit, OnDestroy } from '@angular/core';
+import { Directive, Self, OnInit, OnDestroy, AfterViewInit, Optional } from '@angular/core';
 import { Subscription } from 'rxjs';
 
+import { RouteService } from '@igo2/core';
 import { MapService } from '../../map/shared/map.service';
 import { LayerListComponent } from './layer-list.component';
+import { LayerListService } from './layer-list.service';
 
 @Directive({
   selector: '[igoLayerListBinding]'
 })
-export class LayerListBindingDirective implements OnInit, OnDestroy {
+export class LayerListBindingDirective implements OnInit, AfterViewInit, OnDestroy {
   private component: LayerListComponent;
   private layers$$: Subscription;
 
   constructor(
     @Self() component: LayerListComponent,
-    private mapService: MapService
+    private mapService: MapService,
+    private layerListService: LayerListService,
+    @Optional() private route: RouteService
   ) {
     this.component = component;
   }
@@ -27,7 +31,54 @@ export class LayerListBindingDirective implements OnInit, OnDestroy {
       .layers$.subscribe(layers => (this.component.layers = layers));
   }
 
+  ngAfterViewInit(): void {
+    if (
+      this.route &&
+      (this.route.options.llcKKey || this.route.options.llcAKey ||
+        this.route.options.llcVKey || this.route.options.llcVKey)) {
+      this.route.queryParams.subscribe(params => {
+
+        const keywordFromUrl = params[this.route.options.llcKKey as string];
+        const sortedAplhaFromUrl = params[this.route.options.llcAKey as string];
+        const onlyVisibleFromUrl = params[this.route.options.llcVKey as string];
+        const onlyInRangeFromUrl = params[this.route.options.llcRKey as string];
+        if (keywordFromUrl && !this.layerListService.keywordInitializated) {
+          this.layerListService.keyword = keywordFromUrl;
+          this.layerListService.keywordInitializated = true;
+        }
+        if (sortedAplhaFromUrl && !this.layerListService.sortedAlphaInitializated) {
+          this.layerListService.sortedAlpha = sortedAplhaFromUrl === '1' ? true : false;
+          this.layerListService.sortedAlphaInitializated = true;
+        }
+        if (onlyVisibleFromUrl && !this.layerListService.onlyVisibleInitializated && this.layersVisibilityStatus) {
+          this.layerListService.onlyVisible = onlyVisibleFromUrl === '1' ? true : false;
+          this.layerListService.onlyVisibleInitializated = true;
+        }
+        if (onlyInRangeFromUrl && !this.layerListService.onlyInRangeInitializated && this.layersRangeStatus) {
+          this.layerListService.onlyInRange = onlyInRangeFromUrl === '1' ? true : false;
+          this.layerListService.onlyInRangeInitializated = true;
+        }
+      });
+    }
+  }
+
   ngOnDestroy() {
     this.layers$$.unsubscribe();
   }
+
+  private layersVisibilityStatus(): boolean  {
+    if (this.component.layers.filter(f => f.visible === false).length >= 1) {
+      return true;
+    } else {
+      return true;
+    }
+  }
+  private layersRangeStatus(): boolean {
+    if (this.component.layers.filter(f => f.isInResolutionsRange === false).length >= 1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
 }

--- a/projects/geo/src/lib/layer/layer-list/layer-list-binding.directive.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list-binding.directive.ts
@@ -32,6 +32,10 @@ export class LayerListBindingDirective implements OnInit, AfterViewInit, OnDestr
   }
 
   ngAfterViewInit(): void {
+    this.initRoutes();
+  }
+
+  private initRoutes() {
     if (
       this.route &&
       (this.route.options.llcKKey || this.route.options.llcAKey ||

--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.html
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.html
@@ -1,5 +1,5 @@
 <igo-list [navigation]="false" [selection]="false">
-  <mat-list-item *ngIf="layers.length>=thresholdToFilterAndSort || keyword || onlyInRange || onlyVisible ">
+  <mat-list-item *ngIf="showFilterSortToolbar()">
     <ng-container>
     <mat-form-field class="inputFilter" [floatLabel]="floatLabel">
           <input
@@ -7,48 +7,48 @@
           [placeholder]="placeholder"
           [matTooltip]="'igo.geo.layer.subsetLayersListKeyword' | translate"
            matTooltipShowDelay="500"
-          type="text" [(ngModel)]="keyword">
+          type="text" [(ngModel)]="layerListService.keyword">
           <button
           mat-button
-          *ngIf="keyword"
+          *ngIf="layerListService.keyword"
           matSuffix
           mat-icon-button
           aria-label="Clear"
           color="warn"
-          (click)="keyword = undefined">
+          (click)="layerListService.keyword = undefined">
           <mat-icon>close</mat-icon>
           </button>
     </mat-form-field>
     <button
-      *ngIf="!sortedAlpha"
+      *ngIf="!layerListService.sortedAlpha"
       mat-icon-button
       [matTooltip]="'igo.geo.layer.sortAlphabetically' | translate"
       matTooltipShowDelay="500"
-      (click)="sortedAlpha = true">
+      (click)="layerListService.sortedAlpha = true">
       <mat-icon color="primary">sort_by_alpha</mat-icon>
     </button>
     <button
-      *ngIf="sortedAlpha"
+      *ngIf="layerListService.sortedAlpha"
       mat-icon-button
       [matTooltip]="'igo.geo.layer.sortMapOrder' | translate"
       matTooltipShowDelay="500"
-      (click)="sortedAlpha = false">
+      (click)="layerListService.sortedAlpha = false">
       <mat-icon color="warn">warning</mat-icon>
     </button>
     <button
       mat-icon-button
       [disabled]="!hasLayerNotVisible"
-      [matTooltip]="onlyVisible ?
+      [matTooltip]="layerListService.onlyVisible ?
       ('igo.geo.layer.resetLayersList' | translate) :
       ('igo.geo.layer.subsetLayersListOnlyVisible' | translate)"
       matTooltipShowDelay="500"
-      [color]="onlyVisible ? 'warn' : 'primary'"
+      [color]="layerListService.onlyVisible ? 'warn' : 'primary'"
       (click)="toggleOnlyVisible()">
       <mat-icon>
-        <ng-container *ngIf="!onlyVisible">
+        <ng-container *ngIf="!layerListService.onlyVisible">
           visibility
         </ng-container>
-        <ng-container *ngIf="onlyVisible">
+        <ng-container *ngIf="layerListService.onlyVisible">
             warning
         </ng-container>
       </mat-icon>
@@ -56,17 +56,17 @@
     <button
       mat-icon-button
       [disabled]="!hasLayerOutOfRange"
-      [matTooltip]="onlyInRange ?
+      [matTooltip]="layerListService.onlyInRange ?
       ('igo.geo.layer.resetLayersList' | translate) :
       ('igo.geo.layer.subsetLayersListOnlyInRange' | translate)"
       matTooltipShowDelay="500"
-      [color]="onlyInRange ? 'warn' : 'primary'"
+      [color]="layerListService.onlyInRange ? 'warn' : 'primary'"
       (click)="toggleOnlyInRange()">
       <mat-icon>
-        <ng-container *ngIf="!onlyInRange">
+        <ng-container *ngIf="!layerListService.onlyInRange">
             playlist_add_check
         </ng-container>
-        <ng-container *ngIf="onlyInRange">
+        <ng-container *ngIf="layerListService.onlyInRange">
             warning
         </ng-container>
       </mat-icon>

--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -29,17 +29,30 @@ export class LayerListComponent implements AfterViewInit {
 
   @Input()
   get layers(): Layer[] {
-    if (this._layers.filter(f => f.visible === false).length >= 1 ) {
-      this.hasLayerNotVisible = true;
+    if (this.excludeBaseLayers) {
+      if (this._layers.filter(f => f.visible === false && !f.baseLayer).length >= 1) {
+        this.hasLayerNotVisible = true;
+      } else {
+        this.hasLayerNotVisible = false;
+      }
+      if (this._layers
+        .filter(f => f.isInResolutionsRange === false && !f.baseLayer).length >= 1) {
+        this.hasLayerOutOfRange = true;
+      } else {
+        this.hasLayerOutOfRange = false;
+      }
     } else {
-      this.hasLayerNotVisible = false;
+      if (this._layers.filter(f => f.visible === false).length >= 1) {
+        this.hasLayerNotVisible = true;
+      } else {
+        this.hasLayerNotVisible = false;
+      }
+      if (this._layers.filter(f => f.isInResolutionsRange === false).length >= 1) {
+        this.hasLayerOutOfRange = true;
+      } else {
+        this.hasLayerOutOfRange = false;
+      }
     }
-    if (this._layers.filter(f => f.isInResolutionsRange === false).length >= 1 ) {
-      this.hasLayerOutOfRange = true;
-    } else {
-      this.hasLayerOutOfRange = false;
-    }
-
     this.defineReorderLayersStatus();
     return this._layers;
   }
@@ -125,11 +138,13 @@ export class LayerListComponent implements AfterViewInit {
       this.layerListService.sortedAlpha = this.layerFilterAndSortOptions.sortedAlpha;
       this.layerListService.sortedAlphaInitializated = true;
     }
-    if (this.layerFilterAndSortOptions.onlyVisible && !this.layerListService.onlyVisibleInitializated) {
+    if (this.layerFilterAndSortOptions.onlyVisible && !this.layerListService.onlyVisibleInitializated &&
+      this.hasLayerNotVisible) {
       this.layerListService.onlyVisible = this.layerFilterAndSortOptions.onlyVisible;
       this.layerListService.onlyVisibleInitializated = true;
     }
-    if (this.layerFilterAndSortOptions.onlyInRange && !this.layerListService.onlyInRangeInitializated) {
+    if (this.layerFilterAndSortOptions.onlyInRange && !this.layerListService.onlyInRangeInitializated &&
+      this.hasLayerOutOfRange) {
       this.layerListService.onlyInRange = this.layerFilterAndSortOptions.onlyInRange;
       this.layerListService.onlyInRangeInitializated = true;
     }

--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -109,6 +109,10 @@ export class LayerListComponent implements AfterViewInit {
     public layerListService: LayerListService) {}
 
   ngAfterViewInit(): void {
+    this.initLayerFilterAndSortOptions();
+  }
+
+  private initLayerFilterAndSortOptions() {
     if (this.layerFilterAndSortOptions.toolbarThreshold) {
       this.thresholdToFilterAndSort = this.layerFilterAndSortOptions.toolbarThreshold;
     }

--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -154,12 +154,19 @@ export class LayerListComponent implements AfterViewInit {
           this.layerListService.onlyInRange || this.layerListService.onlyVisible) {
           return true;
         } else {
+          this.layerListService.keyword = '';
+          this.layerListService.sortedAlpha = false;
+          this.layerListService.onlyVisible = false;
+          this.layerListService.onlyInRange = false;
           return false;
         }
     }
   }
 
   filterLayersList(localLayers: Layer[]): Layer[] {
+    if (this.layerFilterAndSortOptions.showToolbar === LayerListControlsEnum.never) {
+      return localLayers;
+    }
     if (this.layerListService.getKeyword() || this.layerListService.onlyInRange || this.layerListService.onlyVisible) {
       const layerIDToKeep = [];
       localLayers.forEach(layer => {

--- a/projects/geo/src/lib/layer/layer-list/layer-list.enum.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.enum.ts
@@ -1,0 +1,5 @@
+export enum LayerListControlsEnum {
+  always = 'always',
+  never = 'never',
+  default = 'default'
+}

--- a/projects/geo/src/lib/layer/layer-list/layer-list.service.spec.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { LayerListService } from './layer-list.service';
+
+
+describe('StyleService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [
+        LayerListService
+      ]
+    });
+  });
+
+  it('should ...', inject([LayerListService], (service: LayerListService) => {
+    expect(service).toBeTruthy();
+  }));
+
+});

--- a/projects/geo/src/lib/layer/layer-list/layer-list.service.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LayerListService {
+  public keyword: string;
+  public sortedAlpha = false;
+  public onlyVisible = false;
+  public onlyInRange = false;
+  public keywordInitializated = false;
+  public sortedAlphaInitializated = false;
+  public onlyVisibleInitializated = false;
+  public onlyInRangeInitializated = false;
+
+  constructor() {}
+
+
+  getKeyword() {
+    return this.keyword;
+  }
+
+}

--- a/projects/geo/src/lib/layer/layer.module.ts
+++ b/projects/geo/src/lib/layer/layer.module.ts
@@ -20,6 +20,7 @@ import {
 
 import { LayerService } from './shared/layer.service';
 import { StyleService } from './shared/style.service';
+import { LayerListService } from './layer-list/layer-list.service';
 import { LayerItemComponent } from './layer-item/layer-item.component';
 import { LayerLegendComponent } from './layer-legend/layer-legend.component';
 import { LayerListComponent } from './layer-list/layer-list.component';
@@ -58,7 +59,7 @@ export class IgoLayerModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: IgoLayerModule,
-      providers: [LayerService, StyleService]
+      providers: [LayerService, StyleService, LayerListService]
     };
   }
 }

--- a/projects/tools/src/lib/map-details-tool/map-details-tool.component.html
+++ b/projects/tools/src/lib/map-details-tool/map-details-tool.component.html
@@ -1,6 +1,7 @@
 <igo-layer-list
   igoLayerListBinding
   [excludeBaseLayers]="excludeBaseLayers"
+  [layerFilterAndSortOptions]="layerFilterAndSortOptions"
   [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
   <ng-template #igoLayerItemToolbar let-layer="layer">

--- a/projects/tools/src/lib/map-details-tool/map-details-tool.component.ts
+++ b/projects/tools/src/lib/map-details-tool/map-details-tool.component.ts
@@ -3,6 +3,7 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Register } from '@igo2/context';
 
 import { MapDetailsToolOptions } from './map-details-tool.interface';
+import { LayerListControlsEnum } from '@igo2/geo';
 
 @Register({
   name: 'mapDetails',
@@ -23,9 +24,57 @@ export class MapDetailsToolComponent {
   }
 
   get excludeBaseLayers(): boolean {
-    return this.options.excludeBaseLayers === undefined
-      ? false
-      : this.options.excludeBaseLayers;
+
+    if (this.options && this.options.layerListControls) {
+      return this.options.layerListControls.excludeBaseLayers === undefined
+        ? false
+        : this.options.layerListControls.excludeBaseLayers;
+    } else {
+      return false;
+    }
+  }
+
+  get layerFilterAndSortOptions(): any {
+
+    const filterSortOptions = {
+      showToolbar: LayerListControlsEnum.default,
+      toolbarThreshold: undefined,
+      keyword: undefined,
+      sortedAlpha: undefined,
+      onlyVisible: undefined,
+      onlyInRange: undefined,
+    };
+
+    if (this.options && this.options.layerListControls) {
+      if (this.options.layerListControls.toolbarThreshold) {
+        filterSortOptions.toolbarThreshold = this.options.layerListControls.toolbarThreshold;
+      }
+      if (this.options.layerListControls.keyword) {
+        filterSortOptions.keyword = this.options.layerListControls.keyword;
+      }
+      if (this.options.layerListControls.sortedAlpha) {
+        filterSortOptions.sortedAlpha = this.options.layerListControls.sortedAlpha;
+      }
+      if (this.options.layerListControls.onlyVisible) {
+        filterSortOptions.onlyVisible = this.options.layerListControls.onlyVisible;
+      }
+      if (this.options.layerListControls.onlyInRange) {
+        filterSortOptions.onlyInRange = this.options.layerListControls.onlyInRange;
+      }
+      switch (this.options.layerListControls.showToolbar) {
+        case LayerListControlsEnum.always:
+          filterSortOptions.showToolbar = LayerListControlsEnum.always,
+          filterSortOptions.toolbarThreshold = undefined;
+          break;
+        case LayerListControlsEnum.never:
+          filterSortOptions.showToolbar = LayerListControlsEnum.never,
+          filterSortOptions.toolbarThreshold = undefined;
+          break;
+        default:
+          break;
+      }
+    }
+    return filterSortOptions;
   }
 
   get ogcFiltersInLayers(): boolean {

--- a/projects/tools/src/lib/map-details-tool/map-details-tool.interface.ts
+++ b/projects/tools/src/lib/map-details-tool/map-details-tool.interface.ts
@@ -1,5 +1,17 @@
+import { LayerListControlsEnum } from '@igo2/geo';
+
 export interface MapDetailsToolOptions {
   toggleLegendOnVisibilityChange?: boolean;
-  excludeBaseLayers?: boolean;
   ogcFiltersInLayers?: boolean;
+  layerListControls?: LayerListControlsOptions;
+}
+
+export interface LayerListControlsOptions {
+  excludeBaseLayers?: boolean;
+  showToolbar?: LayerListControlsEnum;
+  toolbarThreshold?: number;
+  keyword?: string;
+  sortedAlpha?: boolean;
+  onlyVisible?: boolean;
+  onlyInRange?: boolean;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Layer list toolbar only have a behavior:
- default = shown if there is more than 5 layers

![image](https://user-images.githubusercontent.com/7397743/49964305-29165f80-fee8-11e8-943d-4159c6169daf.png)





**What is the new behavior?**

1. Introducing other behavior to layer list toolbar 
    - always
    - never
    - default
These behavior can be controlled by new options in yourcontext.json:
`{ "name": "mapDetails",`
`      "options": {`
`        "layerListControls": {`
`          "showToolbar": 'default',        'never' or 'always, if no value provided, default is used.`
`          "toolbarThreshold": 15, if no value provided, 5 by default,  option not used for always or never values)` 
` }}}`

For the default behavior, you can control the threshold (number of layers) at which the tool appears by the previous option named toolbarThreshold. If you have equal or more layers in your table of content, the tool will appear


2. The layer list toolbar can be controlled by parameters
    -  url  
        -  llck=keywordtofilterlayerlist
        -  llca=1 or 0   (true/false) for sorting layers alphabetically
        -  llcv=1 or 0   (true/false) to show only visible layers
        -  llcr=1 or 0   (true/false) to show only layers in scale range
    -  yourcontext.json into mapDetails options:
`{ "name": "mapDetails",`
`      "options": {`
`        "layerListControls": {`
`          "keyword": "yourOwnKeyword",`
`          "sortedAlpha": true or false,`
`          "onlyVisible": true or false,`
`          "onlyInRange": true or false,`
` }}}`

**Does this PR introduce a breaking change?** (check one with "x")
```
[X] Yes
[ ] No
```
If this PR contains a breaking change, please describe the impact and migration path for existing applications:
In the mapDetails tool options,  excludeBaseLayers is now located into layerListControls property as:
`{ "name": "mapDetails",`
`      "options": {`
`        "toggleLegendOnVisibilityChange": false,`
`        "layerListControls": {`
`          "excludeBaseLayers": true,`
` }}}`


**Other information**:
