### PR TITLE
Abstract as tooltip 1.0.0-alpha.1

### DIFF
--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -37,6 +37,12 @@ export const environment: Environment = {
           title: 'Filtered catalog by regex',
           url: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
           regFilters: ['zpegt']
+        },
+        {
+          id: 'catalogwithtooltipcontrol',
+          title: 'Controling tooltip format',
+          url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/igo_gouvouvert.fcgi',
+          tooltipType: 'abstract' // or title
         }
       ]
     },

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -44,6 +44,12 @@ export const environment: Environment = {
           url: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
           regFilters: ['zpegt']
 
+        },
+        {
+          id: 'catalogwithtooltipcontrol',
+          title: 'Controling tooltip format',
+          url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/igo_gouvouvert.fcgi',
+          tooltipType: 'abstract' // or title
         }
       ]
     },

--- a/packages/geo/src/lib/catalog/shared/catalog.interface.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.interface.ts
@@ -1,6 +1,6 @@
 import { EntityState } from '@igo2/common';
 
-import { LayerOptions } from '../../layer';
+import { LayerOptions, TooltipType } from '../../layer';
 import { TimeFilterOptions } from '../../filter';
 import { QueryFormat, QueryHtmlTarget  } from '../../query';
 
@@ -17,6 +17,7 @@ export interface Catalog {
   queryFormat?: QueryFormat;
   queryHtmlTarget?: QueryHtmlTarget;
   count?: number;
+  tooltipType?: TooltipType.ABSTRACT | TooltipType.TITLE ;
 }
 
 export interface CatalogItem {

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -155,11 +155,6 @@ export class CatalogService {
           const timeFilter = this.capabilitiesService.getTimeFilter(layer);
           const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0 ? true : false;
 
-          let tooltipContent;
-          if (abstract) {
-            tooltipContent = { type: catalogToolTipType } as TooltipContent ;
-          }
-
           const sourceOptions = {
             type: 'wms',
             url: catalog.url,
@@ -190,7 +185,7 @@ export class CatalogService {
                 abstract,
                 keywordList
               },
-              tooltip: tooltipContent,
+              tooltip: { type: catalogToolTipType } as TooltipContent,
               sourceOptions
             }
           });

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -127,7 +127,7 @@ export class CatalogService {
         this.includeRecursiveItems(catalog, group, items);
         continue;
       }
-      const catalogToolTipType = this.retrieveTooltipType(catalog);
+      const catalogTooltipType = this.retrieveTooltipType(catalog);
       const layersQueryFormat = this.findCatalogInfoFormat(catalog);
       // TODO: Slice that into multiple methods
       // Define object of group layer
@@ -185,7 +185,7 @@ export class CatalogService {
                 abstract,
                 keywordList
               },
-              tooltip: { type: catalogToolTipType } as TooltipContent,
+              tooltip: { type: catalogTooltipType } as TooltipContent,
               sourceOptions
             }
           });

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -5,7 +5,7 @@ import { map, catchError } from 'rxjs/operators';
 
 import { LanguageService, ConfigService } from '@igo2/core';
 import { CapabilitiesService, WMSDataSourceOptions, generateIdFromSourceOptions } from '../../datasource';
-import { LayerOptions, ImageLayerOptions } from '../../layer';
+import { LayerOptions, ImageLayerOptions, TooltipContent, TooltipType } from '../../layer';
 import { getResolutionFromScale } from '../../map';
 
 import {
@@ -127,6 +127,7 @@ export class CatalogService {
         this.includeRecursiveItems(catalog, group, items);
         continue;
       }
+      const catalogToolTipType = this.retrieveTooltipType(catalog);
       const layersQueryFormat = this.findCatalogInfoFormat(catalog);
       // TODO: Slice that into multiple methods
       // Define object of group layer
@@ -153,6 +154,11 @@ export class CatalogService {
           const keywordList = layer.KeywordList ? layer.KeywordList : undefined;
           const timeFilter = this.capabilitiesService.getTimeFilter(layer);
           const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0 ? true : false;
+
+          let tooltipContent;
+          if (abstract) {
+            tooltipContent = { type: catalogToolTipType } as TooltipContent ;
+          }
 
           const sourceOptions = {
             type: 'wms',
@@ -184,6 +190,7 @@ export class CatalogService {
                 abstract,
                 keywordList
               },
+              tooltip: tooltipContent,
               sourceOptions
             }
           });
@@ -215,6 +222,13 @@ export class CatalogService {
       queryFormat = baseInfoFormat.queryFormat;
     }
     return queryFormat;
+  }
+
+  private retrieveTooltipType(catalog: Catalog): TooltipType {
+    if (!catalog.tooltipType) {
+      return TooltipType.TITLE;
+    }
+    return catalog.tooltipType;
   }
 
   private findCatalogInfoFormat(catalog: Catalog): {layer: string, queryFormat: QueryFormat}[] {

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.html
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.html
@@ -7,7 +7,7 @@
     [collapsed]="!(showLegend$ | async)"
     (toggle)="toggleLegend($event)">
   </mat-icon>
-  <h4 matLine [matTooltip]="toolTipText" matTooltipShowDelay="500">{{layer.title}}</h4>
+  <h4 matLine [matTooltip]="tooltipText" matTooltipShowDelay="500">{{layer.title}}</h4>
 
   <button
     mat-icon-button

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.html
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.html
@@ -7,7 +7,7 @@
     [collapsed]="!(showLegend$ | async)"
     (toggle)="toggleLegend($event)">
   </mat-icon>
-  <h4 matLine [matTooltip]="layer.title" matTooltipShowDelay="500">{{layer.title}}</h4>
+  <h4 matLine [matTooltip]="toolTipText" matTooltipShowDelay="500">{{layer.title}}</h4>
 
   <button
     mat-icon-button

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -8,7 +8,8 @@ import {
 } from '@angular/core';
 import { Subscription, BehaviorSubject } from 'rxjs';
 
-import { Layer } from '../shared/layers';
+import { Layer, TooltipType } from '../shared/layers';
+import { MetadataLayerOptions } from '../../metadata/shared/metadata.interface';
 
 @Component({
   selector: 'igo-layer-item',
@@ -36,6 +37,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
 
   get opacity() { return this.layer.opacity * 100; }
   set opacity(opacity: number) { this.layer.opacity = opacity / 100; }
+  public toolTipText;
 
   constructor(private cdRef: ChangeDetectorRef) {}
 
@@ -51,6 +53,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
     this.resolution$$ = resolution$.subscribe((resolution: number) => {
       this.onResolutionChange(resolution);
     });
+    this.toolTipText = this.computeToolTip();
   }
 
   ngOnDestroy() {
@@ -65,6 +68,33 @@ export class LayerItemComponent implements OnInit, OnDestroy {
     this.layer.visible = !this.layer.visible;
     if (this.toggleLegendOnVisibilityChange) {
       this.toggleLegend(!this.layer.visible);
+    }
+  }
+
+  computeToolTip(): string {
+    const layerOptions = this.layer.options;
+    if (!layerOptions.tooltip) {
+      return this.layer.title;
+    }
+    const layerToolTip = layerOptions.tooltip;
+    const layerMetadata = (layerOptions as MetadataLayerOptions).metadata;
+    switch (layerOptions.tooltip.type) {
+      case TooltipType.TITLE:
+        return this.layer.title;
+      case TooltipType.ABSTRACT:
+        if (layerMetadata && layerMetadata.abstract) {
+          return layerMetadata.abstract;
+        } else {
+          return this.layer.title;
+        }
+      case TooltipType.CUSTOM:
+        if (layerToolTip && layerToolTip.text) {
+          return layerToolTip.text;
+        } else {
+          return this.layer.title;
+        }
+      default:
+        return this.layer.title;
     }
   }
 

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -37,7 +37,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
 
   get opacity() { return this.layer.opacity * 100; }
   set opacity(opacity: number) { this.layer.opacity = opacity / 100; }
-  public toolTipText;
+  public tooltipText;
 
   constructor(private cdRef: ChangeDetectorRef) {}
 
@@ -53,7 +53,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
     this.resolution$$ = resolution$.subscribe((resolution: number) => {
       this.onResolutionChange(resolution);
     });
-    this.toolTipText = this.computeToolTip();
+    this.tooltipText = this.computeToolTip();
   }
 
   ngOnDestroy() {

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -53,7 +53,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
     this.resolution$$ = resolution$.subscribe((resolution: number) => {
       this.onResolutionChange(resolution);
     });
-    this.tooltipText = this.computeToolTip();
+    this.tooltipText = this.computeTooltip();
   }
 
   ngOnDestroy() {
@@ -71,12 +71,12 @@ export class LayerItemComponent implements OnInit, OnDestroy {
     }
   }
 
-  computeToolTip(): string {
+  computeTooltip(): string {
     const layerOptions = this.layer.options;
     if (!layerOptions.tooltip) {
       return this.layer.title;
     }
-    const layerToolTip = layerOptions.tooltip;
+    const layerTooltip = layerOptions.tooltip;
     const layerMetadata = (layerOptions as MetadataLayerOptions).metadata;
     switch (layerOptions.tooltip.type) {
       case TooltipType.TITLE:
@@ -88,8 +88,8 @@ export class LayerItemComponent implements OnInit, OnDestroy {
           return this.layer.title;
         }
       case TooltipType.CUSTOM:
-        if (layerToolTip && layerToolTip.text) {
-          return layerToolTip.text;
+        if (layerTooltip && layerTooltip.text) {
+          return layerTooltip.text;
         } else {
           return this.layer.title;
         }

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -15,6 +15,7 @@ import { LayerListControlsEnum } from './layer-list.enum';
 import { LayerListService } from './layer-list.service';
 import { BehaviorSubject, ReplaySubject, Subscription, EMPTY, timer } from 'rxjs';
 import { debounce } from 'rxjs/operators';
+import { MetadataOptions, MetadataLayerOptions } from '../../metadata/shared/metadata.interface';
 
 // TODO: This class could use a clean up. Also, some methods could be moved ealsewhere
 @Component({
@@ -165,9 +166,9 @@ export class LayerListComponent implements OnInit, OnDestroy {
     const keepLayerIds = layers.map((layer: Layer) => layer.id);
 
     layers.forEach((layer: Layer) => {
-      const layerOptions = layer.options || {};
+      const layerOptions = layer.options as MetadataLayerOptions || {};
       const dataSourceOptions = layer.dataSource.options || {};
-      const metadata = (layerOptions as any).metadata || {};
+      const metadata = layerOptions.metadata || {} as MetadataOptions;
       const keywords = metadata.keywordList || [] ;
       const layerKeywords = keywords.map((kw: string) => {
         return kw.normalize('NFD').replace(/[\u0300-\u036f]/g, '');

--- a/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
@@ -18,6 +18,7 @@ export interface LayerOptions {
   showInLayerList?: boolean;
   removable?: boolean;
   ol?: olLayer;
+  tooltip?: TooltipContent;
 }
 
 export interface GroupLayers {
@@ -30,4 +31,14 @@ export interface LayerLegend {
   title: string;
   url: string;
   image: string;
+}
+
+export interface TooltipContent {
+  type?: TooltipType;
+  text?: string;
+}
+export enum TooltipType {
+  TITLE = 'title',
+  ABSTRACT = 'abstract',
+  CUSTOM = 'custom'
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The tool tip only repeat the layer title


**What is the new behavior?**
At the layer level, the tooltip could be configured by 3 way
```
      "tooltip": {
        "type":"title" // layer title, by GetCapabilities or title property in layer config.
      },
or
      "tooltip": {
        "type":"abstract"  // by GetCapabilities Or metadata.abstract property
      },
or
      "tooltip": {
        "type":"custom",
        "text": "you custom tooltip"
      }
```
At the catalog level, you can configure the tooltip type into config.json
```
        {
          id: 'catalogwithtooltipcontrol',
          title: 'Controling tooltip type',
          url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/igo_gouvouvert.fcgi',
          tooltipType: 'abstract' // or title
        }
```

If you set "abstract" and the layer do not own any abstract, the title will be used as the tooltip. 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
