### PR TITLE
Apply same filter on WMS layer with grouped layers (comma separated)

### DIFF
--- a/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -84,6 +84,12 @@ export class WMSDataSource extends DataSource {
       options.sourceFields = [];
     }
 
+    if (sourceParams.layers.split(',').lenght > 1 && this.options
+      && (this.options as OgcFilterableDataSourceOptions).ogcFilters
+      && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled) {
+        console.log('BE CAREFULL, YOUR LAYERS MUST SHARE THE SAME FIELDS TO ALLOW TO FILTER TO WORK !! ');
+    }
+
     if (this.options
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled

--- a/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -88,7 +88,7 @@ export class WMSDataSource extends DataSource {
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled) {
         console.log('*******************************');
-        console.log('BE CAREFULL, YOUR LAYERS ('
+        console.log('BE CAREFULL, YOUR WMS LAYERS ('
         + sourceParams.layers
         + ') MUST SHARE THE SAME FIELDS TO ALLOW ogcFilters TO WORK !! ');
         console.log('*******************************');

--- a/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -89,7 +89,16 @@ export class WMSDataSource extends DataSource {
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.filters) {
         const filters = (this.options as OgcFilterableDataSourceOptions).ogcFilters.filters;
-        this.ol.updateParams({ filter: this.ogcFilterWriter.buildFilter(filters) });
+        const rebuildFilter = this.ogcFilterWriter.buildFilter(filters);
+        let appliedFilter = '';
+        if (rebuildFilter.length > 0 && sourceParams.layers.indexOf(',') !== -1) {
+          sourceParams.layers.split(',').forEach(element => {
+            appliedFilter = appliedFilter + '(' + rebuildFilter.replace('filter=', '') + ')';
+          });
+        } else {
+          appliedFilter = rebuildFilter;
+        }
+        this.ol.updateParams({ filter: appliedFilter });
       }
 
   }

--- a/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/projects/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -84,10 +84,14 @@ export class WMSDataSource extends DataSource {
       options.sourceFields = [];
     }
 
-    if (sourceParams.layers.split(',').lenght > 1 && this.options
+    if (sourceParams.layers.split(',').length > 1 && this.options
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled) {
-        console.log('BE CAREFULL, YOUR LAYERS MUST SHARE THE SAME FIELDS TO ALLOW TO FILTER TO WORK !! ');
+        console.log('*******************************');
+        console.log('BE CAREFULL, YOUR LAYERS ('
+        + sourceParams.layers
+        + ') MUST SHARE THE SAME FIELDS TO ALLOW ogcFilters TO WORK !! ');
+        console.log('*******************************');
     }
 
     if (this.options

--- a/projects/geo/src/lib/filter/shared/ogc-filter.service.ts
+++ b/projects/geo/src/lib/filter/shared/ogc-filter.service.ts
@@ -11,9 +11,20 @@ export class OGCFilterService {
   constructor() {}
 
   public filterByOgc(wmsDatasource: WMSDataSource, filterString: string) {
+
+    let appliedFilter = '';
+    const wmsDatasourceLayers = wmsDatasource.options.params.layers;
+    if (filterString.length > 0 && wmsDatasourceLayers.indexOf(',') !== -1) {
+      wmsDatasourceLayers.split(',').forEach(element => {
+        appliedFilter = appliedFilter + '(' + filterString.replace('filter=', '') + ')';
+      });
+      appliedFilter = 'filter=' + appliedFilter;
+    } else {
+      appliedFilter = filterString;
+    }
     const wmsFilterValue =
-      filterString.length > 0
-        ? filterString.substr(7, filterString.length + 1)
+        appliedFilter.length > 0
+        ? appliedFilter.substr(7, appliedFilter.length + 1)
         : undefined;
     wmsDatasource.ol.updateParams({ filter: wmsFilterValue });
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When you filter a wms layer built from 2 layers
![image](https://user-images.githubusercontent.com/7397743/54822483-6aeb3a80-4c7b-11e9-829d-bb5fcd37740e.png)
, filter do not work because you try to apply a single filter on 2 layers...

**What is the new behavior?**
Repeating the filter into the url for every filter.

Ex:
```
        "params": {
          "layers": "layerA,layerB"
        },
```
will build a url like : ...&filter=(...filterforlayerA...)(...filterforlayerB...)

Your layers MUST share the same fields. You can control the fields by this property
```
      "sourceFields": [
          {"alias":"Alias1","name": "name1", "values": ["value1","value2","value3"]},
          {"alias":"Alias2","name": "name2", "values": [1,2,3,4,5,6,7,8]},
        ]
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
