### PR TITLE
feat(wms) Provide title to grouped layers (comma)

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
@@ -2,6 +2,7 @@ import olSourceImageWMS from 'ol/source/ImageWMS';
 
 import { DataSourceOptions } from './datasource.interface';
 import { WFSDataSourceOptionsParams } from './wfs-datasource.interface';
+import { MetadataOptions } from '../../../metadata/shared/metadata.interface';
 
 export interface WMSDataSourceOptions extends DataSourceOptions {
   // type?: 'wms';
@@ -16,10 +17,18 @@ export interface WMSDataSourceOptions extends DataSourceOptions {
   ratio?: number;
   ol?: olSourceImageWMS;
   refreshIntervalSec?: number;
+  _layerOptionsFromCapabilities?: WMSLayerOptionsFromCapabilities;
 }
 
 export interface WMSDataSourceOptionsParams {
   layers: string;
   version?: string;
   time?: string;
+}
+
+export interface WMSLayerOptionsFromCapabilities {
+  title?: string;
+  minResolution?: number;
+  maxResolution?: string;
+  metadata?: MetadataOptions;
 }

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.html
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.html
@@ -10,7 +10,7 @@
           [target]="legend"
           [collapsed]="false">
         </mat-icon>
-        <h4 matLine>{{computeItemTitle(item)}}</h4>
+        <h4 matLine>{{computeItemTitle(item) | async}}</h4>
       </mat-list-item>
     
       <div #legend class="igo-layer-legend" [ngClass]="{'with-title': item.title}">

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.html
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.html
@@ -12,7 +12,7 @@
       [target]="legend"
       [collapsed]="false">
     </mat-icon>
-    <h4 matLine>{{item.title}}</h4>
+    <h4 matLine>{{computeItemTitle(item)}}</h4>
   </mat-list-item>
 
   <div #legend class="igo-layer-legend" [ngClass]="{'with-title': item.title}">

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -1,11 +1,10 @@
 import { Component, Input, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
 
-import { Subscription, BehaviorSubject, of } from 'rxjs';
+import { Subscription, BehaviorSubject, of, Observable } from 'rxjs';
 
 import { DataSourceLegendOptions } from '../../datasource/shared/datasources/datasource.interface';
 import { Layer } from '../shared/layers';
 import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
-import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -20,13 +19,11 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
    * Observable of the legend items
    */
   legendItems$: BehaviorSubject<DataSourceLegendOptions[]> = new BehaviorSubject([]);
-  legendItemTitle$ = new BehaviorSubject<string>(undefined);
 
   /**
    * Subscription to the map's resolution
    */
   private resolution$$: Subscription;
-  private legendItemTitle$$: Subscription;
   /**
    * Layer
    */

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 import { Layer } from '../shared/layers';
 import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'igo-layer-legend',
@@ -30,9 +31,11 @@ export class LayerLegendComponent {
 
   constructor(private capabilitiesService: CapabilitiesService) {}
 
-   computeItemTitle(item): string {
+   computeItemTitle(item): Observable<string> {
     const layerOptions = this.layer.dataSource.options as any;
-    if (layerOptions.type === 'wms' && layerOptions.optionsFromCapabilities) {
+    if (layerOptions.type !== 'wms' && !layerOptions.optionsFromCapabilities) {
+      return item.title;
+    } else {
       let localLayerOptions = JSON.parse(JSON.stringify(layerOptions)); // to avoid to alter the original options.
       layerOptions.params.layers.split(',').forEach(layer => {
         if (layer === item.title) {
@@ -45,8 +48,6 @@ export class LayerLegendComponent {
       } else {
         return item.title;
       }
-    } else {
-      return item.title;
     }
   }
 }

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 import { Layer } from '../shared/layers';
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
 
 @Component({
   selector: 'igo-layer-legend',
@@ -27,5 +28,25 @@ export class LayerLegendComponent {
   }
   private _legend;
 
-  constructor() {}
+  constructor(private capabilitiesService: CapabilitiesService) {}
+
+   computeItemTitle(item): string {
+    const layerOptions = this.layer.dataSource.options as any;
+    if (layerOptions.type === 'wms' && layerOptions.optionsFromCapabilities) {
+      let localLayerOptions = JSON.parse(JSON.stringify(layerOptions)); // to avoid to alter the original options.
+      layerOptions.params.layers.split(',').forEach(layer => {
+        if (layer === item.title) {
+          localLayerOptions.params.layers = layer;
+          this.capabilitiesService.getWMSOptions(localLayerOptions).subscribe(r => localLayerOptions = r);
+        }
+      });
+      if (localLayerOptions && localLayerOptions._layerOptionsFromCapabilities) {
+        return localLayerOptions._layerOptionsFromCapabilities.title;
+      } else {
+        return item.title;
+      }
+    } else {
+      return item.title;
+    }
+  }
 }

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -72,7 +72,7 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
     return this.capabilitiesService
       .getWMSOptions(localLayerOptions)
       .pipe(map(wmsDataSourceOptions => {
-        return (wmsDataSourceOptions as any)._layerOptionsFromCapabilities.title;
+        return wmsDataSourceOptions._layerOptionsFromCapabilities.title;
       }));
   }
 }

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -65,17 +65,14 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
     const layerOptions = this.layer.dataSource.options as any;
     if (layerOptions.type !== 'wms') {
       return of(layerLegend.title);
-    /*} else if (!layerOptions.optionsFromCapabilities) {
-      return of(layerLegend.title);*/
-    } else {
-      const layers = layerOptions.params.layers.split(',');
-      const localLayerOptions = JSON.parse(JSON.stringify(layerOptions)); // to avoid to alter the original options.
-      localLayerOptions.params.layers = layers.find(layer => layer === layerLegend.title);
-      return this.capabilitiesService
-        .getWMSOptions(localLayerOptions)
-        .pipe(map(wmsDataSourceOptions => {
-          return (wmsDataSourceOptions as any)._layerOptionsFromCapabilities.title;
-        }));
     }
+    const layers = layerOptions.params.layers.split(',');
+    const localLayerOptions = JSON.parse(JSON.stringify(layerOptions)); // to avoid to alter the original options.
+    localLayerOptions.params.layers = layers.find(layer => layer === layerLegend.title);
+    return this.capabilitiesService
+      .getWMSOptions(localLayerOptions)
+      .pipe(map(wmsDataSourceOptions => {
+        return (wmsDataSourceOptions as any)._layerOptionsFromCapabilities.title;
+      }));
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

![image](https://user-images.githubusercontent.com/7397743/56290240-b664fd00-60f0-11e9-8b20-b7e0548b13fb.png)
The title of grouped wms layers are the name of the layer.
**What is the new behavior?**
For WMS grouped layers, with "optionsFromCapabilities" set true, the app will try to catch the title from the wms getcapabilities and provide it as the title.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
