### PR TITLE
refactor reseau-transport-quebec search sources

### DIFF
--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -38,7 +38,19 @@ export const environment: Environment = {
         limit: 5,
         locateLimit: 15,
         zoomMaxOnSelect: 8,
-        enabled: false
+        enabled: false,
+        allowedPropertiesAlias:
+        [
+          {name: 'title', alias: 'Titre'},
+          {name: 'etiquette', alias: 'Informations'},
+          {name: 'nommun', alias: 'Municipalité'},
+          {name: 'messagpan', alias: 'Message'},
+          {name: 'noroute', alias: '# de route'},
+          {name: 'nosortie', alias: '# de sortie'},
+          {name: 'direction', alias: 'Direction'},
+          {name: 'typesort', alias: 'Type de sortie'}
+        ],
+        distance : 0.5
       },
       icherche: {
         searchUrl: 'https://geoegl.msp.gouv.qc.ca/icherche/geocode',

--- a/projects/geo/src/lib/search/search-sources/search-source.interface.ts
+++ b/projects/geo/src/lib/search/search-sources/search-source.interface.ts
@@ -7,6 +7,7 @@ export interface SearchSourceOptions {
   type?: string;
   distance?: number;
   zoomMaxOnSelect?: number;
+  allowedPropertiesAlias?: AllowedPropertiesAlias[];
 }
 
 export interface SearchSourcesOptions {
@@ -14,4 +15,9 @@ export interface SearchSourcesOptions {
   nominatim?: SearchSourceOptions;
   datasource?: SearchSourceOptions;
   reseautq?: SearchSourceOptions;
+}
+
+export interface AllowedPropertiesAlias {
+  name: any;
+  alias: any;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When using the search bar, the search source was trying to detect which service (wfs) to call. 
Sometime, the wrong service was called and no features were returned.


**What is the new behavior?**
For each search into the searchbar, every service from this search source are called. 
* Adding a way to find roads exits (number of the exit, not by road).
* Providing alias for search sources  (config.json)
* Providing a way to control search distance into config.json (distance in km).



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
