### PR TITLE
Provide ALIAS to wms getfeatureinfo(gml), wfs and vector datasources

### DIFF
--- a/projects/geo/src/lib/feature/feature-details/feature-details.component.html
+++ b/projects/geo/src/lib/feature/feature-details/feature-details.component.html
@@ -1,6 +1,6 @@
 <table class="igo-striped" *ngIf="feature && isObject(feature.properties) && feature.properties.target !== 'innerhtml'">
   <tbody>
-    <tr *ngFor="let property of feature.properties | keyvalue">
+    <tr *ngFor="let property of filterFeatureProperties(feature) | keyvalue">
 
       <td *ngIf="feature.properties.target === '_blank' && property.key === 'url'">
         <mat-icon mat-list-avatar>{{feature.icon}}</mat-icon>

--- a/projects/geo/src/lib/feature/feature-details/feature-details.component.ts
+++ b/projects/geo/src/lib/feature/feature-details/feature-details.component.ts
@@ -27,7 +27,7 @@ export class FeatureDetailsComponent {
   constructor(
     private cdRef: ChangeDetectorRef,
     private sanitizer: DomSanitizer
-  ) {}
+  ) { }
 
   isUrl(value): SafeResourceUrl {
     return this.sanitizer.bypassSecurityTrustResourceUrl(value);
@@ -35,5 +35,26 @@ export class FeatureDetailsComponent {
 
   isObject(value) {
     return typeof value === 'object';
+  }
+
+  filterFeatureProperties(feature) {
+    const allowedFieldsAndAlias = feature.alias;
+    const properties = Object.assign({}, feature.properties);
+
+    if (allowedFieldsAndAlias) {
+      Object.keys(properties).forEach(property => {
+        if (Object.keys(allowedFieldsAndAlias).indexOf(property) === -1) {
+          delete properties[property];
+        } else {
+          properties[allowedFieldsAndAlias[property]] = properties[property];
+          if (allowedFieldsAndAlias[property] !== property) {
+            delete properties[property];
+          }
+        }
+      });
+      return properties;
+    } else {
+      return feature.properties;
+    }
   }
 }

--- a/projects/geo/src/lib/feature/shared/feature.interface.ts
+++ b/projects/geo/src/lib/feature/shared/feature.interface.ts
@@ -20,6 +20,7 @@ export interface Feature {
   extent?: [number, number, number, number];
   properties?: { [key: string]: any };
   layer?: AnyLayerOptions;
+  alias?: { [key: string]: any };
 }
 
 export interface FeatureGeometry {

--- a/projects/geo/src/lib/query/shared/query.directive.ts
+++ b/projects/geo/src/lib/query/shared/query.directive.ts
@@ -119,6 +119,21 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
         ];
       }
       featureOL.set('clickedTitle', title + queryTitleValue);
+      let allowedFieldsAndAlias;
+      if (
+        layerOL.get('sourceOptions').sourceFields &&
+        layerOL.get('sourceOptions').sourceFields.length >= 1) {
+          allowedFieldsAndAlias = {};
+          layerOL.get('sourceOptions').sourceFields.forEach(sourceField => {
+            const alias = sourceField.alias ? sourceField.alias : sourceField.name;
+            allowedFieldsAndAlias[sourceField.name] = alias;
+          });
+        }
+          featureOL.set('igoAliasList', allowedFieldsAndAlias);
+        if (
+          layerOL.get('title')) {
+            featureOL.set('igoLayerTitle', layerOL.get('title'));
+          }
       return featureOL;
     }
   }
@@ -165,16 +180,17 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
     parsedClickedFeatures = featuresGeoJSON.features.map(f =>
       Object.assign({}, f, {
         sourceType: SourceFeatureType.Click,
-        source: this.languageService.translate.instant(
-          'igo.geo.clickOnMap.clickedFeature'
-        ),
+        source: f.properties.igoLayerTitle,
         id: f.properties.clickedTitle + ' ' + String(i++),
-        icon: 'mouse',
-        title: f.properties.clickedTitle
+        icon: 'place',
+        title: f.properties.clickedTitle,
+        alias: f.properties.igoAliasList
       })
     );
     parsedClickedFeatures.forEach(element => {
       delete element.properties['clickedTitle'];
+      delete element.properties['igoAliasList'];
+      delete element.properties['igoLayerTitle'];
     });
     const view = this.map.ol.getView();
     const queries$ = this.queryService.query(this.queryLayers, {

--- a/projects/geo/src/lib/query/shared/query.directive.ts
+++ b/projects/geo/src/lib/query/shared/query.directive.ts
@@ -108,6 +108,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
       }
       let queryTitleValue = '';
       if (
+        layerOL.get('sourceOptions') &&
         layerOL.get('sourceOptions').queryTitle &&
         featureOL
           .getProperties()
@@ -121,6 +122,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
       featureOL.set('clickedTitle', title + queryTitleValue);
       let allowedFieldsAndAlias;
       if (
+        layerOL.get('sourceOptions') &&
         layerOL.get('sourceOptions').sourceFields &&
         layerOL.get('sourceOptions').sourceFields.length >= 1) {
           allowedFieldsAndAlias = {};
@@ -130,10 +132,13 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
           });
         }
           featureOL.set('igoAliasList', allowedFieldsAndAlias);
+        let groupTitle = this.languageService.translate.instant(
+          'igo.geo.clickOnMap.clickedFeature');
         if (
           layerOL.get('title')) {
-            featureOL.set('igoLayerTitle', layerOL.get('title'));
+            groupTitle = layerOL.get('title');
           }
+          featureOL.set('igoLayerTitle', groupTitle);
       return featureOL;
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
There is no way to provide alias to datasources.

**What is the new behavior?**

1.  By using the sourceFields param (also used for ogc-filter) , you can provide an alias to a field

`"sourceFields": [`
`          {"name": "fieldname", "alias": "fieldAlias"},`
`          ....`
`          ...`
`        ]}`

2. When you click on map to query the vector source, the result is now grouped with the layer title instead of a generic group name named  "Clicked feature". e.g.
Before:
![image](https://user-images.githubusercontent.com/7397743/50158925-5de93480-02a3-11e9-9ded-e163876f0ab7.png)

After:
![image](https://user-images.githubusercontent.com/7397743/50159030-a9034780-02a3-11e9-9534-b3a0930fe34f.png)





**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
