### PR TITLE
Catalog enhancement (info_format, count)

### DIFF
--- a/projects/geo/src/lib/catalog/catalog-layers-list/catalog-layers-list-binding.directive.ts
+++ b/projects/geo/src/lib/catalog/catalog-layers-list/catalog-layers-list-binding.directive.ts
@@ -20,6 +20,7 @@ import { DataSourceService } from '../../datasource/shared/datasource.service';
 import { CatalogService } from '../shared/catalog.service';
 import { Catalog } from '../shared/catalog.interface';
 import { CatalogLayersListComponent } from './catalog-layers-list.component';
+import { QueryFormat } from '../../query';
 
 @Directive({
   selector: '[igoCatalogLayersListBinding]'
@@ -27,6 +28,7 @@ import { CatalogLayersListComponent } from './catalog-layers-list.component';
 export class CatalogLayersListBindingDirective implements OnInit, OnDestroy {
   private component: CatalogLayersListComponent;
   private selectedCatalog$$: Subscription;
+  private catalogsInfoFormats = [];
 
   @HostListener('select', ['$event'])
   onSelect(layer: LayerOptions) {
@@ -49,6 +51,7 @@ export class CatalogLayersListBindingDirective implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.findCatalogInfoFormat();
     this.selectedCatalog$$ = this.catalogService.catalog$.subscribe(catalog =>
       this.handleCatalogChanged(catalog)
     );
@@ -56,6 +59,88 @@ export class CatalogLayersListBindingDirective implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.selectedCatalog$$.unsubscribe();
+  }
+
+  /**
+   * How to manage a layer declared in multiple formats?
+   * The first occurence of the layer or * is used.
+   * Next occurences are ignored.
+   */
+  findCatalogInfoFormat() {
+    const catalogSources = this.catalogService.getCatalogSources();
+    catalogSources.forEach(source => {
+      const id = source.id !== undefined ? source.id : source.title;
+      if (source.queryFormat) {
+        const layersQueryFormat = [];
+        Object.keys(source.queryFormat).forEach(infoF => {
+          if (source.queryFormat[infoF] instanceof Array) {
+            source.queryFormat[infoF].forEach(element => {
+              if (layersQueryFormat.filter(specific => specific.layer === element).length === 0) {
+                layersQueryFormat.push({layer: element, queryFormat: infoF});
+              }
+            });
+          } else {
+            if (layersQueryFormat.filter(specific => specific.layer === source.queryFormat[infoF]).length === 0) {
+              layersQueryFormat.push({ layer: source.queryFormat[infoF], queryFormat: infoF });
+            }
+          }
+        });
+        this.catalogsInfoFormats.push({id: id, queryFormat: layersQueryFormat});
+      }
+    });
+  }
+
+  retriveLayerInfoFormat(catalog, layer) {
+    const id = catalog.id !== undefined ? catalog.id : catalog.title;
+    let baseInfoFormat;
+    let currentLayerInfoFormat;
+    const catalogInfoFormats = this.catalogsInfoFormats.find(f => f.id === id);
+    if (!catalogInfoFormats) {
+      return;
+    }
+    catalogInfoFormats.queryFormat.forEach(format => {
+      if (format.layer === '*') {
+        baseInfoFormat = format.queryFormat;
+      }
+      if (format.layer === layer.Name) {
+        currentLayerInfoFormat = format.queryFormat;
+      }
+    });
+
+    let queryFormat;
+
+    if (baseInfoFormat && currentLayerInfoFormat) {
+      queryFormat = currentLayerInfoFormat;
+    } else if (!baseInfoFormat && currentLayerInfoFormat) {
+      queryFormat = currentLayerInfoFormat;
+    } else if (baseInfoFormat && !currentLayerInfoFormat) {
+      queryFormat = baseInfoFormat;
+    }
+
+   let returnFormat;
+    switch (queryFormat) {
+      case QueryFormat.GML3:
+        returnFormat = QueryFormat.GML3;
+        break;
+      case QueryFormat.JSON:
+        returnFormat = QueryFormat.JSON;
+        break;
+      case QueryFormat.GEOJSON:
+        returnFormat = QueryFormat.GEOJSON;
+        break;
+      case QueryFormat.ESRIJSON:
+        returnFormat = QueryFormat.ESRIJSON;
+        break;
+      case QueryFormat.TEXT:
+        returnFormat = QueryFormat.TEXT;
+        break;
+      case QueryFormat.HTML:
+        returnFormat = QueryFormat.HTML;
+        break;
+      default:
+        break;
+    }
+    return returnFormat;
   }
 
   /**
@@ -101,8 +186,12 @@ export class CatalogLayersListBindingDirective implements OnInit, OnDestroy {
               const abstract = layer.Abstract ? layer.Abstract : undefined;
               const keywordList = layer.KeywordList ? layer.KeywordList : undefined;
               const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0 ? true : false;
+              const count = catalog.count ? catalog.count : 5;
+              const queryHtmlTarget = catalog.queryHtmlTarget ? catalog.queryHtmlTarget : 'innerhtml' ;
               arrLayer.push({
                 title: layer.Title,
+                maxResolution: this.getResolutionFromScale(layer.MaxScaleDenominator) || Infinity,
+                minResolution: this.getResolutionFromScale(layer.MinScaleDenominator) || 0,
                 metadata: {
                   url: metadata ? metadata.OnlineResource : undefined,
                   extern: metadata ? true : undefined,
@@ -112,8 +201,12 @@ export class CatalogLayersListBindingDirective implements OnInit, OnDestroy {
                 sourceOptions: {
                   type: 'wms',
                   url: catalog.url,
+                  queryable: layer.queryable,
+                  queryFormat: this.retriveLayerInfoFormat(catalog, layer),
+                  queryHtmlTarget: queryHtmlTarget,
                   params: {
-                    layers: layer.Name
+                    layers: layer.Name,
+                    feature_count: count
                   },
                   // Merge catalog time filter in layer timeFilter
                   timeFilter: { ...timeFilter, ...catalog.timeFilter },
@@ -133,6 +226,11 @@ export class CatalogLayersListBindingDirective implements OnInit, OnDestroy {
         break;
       }
     }
+  }
+
+  private getResolutionFromScale(scale: number): number {
+    const dpi = 25.4 / 0.28;
+    return scale / (39.37 * dpi);
   }
 
   handleCatalogChanged(catalog: Catalog) {

--- a/projects/geo/src/lib/catalog/catalog-layers-list/catalog-layers-list-binding.directive.ts
+++ b/projects/geo/src/lib/catalog/catalog-layers-list/catalog-layers-list-binding.directive.ts
@@ -20,7 +20,7 @@ import { DataSourceService } from '../../datasource/shared/datasource.service';
 import { CatalogService } from '../shared/catalog.service';
 import { Catalog } from '../shared/catalog.interface';
 import { CatalogLayersListComponent } from './catalog-layers-list.component';
-import { QueryFormat } from '../../query';
+import { QueryFormat } from '../../query/shared/query.enums';
 
 @Directive({
   selector: '[igoCatalogLayersListBinding]'

--- a/projects/geo/src/lib/catalog/shared/catalog.interface.ts
+++ b/projects/geo/src/lib/catalog/shared/catalog.interface.ts
@@ -4,6 +4,9 @@ export interface Catalog {
   url?: string;
   type?: string;
   regFilters?: Array<string>;
+  queryFormat?: any;
+  queryHtmlTarget?: string;
+  count?: number;
 }
 
 export interface CatalogServiceOptions {

--- a/projects/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/projects/geo/src/lib/catalog/shared/catalog.service.ts
@@ -44,6 +44,10 @@ export class CatalogService {
     }
   }
 
+  getCatalogSources() {
+    return this.config.getConfig('catalog').sources;
+  }
+
   load() {
     const catalogConfig = this.config.getConfig('catalog') || {};
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Allow to configure catalog to control which:

-  info_format 
-  html destination (_blank or innerhtml)
-  feature_count 
should be used for getfeatureinfo queries.

```
{
        "title": "MTQ Québec",
        "url": "https://ws.mapserver.transports.gouv.qc.ca/swtq",
        "queryFormat": {
          "html": "*",
          "json": "stations_meteoroutieres"
        },
        "queryHtmlTarget": "innerhtml",
        "count": 365
      }
```

In this case, every layer called by getfeatureinfo will be in text/html. Except for stations_meteoroutieres which be called in json. 

Refer to https://github.com/infra-geo-ouverte/igo2-lib/blob/master/projects/geo/src/lib/query/shared/query.enum.ts for allowed types.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
