### PR TITLE
fix(custom-html) ByPassTrustHtml for string declared as html

### DIFF
--- a/projects/common/src/lib/custom-html/custom-html.component.html
+++ b/projects/common/src/lib/custom-html/custom-html.component.html
@@ -1,1 +1,1 @@
-<div class="custom-html" [innerHTML]="html"></div>
+<div class="custom-html" [innerHTML]="html | sanitizeHtml "></div>

--- a/projects/common/src/lib/custom-html/custom-html.module.ts
+++ b/projects/common/src/lib/custom-html/custom-html.module.ts
@@ -10,6 +10,7 @@ import {
 import { IgoLanguageModule } from '@igo2/core';
 
 import { CustomHtmlComponent } from './custom-html.component';
+import { SanitizeHtmlPipe } from './custom-html.pipe';
 
 @NgModule({
   imports: [
@@ -20,8 +21,8 @@ import { CustomHtmlComponent } from './custom-html.component';
     MatButtonModule,
     IgoLanguageModule
   ],
-  exports: [CustomHtmlComponent],
-  declarations: [CustomHtmlComponent]
+  exports: [SanitizeHtmlPipe, CustomHtmlComponent],
+  declarations: [SanitizeHtmlPipe, CustomHtmlComponent]
 })
 export class IgoCustomHtmlModule {
   static forRoot(): ModuleWithProviders {

--- a/projects/common/src/lib/custom-html/custom-html.pipe.ts
+++ b/projects/common/src/lib/custom-html/custom-html.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Pipe({ name: 'sanitizeHtml' })
+export class SanitizeHtmlPipe implements PipeTransform {
+  constructor(private _sanitizer: DomSanitizer) {
+  }
+  transform(v: string): SafeHtml {
+    return this._sanitizer.bypassSecurityTrustHtml(v);
+  }
+}

--- a/projects/common/src/lib/custom-html/index.ts
+++ b/projects/common/src/lib/custom-html/index.ts
@@ -1,1 +1,2 @@
 export * from './custom-html.component';
+export * from './custom-html.pipe';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Some content (string) passed to the custom html component are sanitized and then, unusable. 
Ex: `<h1 style="color:blue;margin-left:30px;">This is a heading</h1>"`
The style was not used. 

**What is the new behavior?**
The declared html is not sanitize anymore.  

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
