### PR TITLE
feat(wms) Provide title to grouped layers

### DIFF
--- a/projects/geo/src/lib/layer/layer-legend/layer-legend.component.html
+++ b/projects/geo/src/lib/layer/layer-legend/layer-legend.component.html
@@ -12,7 +12,7 @@
       [target]="legend"
       [collapsed]="false">
     </mat-icon>
-    <h4 matLine>{{item.title}}</h4>
+    <h4 matLine>{{validateItemTitle(item)}}</h4>
   </mat-list-item>
 
   <div #legend class="igo-layer-legend" [ngClass]="{'with-title': item.title}">

--- a/projects/geo/src/lib/layer/layer-legend/layer-legend.component.html
+++ b/projects/geo/src/lib/layer/layer-legend/layer-legend.component.html
@@ -12,7 +12,7 @@
       [target]="legend"
       [collapsed]="false">
     </mat-icon>
-    <h4 matLine>{{validateItemTitle(item)}}</h4>
+    <h4 matLine>{{computeItemTitle(item)}}</h4>
   </mat-list-item>
 
   <div #legend class="igo-layer-legend" [ngClass]="{'with-title': item.title}">

--- a/projects/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/projects/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -40,7 +40,7 @@ export class LayerLegendComponent {
           this.capabilitiesService.getWMSOptions(localLayerOptions).subscribe(r => localLayerOptions = r);
         }
       });
-      if (localLayerOptions._layerOptionsFromCapabilities && localLayerOptions._layerOptionsFromCapabilities) {
+      if (localLayerOptions && localLayerOptions._layerOptionsFromCapabilities) {
         return localLayerOptions._layerOptionsFromCapabilities.title;
       } else {
         return item.title;

--- a/projects/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/projects/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -30,7 +30,7 @@ export class LayerLegendComponent {
 
   constructor(private capabilitiesService: CapabilitiesService) {}
 
-  validateItemTitle(item): string {
+  computeItemTitle(item): string {
     const layerOptions = this.layer.dataSource.options as any;
     if (layerOptions.type === 'wms' && layerOptions.optionsFromCapabilities) {
       let localLayerOptions = JSON.parse(JSON.stringify(layerOptions)); // to avoid to alter the original options.

--- a/projects/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/projects/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 import { Layer } from '../shared/layers';
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
 
 @Component({
   selector: 'igo-layer-legend',
@@ -27,5 +28,25 @@ export class LayerLegendComponent {
   }
   private _legend;
 
-  constructor() {}
+  constructor(private capabilitiesService: CapabilitiesService) {}
+
+  validateItemTitle(item): string {
+    const layerOptions = this.layer.dataSource.options as any;
+    if (layerOptions.type === 'wms' && layerOptions.optionsFromCapabilities) {
+      let localLayerOptions = JSON.parse(JSON.stringify(layerOptions)); // to avoid to alter the original options.
+      layerOptions.params.layers.split(',').forEach(layer => {
+        if (layer === item.title) {
+          localLayerOptions.params.layers = layer;
+          this.capabilitiesService.getWMSOptions(localLayerOptions).subscribe(r => localLayerOptions = r);
+        }
+      });
+      if (localLayerOptions._layerOptionsFromCapabilities && localLayerOptions._layerOptionsFromCapabilities) {
+        return localLayerOptions._layerOptionsFromCapabilities.title;
+      } else {
+        return item.title;
+      }
+    } else {
+      return item.title;
+    }
+  }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The title of grouped wms layers are the name of the layer.

![image](https://user-images.githubusercontent.com/7397743/54779696-354c4000-4bee-11e9-9f32-8c3b7f552b5e.png)
 Into the mapDetails section, these name will be used as the title of the layer.

**What is the new behavior?**
For WMS grouped layers, with "optionsFromCapabilities" set true, the app will try to catch the title from the wms getcapabilities and provide it as the title.



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
