### PR TITLE
feat(layer) Visible layers show legend onInit

### DIFF
--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -16,6 +16,7 @@
   <igo-panel title="Layers">
     <igo-layer-list 
     [layers]="map.layers"
+    [expandLegendOfVisibleLayers]=true
     placeholder="Filter"
     floatLabel="never">
 

--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -16,7 +16,7 @@
   <igo-panel title="Layers">
     <igo-layer-list 
     [layers]="map.layers"
-    [expandLegendOfVisibleLayers]=false
+    [expandLegendOfVisibleLayers]="false"
     placeholder="Filter"
     floatLabel="never">
 

--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -16,7 +16,7 @@
   <igo-panel title="Layers">
     <igo-layer-list 
     [layers]="map.layers"
-    [expandLegendOfVisibleLayers]=true
+    [expandLegendOfVisibleLayers]=false
     placeholder="Filter"
     floatLabel="never">
 

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -28,6 +28,8 @@ export class LayerItemComponent implements OnInit, OnDestroy {
 
   @Input() toggleLegendOnVisibilityChange: boolean = false;
 
+  @Input() expandLegendVisibleLayers: boolean = false;
+
   @Input() orderable: boolean = true;
 
   get removable(): boolean { return this.layer.options.removable !== false; }
@@ -39,7 +41,10 @@ export class LayerItemComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     const legend = this.layer.dataSource.options.legend || {};
-    const legendCollapsed = legend.collapsed === false ? false : true;
+    let legendCollapsed = legend.collapsed === false ? false : true;
+    if (this.layer.visible && this.expandLegendVisibleLayers) {
+      legendCollapsed = false;
+    }
     this.showLegend$.next(!legendCollapsed);
 
     const resolution$ = this.layer.map.viewController.resolution$;

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -28,7 +28,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
 
   @Input() toggleLegendOnVisibilityChange: boolean = false;
 
-  @Input() expandLegendVisibleLayers: boolean = false;
+  @Input() expandLegendIfVisible: boolean = false;
 
   @Input() orderable: boolean = true;
 
@@ -42,7 +42,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
   ngOnInit() {
     const legend = this.layer.dataSource.options.legend || {};
     let legendCollapsed = legend.collapsed === false ? false : true;
-    if (this.layer.visible && this.expandLegendVisibleLayers) {
+    if (this.layer.visible && this.expandLegendIfVisible) {
       legendCollapsed = false;
     }
     this.showLegend$.next(!legendCollapsed);

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.html
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.html
@@ -79,6 +79,7 @@
         igoListItem
         [layer]="layer"
         [orderable]="orderable"
+        [expandLegendVisibleLayers]="expandLegendVisibleLayers"
         [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
         <ng-container igoLayerItemToolbar

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.html
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.html
@@ -79,7 +79,7 @@
         igoListItem
         [layer]="layer"
         [orderable]="orderable"
-        [expandLegendVisibleLayers]="expandLegendVisibleLayers"
+        [expandLegendIfVisible]="expandLegendOfVisibleLayers"
         [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
         <ng-container igoLayerItemToolbar

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -58,6 +58,8 @@ export class LayerListComponent implements OnInit, OnDestroy {
 
   @Input() toggleLegendOnVisibilityChange: boolean = false;
 
+  @Input() expandLegendVisibleLayers: boolean = false;
+
   get keyword(): string { return this.layerListService.keyword; }
   set keyword(value: string) {
     this.layerListService.keyword = value;

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -58,7 +58,7 @@ export class LayerListComponent implements OnInit, OnDestroy {
 
   @Input() toggleLegendOnVisibilityChange: boolean = false;
 
-  @Input() expandLegendVisibleLayers: boolean = false;
+  @Input() expandLegendOfVisibleLayers: boolean = false;
 
   get keyword(): string { return this.layerListService.keyword; }
   set keyword(value: string) {

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -2,7 +2,7 @@
   igoLayerListBinding
   [excludeBaseLayers]="excludeBaseLayers"
   [layerFilterAndSortOptions]="layerFilterAndSortOptions"
-  [expandLegendVisibleLayers]="expandLegendVisibleLayers"
+  [expandLegendOfVisibleLayers]="expandLegendOfVisibleLayers"
   [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
   <ng-template #igoLayerItemToolbar let-layer="layer">

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -2,6 +2,7 @@
   igoLayerListBinding
   [excludeBaseLayers]="excludeBaseLayers"
   [layerFilterAndSortOptions]="layerFilterAndSortOptions"
+  [expandLegendVisibleLayers]="expandLegendVisibleLayers"
   [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
   <ng-template #igoLayerItemToolbar let-layer="layer">

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
@@ -17,7 +17,7 @@ import { LayerListControlsOptions } from '../shared/map-details-tool.interface';
 export class MapDetailsToolComponent {
   @Input() toggleLegendOnVisibilityChange: boolean = false;
   @Input() ogcFiltersInLayers: boolean = true;
-  @Input() expandLegendVisibleLayers: boolean = false;
+  @Input() expandLegendOfVisibleLayers: boolean = false;
   @Input() layerListControls: LayerListControlsOptions = {};
 
   get excludeBaseLayers(): boolean {

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
@@ -17,7 +17,7 @@ import { LayerListControlsOptions } from '../shared/map-details-tool.interface';
 export class MapDetailsToolComponent {
   @Input() toggleLegendOnVisibilityChange: boolean = false;
   @Input() ogcFiltersInLayers: boolean = true;
-
+  @Input() expandLegendVisibleLayers: boolean = false;
   @Input() layerListControls: LayerListControlsOptions = {};
 
   get excludeBaseLayers(): boolean {

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -5,6 +5,7 @@
       igoLayerListBinding
       [excludeBaseLayers]="excludeBaseLayers"
       [layerFilterAndSortOptions]="layerFilterAndSortOptions"
+      [expandLegendVisibleLayers]="expandLegendVisibleLayers"
       [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
       <ng-template #igoLayerItemToolbar let-layer="layer">

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -5,7 +5,7 @@
       igoLayerListBinding
       [excludeBaseLayers]="excludeBaseLayers"
       [layerFilterAndSortOptions]="layerFilterAndSortOptions"
-      [expandLegendVisibleLayers]="expandLegendVisibleLayers"
+      [expandLegendOfVisibleLayers]="expandLegendOfVisibleLayers"
       [toggleLegendOnVisibilityChange]="toggleLegendOnVisibilityChange">
 
       <ng-template #igoLayerItemToolbar let-layer="layer">

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.ts
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.ts
@@ -20,7 +20,7 @@ import { LayerListControlsOptions } from '../shared/map-details-tool.interface';
 })
 export class MapToolComponent {
   @Input() toggleLegendOnVisibilityChange: boolean = false;
-  @Input() expandLegendVisibleLayers: boolean = false;
+  @Input() expandLegendOfVisibleLayers: boolean = false;
   @Input() ogcFiltersInLayers: boolean = true;
 
   @Input() layerListControls: LayerListControlsOptions = {};

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.ts
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.ts
@@ -20,6 +20,7 @@ import { LayerListControlsOptions } from '../shared/map-details-tool.interface';
 })
 export class MapToolComponent {
   @Input() toggleLegendOnVisibilityChange: boolean = false;
+  @Input() expandLegendVisibleLayers: boolean = false;
   @Input() ogcFiltersInLayers: boolean = true;
 
   @Input() layerListControls: LayerListControlsOptions = {};


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Visible layers with toggleLegendOnVisibilityChange= true do not show the legend onInit (legend is collapsed).


**What is the new behavior?**
Now If the layer is visible & expandLegendVisibleLayers= true, legend is now shown on init.
Adding a new property to mapDetails's options : expandLegendVisibleLayers


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
