### PR TITLE
feat(query): the query directive now allows querying vector features,…

### DIFF
--- a/packages/geo/src/lib/feature/shared/feature.interfaces.ts
+++ b/packages/geo/src/lib/feature/shared/feature.interfaces.ts
@@ -23,6 +23,7 @@ export interface FeatureMeta {
   mapTitle?: string;
   order?: number;
   alias?: {[key: string]: string};
+  revision?: number;
 }
 
 export interface FeatureGeometry {

--- a/packages/geo/src/lib/import-export/shared/import.utils.ts
+++ b/packages/geo/src/lib/import-export/shared/import.utils.ts
@@ -3,10 +3,12 @@ import * as olStyle from 'ol/style';
 import { MessageService, LanguageService } from '@igo2/core';
 
 import { FeatureDataSource } from '../../datasource/shared/datasources/feature-datasource';
+import { FeatureDataSourceOptions } from '../../datasource/shared/datasources/feature-datasource.interface';
 import { Feature } from '../../feature/shared/feature.interfaces';
 import { featureToOl, moveToOlFeatures } from '../../feature/shared/feature.utils';
 import { VectorLayer } from '../../layer/shared/layers/vector-layer';
 import { IgoMap } from '../../map/shared/map';
+import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 
 export function addLayerAndFeaturesToMap(features: Feature[], map: IgoMap, layerTitle: string): VectorLayer {
   const olFeatures = features.map((feature: Feature) => featureToOl(feature, map.projection));
@@ -22,7 +24,10 @@ export function addLayerAndFeaturesToMap(features: Feature[], map: IgoMap, layer
   const fill = new olStyle.Fill({
     color: [r, g, b, 0.4]
   });
-  const source = new FeatureDataSource();
+  const sourceOptions: FeatureDataSourceOptions & QueryableDataSourceOptions = {
+    queryable: true
+  };
+  const source = new FeatureDataSource(sourceOptions);
   source.ol.addFeatures(olFeatures);
   const layer = new VectorLayer({
     title: layerTitle,
@@ -55,7 +60,7 @@ export function handleFileImportSuccess(
     return;
   }
 
-  const layerTitle = file.name.substr(0, file.name.lastIndexOf('.'));
+  const layerTitle = computeLayerTitleFromFile(file);
   addLayerAndFeaturesToMap(features, map, layerTitle);
 
   const translate = languageService.translate;
@@ -97,4 +102,8 @@ export function handleNothingToImportError(
 
 export function getFileExtension(file: File): string {
   return file.name.split('.').pop().toLowerCase();
+}
+
+export function computeLayerTitleFromFile(file: File): string {
+  return file.name.substr(0, file.name.lastIndexOf('.'));
 }

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -9,7 +9,7 @@ import {
 import { Subscription, BehaviorSubject } from 'rxjs';
 
 import { MetadataLayerOptions } from '../../metadata/shared/metadata.interface';
-import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
+import { layerIsQueryable } from '../../query/shared/query.utils';
 import { Layer, TooltipType } from '../shared/layers';
 
 @Component({
@@ -119,7 +119,7 @@ export class LayerItemComponent implements OnInit, OnDestroy {
   private updateQueryBadge() {
     const hidden = this.queryBadge === false ||
       this.layer.visible === false ||
-      (this.layer.dataSource.options as QueryableDataSourceOptions).queryable !== true;
+      !layerIsQueryable(this.layer);
     this.queryBadgeHidden$.next(hidden);
   }
 }

--- a/packages/geo/src/lib/layer/shared/layers/layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.ts
@@ -94,6 +94,8 @@ export abstract class Layer {
       this.options.visible === undefined ? true : this.options.visible;
     this.opacity =
       this.options.opacity === undefined ? 1 : this.options.opacity;
+
+    this.ol.set('_layer', this, true);
   }
 
   protected abstract createOlLayer(): olLayer;

--- a/packages/geo/src/lib/query/shared/index.ts
+++ b/packages/geo/src/lib/query/shared/index.ts
@@ -2,4 +2,5 @@ export * from './query.service';
 export * from './query.directive';
 export * from './query.enums';
 export * from './query.interfaces';
+export * from './query.utils';
 export * from './query-search-source';

--- a/packages/geo/src/lib/query/shared/query.utils.ts
+++ b/packages/geo/src/lib/query/shared/query.utils.ts
@@ -1,0 +1,24 @@
+import OlLayer from 'ol/layer/Layer';
+
+import { AnyLayer } from '../../layer/shared/layers/any-layer';
+import { QueryableDataSource } from './query.interfaces';
+
+/**
+ * Whether a layer is queryable
+ * @param layer Layer
+ * @returns True if the layer s squeryable
+ */
+export function layerIsQueryable(layer: AnyLayer): boolean {
+  const dataSource = layer.dataSource as QueryableDataSource;
+  return dataSource.options.queryable === true;
+}
+
+/**
+ * Whether an OL layer is queryable
+ * @param layer Layer
+ * @returns True if the ol layer is queryable
+ */
+export function olLayerIsQueryable(olLayer: OlLayer): boolean {
+  const layer = olLayer.get('_layer');
+  return layer === undefined ? false : layerIsQueryable(layer);
+}

--- a/packages/geo/src/lib/search/shared/sources/ilayer.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.interfaces.ts
@@ -1,3 +1,9 @@
+import { SearchSourceOptions } from './source.interfaces';
+
+export interface ILayerSearchSourceOptions extends SearchSourceOptions {
+  queryFormat?: {[key: string]: string | {urls: string[]}};
+}
+
 export interface ILayerData {
   id: string;
   source: ILayerDataSource;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Vector features cannot be queried with the query directive, like they used to.


**What is the new behavior?**
Vector features can now be queried with the query directive but, for now, it's not possible to query with a dragbox.
Queryable features include those imported or those obtained from the ilayer search source.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
