### PR TITLE
Apply same filter on WMS layer with grouped layers (comma separated) 

### DIFF
--- a/demo/src/app/geo/ogc-filter/ogc-filter.component.ts
+++ b/demo/src/app/geo/ogc-filter/ogc-filter.component.ts
@@ -117,6 +117,39 @@ export class AppOgcFilterComponent {
       extends WMSDataSourceOptions,
         OgcFilterableDataSourceOptions {}
 
+    const datasourceWmsWith2Layers: WMSoptions = {
+      type: 'wms',
+      url: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+      urlWfs: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
+      params: {
+        layers: 'stations_meteoroutieres,histo_stations_meteoroutieres',
+        version: '1.3.0'
+      },
+      ogcFilters: {
+        enabled: true,
+        editable: true
+      },
+      paramsWFS: {
+        featureTypes: 'histo_stations_meteoroutieres',
+        fieldNameGeometry: 'geometry',
+        maxFeatures: 10000,
+        version: '1.1.0',
+        outputFormat: 'geojson',
+        outputFormatDownload: 'shp'
+      } as WFSDataSourceOptionsParams
+    };
+
+    this.dataSourceService
+      .createAsyncDataSource(datasourceWmsWith2Layers)
+      .subscribe(dataSource => {
+        this.map.addLayer(
+          this.layerService.createLayer({
+            title: 'Layer build from 2 WMS layers',
+            source: dataSource
+          })
+        );
+      });
+
     const datasourceWms: WMSoptions = {
       type: 'wms',
       url: '/geoserver/wms',

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -81,21 +81,16 @@ export class WMSDataSource extends DataSource {
     if (!options.sourceFields || options.sourceFields.length === 0) {
       options.sourceFields = [];
     }
-    const ogcFilterableDataSourceOptions: OgcFilterableDataSourceOptions = this.options;
-    if (sourceParams.layers.split(',').length > 1 && this.options
-    && ogcFilterableDataSourceOptions.ogcFilters
-    && ogcFilterableDataSourceOptions.ogcFilters.enabled) {
+    const initOgcFilters = (this.options as OgcFilterableDataSourceOptions).ogcFilters;
+    if (sourceParams.layers.split(',').length > 1 && this.options && initOgcFilters && initOgcFilters.enabled) {
       console.log('*******************************');
       console.log('BE CAREFULL, YOUR WMS LAYERS (' + sourceParams.layers
       + ') MUST SHARE THE SAME FIELDS TO ALLOW ogcFilters TO WORK !! ');
       console.log('*******************************');
   }
 
-    if (this.options
-      && ogcFilterableDataSourceOptions.ogcFilters
-      && ogcFilterableDataSourceOptions.ogcFilters.enabled
-      && ogcFilterableDataSourceOptions.ogcFilters.filters) {
-        const filters = ogcFilterableDataSourceOptions.ogcFilters.filters;
+    if (this.options && initOgcFilters && initOgcFilters.enabled && initOgcFilters.filters) {
+        const filters = initOgcFilters.filters;
         const rebuildFilter = this.ogcFilterWriter.buildFilter(filters);
         const appliedFilter = this.formatProcessedOgcFilter(rebuildFilter, sourceParams.layers);
         const wmsFilterValue = appliedFilter.length > 0
@@ -153,22 +148,11 @@ export class WMSDataSource extends DataSource {
         ? this.options.paramsWFS.version
         : '2.0.0';
     }
-    const ogcFilterableDataSourceOptions: OgcFilterableDataSourceOptions = this.options;
+    let initOgcFilters = (this.options as OgcFilterableDataSourceOptions).ogcFilters;
     const ogcFiltersDefaultValue = false; // default values for wms.
-    ogcFilterableDataSourceOptions.ogcFilters =
-    ogcFilterableDataSourceOptions.ogcFilters === undefined
-        ? {}
-        : ogcFilterableDataSourceOptions.ogcFilters;
-    ogcFilterableDataSourceOptions.ogcFilters.enabled =
-    ogcFilterableDataSourceOptions.ogcFilters.enabled ===
-      undefined
-        ? ogcFiltersDefaultValue
-        : ogcFilterableDataSourceOptions.ogcFilters.enabled;
-    ogcFilterableDataSourceOptions.ogcFilters.editable =
-    ogcFilterableDataSourceOptions.ogcFilters.editable ===
-      undefined
-        ? ogcFiltersDefaultValue
-        : ogcFilterableDataSourceOptions.ogcFilters.editable;
+    initOgcFilters = initOgcFilters === undefined ? {} : initOgcFilters;
+    initOgcFilters.enabled = initOgcFilters.enabled === undefined ? ogcFiltersDefaultValue : initOgcFilters.enabled;
+    initOgcFilters.editable = initOgcFilters.editable === undefined ? ogcFiltersDefaultValue : initOgcFilters.editable;
     return new olSourceImageWMS(this.options);
   }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -82,12 +82,30 @@ export class WMSDataSource extends DataSource {
       options.sourceFields = [];
     }
 
+    if (sourceParams.layers.split(',').length > 1 && this.options
+    && (this.options as OgcFilterableDataSourceOptions).ogcFilters
+    && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled) {
+      console.log('*******************************');
+      console.log('BE CAREFULL, YOUR WMS LAYERS (' + sourceParams.layers
+      + ') MUST SHARE THE SAME FIELDS TO ALLOW ogcFilters TO WORK !! ');
+      console.log('*******************************');
+  }
+
     if (this.options
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.enabled
       && (this.options as OgcFilterableDataSourceOptions).ogcFilters.filters) {
         const filters = (this.options as OgcFilterableDataSourceOptions).ogcFilters.filters;
-        this.ol.updateParams({ filter: this.ogcFilterWriter.buildFilter(filters) });
+        const rebuildFilter = this.ogcFilterWriter.buildFilter(filters);
+        let appliedFilter = '';
+        if (rebuildFilter.length > 0 && sourceParams.layers.indexOf(',') !== -1) {
+          sourceParams.layers.split(',').forEach(element => {
+            appliedFilter = appliedFilter + '(' + rebuildFilter.replace('filter=', '') + ')';
+          });
+        } else {
+          appliedFilter = rebuildFilter;
+        }
+        this.ol.updateParams({ filter: appliedFilter });
       }
 
   }

--- a/packages/geo/src/lib/filter/shared/ogc-filter.service.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.service.ts
@@ -11,18 +11,9 @@ export class OGCFilterService {
   constructor() {}
 
   public filterByOgc(wmsDatasource: WMSDataSource, filterString: string) {
-    let appliedFilter = '';
-    const wmsDatasourceLayers = wmsDatasource.options.params.layers;
-    if (filterString.length > 0 && wmsDatasourceLayers.indexOf(',') !== -1) {
-      wmsDatasourceLayers.split(',').forEach(element => {
-        appliedFilter = appliedFilter + '(' + filterString.replace('filter=', '') + ')';
-      });
-      appliedFilter = 'filter=' + appliedFilter;
-    } else {
-      appliedFilter = filterString;
-    }
+    const appliedFilter = wmsDatasource.formatProcessedOgcFilter(filterString, wmsDatasource.options.params.layers);
     const wmsFilterValue = appliedFilter.length > 0
-        ? appliedFilter.substr(7, appliedFilter.length + 1)
+        ? appliedFilter.replace('filter=', '')
         : undefined;
     wmsDatasource.ol.updateParams({ filter: wmsFilterValue });
   }

--- a/packages/geo/src/lib/filter/shared/ogc-filter.service.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.service.ts
@@ -11,9 +11,18 @@ export class OGCFilterService {
   constructor() {}
 
   public filterByOgc(wmsDatasource: WMSDataSource, filterString: string) {
-    const wmsFilterValue =
-      filterString.length > 0
-        ? filterString.substr(7, filterString.length + 1)
+    let appliedFilter = '';
+    const wmsDatasourceLayers = wmsDatasource.options.params.layers;
+    if (filterString.length > 0 && wmsDatasourceLayers.indexOf(',') !== -1) {
+      wmsDatasourceLayers.split(',').forEach(element => {
+        appliedFilter = appliedFilter + '(' + filterString.replace('filter=', '') + ')';
+      });
+      appliedFilter = 'filter=' + appliedFilter;
+    } else {
+      appliedFilter = filterString;
+    }
+    const wmsFilterValue = appliedFilter.length > 0
+        ? appliedFilter.substr(7, appliedFilter.length + 1)
         : undefined;
     wmsDatasource.ol.updateParams({ filter: wmsFilterValue });
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When you filter a wms layer built from 2 layers
![image](https://user-images.githubusercontent.com/7397743/56291255-f1683000-60f2-11e9-8022-b5ee51ab5a36.png)
, filter do not work because you try to apply a single filter on 2 layers...

**What is the new behavior?**
Repeating the filter into the url for every filter.
Ex:

```
        "params": {
          "layers": "layerA,layerB"
        },
```

will build a url like : ...&filter=(...filterforlayerA...)(...filterforlayerB...)

Your layers MUST share the same fields. You can control the fields by this property

```
      "sourceFields": [
          {"alias":"Alias1","name": "name1", "values": ["value1","value2","value3"]},
          {"alias":"Alias2","name": "name2", "values": [1,2,3,4,5,6,7,8]},
        ]
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
