### PR TITLE
Visible layers show legend onInit

### DIFF
--- a/projects/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/projects/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -63,6 +63,16 @@ export class LayerItemComponent implements OnInit, OnDestroy {
   private _toggleLegendOnVisibilityChange = false;
 
   @Input()
+  get expandLegendVisibleLayers() {
+    return this._expandLegendVisibleLayers;
+  }
+  set expandLegendVisibleLayers(value: boolean) {
+    this._expandLegendVisibleLayers = value;
+  }
+  private _expandLegendVisibleLayers = false;
+
+
+  @Input()
   get disableReorderLayers() {
     return this._disableReorderLayers;
   }
@@ -95,7 +105,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    if (this.layer.visible && this.toggleLegendOnVisibilityChange) {
+    if (this.layer.visible && this.expandLegendVisibleLayers) {
       this.legendCollapsed = false;
     }
   }

--- a/projects/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/projects/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   Input,
+  OnInit,
   OnDestroy,
   ChangeDetectorRef,
   ChangeDetectionStrategy
@@ -19,7 +20,7 @@ import { Layer, VectorLayer } from '../shared/layers';
   styleUrls: ['./layer-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.Default
 })
-export class LayerItemComponent implements OnDestroy {
+export class LayerItemComponent implements OnInit, OnDestroy {
   @Input()
   get layer(): Layer {
     return this._layer;
@@ -92,6 +93,12 @@ export class LayerItemComponent implements OnDestroy {
     private cdRef: ChangeDetectorRef,
     private mapService: MapService
   ) {}
+
+  ngOnInit(): void {
+    if (this.layer.visible && this.toggleLegendOnVisibilityChange) {
+      this.legendCollapsed = false;
+    }
+  }
 
   ngOnDestroy() {
     this.resolution$$.unsubscribe();

--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.html
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.html
@@ -83,7 +83,8 @@
         [color]="color"
         [layer]="layer"
         [disableReorderLayers]="disableReorderLayers"
-        [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
+        [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange"
+        [expandLegendVisibleLayers]="expandLegendVisibleLayers">
 
         <ng-container igoLayerItemToolbar
           [ngTemplateOutlet]="templateLayerToolbar"

--- a/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/projects/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -117,6 +117,15 @@ export class LayerListComponent implements AfterViewInit {
   }
   private _toggleLegendOnVisibilityChange = false;
 
+  @Input()
+  get expandLegendVisibleLayers() {
+    return this._expandLegendVisibleLayers;
+  }
+  set expandLegendVisibleLayers(value: boolean) {
+    this._expandLegendVisibleLayers = value;
+  }
+  private _expandLegendVisibleLayers = false;
+
   constructor(
     private cdRef: ChangeDetectorRef,
     public layerListService: LayerListService) {}

--- a/projects/tools/src/lib/map-details-tool/map-details-tool.component.html
+++ b/projects/tools/src/lib/map-details-tool/map-details-tool.component.html
@@ -2,7 +2,8 @@
   igoLayerListBinding
   [excludeBaseLayers]="excludeBaseLayers"
   [layerFilterAndSortOptions]="layerFilterAndSortOptions"
-  [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
+  [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange"
+  [expandLegendVisibleLayers]="expandLegendVisibleLayers">
 
   <ng-template #igoLayerItemToolbar let-layer="layer">
     <igo-download-button [layer]="layer"></igo-download-button>

--- a/projects/tools/src/lib/map-details-tool/map-details-tool.component.ts
+++ b/projects/tools/src/lib/map-details-tool/map-details-tool.component.ts
@@ -23,6 +23,12 @@ export class MapDetailsToolComponent {
       : this.options.toggleLegendOnVisibilityChange;
   }
 
+  get expandLegendVisibleLayers(): boolean {
+    return this.options.expandLegendVisibleLayers === undefined
+      ? false
+      : this.options.expandLegendVisibleLayers;
+  }
+
   get excludeBaseLayers(): boolean {
 
     if (this.options && this.options.layerListControls) {

--- a/projects/tools/src/lib/map-details-tool/map-details-tool.interface.ts
+++ b/projects/tools/src/lib/map-details-tool/map-details-tool.interface.ts
@@ -1,6 +1,7 @@
 import { LayerListControlsEnum } from '@igo2/geo';
 
 export interface MapDetailsToolOptions {
+  expandLegendVisibleLayers?: boolean;
   toggleLegendOnVisibilityChange?: boolean;
   ogcFiltersInLayers?: boolean;
   layerListControls?: LayerListControlsOptions;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Visible layers with toggleLegendOnVisibilityChange= true do not show the legend onInit (legend is collapsed).


**What is the new behavior?**
Now If the layer is visible & expandLegendVisibleLayers= true, legend is now shown on init. 
Adding a new property to mapDetails's options :  expandLegendVisibleLayers 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
