### PR TITLE
feat(layer-list)Allow search with layer keyword (capabilitie or context)

### DIFF
--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -117,12 +117,19 @@ export class LayerListComponent {
       });
 
       localLayers.forEach(layer => {
+        const localLayerKeywords = [];
+        if (layer.options && layer.options['metadata'] && layer.options['metadata'].keywordList ) {
+          layer.options['metadata'].keywordList.forEach(kw => {
+            localLayerKeywords.push(kw.normalize('NFD').replace(/[\u0300-\u036f]/g, ''));
+          });
+        }
         if (this.keyword) {
           const localKeyword = this.keyword.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
           const localLayerTitle = layer.title.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
           if (
             !new RegExp(localKeyword, 'gi').test(localLayerTitle) &&
-            !(this.keyword.toLowerCase() === layer.dataSource.options.type.toString().toLowerCase()) ) {
+            !(this.keyword.toLowerCase() === layer.dataSource.options.type.toString().toLowerCase()) &&
+            localLayerKeywords.filter(kw => new RegExp(localKeyword, 'gi').test(kw)).length === 0) {
             const index = layerIDToKeep.indexOf(layer.id);
             if (index > -1) {
               layerIDToKeep.splice(index, 1);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Into the mapDetails tool, layer list could be controled/subsetted by
-  layer title
-  type
- visiblity  (visible or in scale range)


**What is the new behavior?**
Adding a way to control/subset  by keyword.

The keyword could be provided by 2 ways:

1. "optionsFromCapabilities": true,   ==> wms layer's keywords
2.  "metadata": {
        "keywordList": ["your","own","keyword", "list"]
      }


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
