### PR TITLE
rainbow of possibilities for searching coordinate

### DIFF
--- a/demo/src/app/geo/search/search.component.ts
+++ b/demo/src/app/geo/search/search.component.ts
@@ -20,6 +20,7 @@ import {
   Layer,
   LAYER,
   LayerOptions,
+  ProjectionService,
   Research,
   SearchResult,
   SearchService
@@ -64,6 +65,7 @@ export class AppSearchComponent implements OnInit, OnDestroy {
 
   constructor(
     private languageService: LanguageService,
+    private projectionService: ProjectionService,
     private mapService: MapService,
     private layerService: LayerService,
     private searchState: SearchState,

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -6,6 +6,14 @@ interface Environment {
 export const environment: Environment = {
   production: true,
   igo: {
+    projections: [
+      {
+      code: 'EPSG:32198',
+      def:
+      '+proj=lcc +lat_1=60 +lat_2=46 +lat_0=44 +lon_0=-68.5 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+      extent: [-886251.0296, 180252.9126, 897177.3418, 2106143.8139]
+      }
+      ],
     auth: {
       intern: {
         enabled: true

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -12,6 +12,13 @@ interface Environment {
 export const environment: Environment = {
   production: false,
   igo: {
+    projections: [
+      {
+        code: 'EPSG:32198',
+        def: '+proj=lcc +lat_1=60 +lat_2=46 +lat_0=44 +lon_0=-68.5 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+        extent: [-886251.0296, 180252.9126, 897177.3418, 2106143.8139]
+      }
+    ],
     auth: {
       intern: {
         enabled: true

--- a/packages/geo/src/lib/map/shared/map.utils.ts
+++ b/packages/geo/src/lib/map/shared/map.utils.ts
@@ -22,7 +22,6 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
 
   let lonLat: [number, number];
   let coordStr: string;
-  let fullCoord: string;
   let negativeLon: string;
   let degreesLon: string;
   let minutesLon: string;
@@ -84,23 +83,22 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
   }
 
   if (lonLatRegex.test(coordStr)) {
-    let temp1: string;
-    let temp2: string;
-    [fullCoord,
+
+    [,
      negativeLon,
      lon,
-     temp1,
+     ,
      decimalLon,
      negativeLat,
      lat,
-     temp2,
+     ,
      decimalLat] = coordStr.match(lonLatPattern);
 
     lon = parseFloat((negativeLon ? negativeLon : '') + lon + '.' + decimalLon);
     lat = parseFloat((negativeLat ? negativeLat : '') + lat + '.' + decimalLat);
 
   } else if (dmsRegex.test(coordStr)) {
-      [fullCoord,
+      [,
        degreesLon,
        minutesLon,
        secondsLon,
@@ -110,17 +108,17 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
        secondsLat,
        directionLat] = coordStr.match(dmsCoordPattern);
 
-      lon = ConvertDMSToDD(parseFloat(degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
-      lat = ConvertDMSToDD(parseFloat(degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+      lon = convertDMSToDD(parseFloat(degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+      lat = convertDMSToDD(parseFloat(degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
 
   } else if (utmMtmRegex.test(coordStr)) {
-      [fullCoord, pattern, timeZone, lon, lat] = coordStr.match(patternUtmMtm);
+      [, pattern, timeZone, lon, lat] = coordStr.match(patternUtmMtm);
       const utm = '+proj=' + pattern + ' +zone=' + timeZone;
       const wgs84 = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
       [lon, lat] = proj4(utm.toLocaleLowerCase(), wgs84, [parseFloat(lon), parseFloat(lat)]);
 
   } else if (dmdRegex.test(coordStr)) {
-    [fullCoord,
+    [,
       negativeLon,
       degreesLon,
       minutesLon,
@@ -132,11 +130,11 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
       secondsLat,
       decimalLat] = coordStr.match(patternDmd);
 
-    lon = ConvertDMSToDD(parseFloat((negativeLon ? negativeLon : '') + degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
-    lat = ConvertDMSToDD(parseFloat((negativeLat ? negativeLat : '') + degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+    lon = convertDMSToDD(parseFloat((negativeLon ? negativeLon : '') + degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+    lat = convertDMSToDD(parseFloat((negativeLat ? negativeLat : '') + degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
 
   } else if (ddRegex.test(coordStr)) {
-      [fullCoord,
+      [,
         negativeLon,
         degreesLon,
         decimalLon,
@@ -144,25 +142,22 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
         degreesLat,
         decimalLat] = coordStr.match(patternDd);
 
-      lon = ConvertDMSToDD(parseFloat((negativeLon ? negativeLon : '') + degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
-      lat = ConvertDMSToDD(parseFloat((negativeLat ? negativeLat : '') + degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+      lon = convertDMSToDD(parseFloat((negativeLon ? negativeLon : '') + degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+      lat = convertDMSToDD(parseFloat((negativeLat ? negativeLat : '') + degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
 
   } else if (bellRegex.test(coordStr)) {
-    let temp1: string;
-    let temp2: string;
-
-    [fullCoord,
+    [,
       negativeLat,
       degreesLat,
       minutesLat,
       secondsLat,
-      temp2,
+      ,
       directionLat,
       negativeLon,
       degreesLon,
       minutesLon,
       secondsLon,
-      temp1,
+      ,
       directionLon,
       radius,
       conf] = coordStr.match(patternBELL);
@@ -176,17 +171,17 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
     if (minutesLon && minutesLon.length > 2) {
       lon = parseFloat((negativeLon ? negativeLon : '') + degreesLon + '.' + minutesLon);
     } else {
-      lon = ConvertDMSToDD(parseFloat(degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+      lon = convertDMSToDD(parseFloat(degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
     }
 
     if (minutesLat && minutesLat.length > 2) {
       lat = parseFloat((negativeLat ? negativeLat : '') + degreesLat + '.' + minutesLat);
     } else {
-      lat = ConvertDMSToDD(parseFloat(degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+      lat = convertDMSToDD(parseFloat(degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
     }
 
   } else if (mmRegex.test(coordStr)) {
-      [fullCoord, lon, decimalLon, lat, decimalLat] = coordStr.match(mmPattern);
+      [, lon, decimalLon, lat, decimalLat] = coordStr.match(mmPattern);
 
       if (decimalLon) {
         lon = parseFloat(lon + '.' + decimalLon);
@@ -239,7 +234,7 @@ export function stringToLonLat(str: string, mapProjection: string): {lonLat: [nu
  * @param seconds Seconds
  * @param direction Direction
  */
-function ConvertDMSToDD(degrees: number, minutes: number, seconds: number, direction: string) {
+function convertDMSToDD(degrees: number, minutes: number, seconds: number, direction: string) {
   minutes = minutes || 0;
   seconds = seconds || 0;
   let dd = degrees + (minutes / 60) + (seconds / 3600);

--- a/packages/geo/src/lib/map/shared/map.utils.ts
+++ b/packages/geo/src/lib/map/shared/map.utils.ts
@@ -3,39 +3,251 @@ import { MapBrowserPointerEvent as OlMapBrowserPointerEvent } from 'ol/MapBrowse
 import { MAC } from 'ol/has';
 
 import { MapViewState } from './map.interface';
+import proj4 from 'proj4';
 
 /**
- * This method extracts a [lon, lat] tuple from a string.
+ * This method extracts a coordinate tuple from a string.
  * @param str Any string
- * @returns A [lon, lat] tuple if one is found in the string
- * @todo Reproject coordinates
+ * @param mapProjection string Map Projection
+ * @returns object:
+ *             lonLat: Coordinate,
+ *             message: Message of error,
+ *             radius: radius of the confience of coordinate,
+ *             conf: confidence of the coordinate}
  */
-export function stringToLonLat(str: string): [number, number] | undefined {
-  const coordPattern =  '[-+]?[\\d]{1,8}(\\.)?(\\d+)?';
-  const projectionPattern = '(;[\\d]{4,5})';
-  const lonLatPattern = `^${coordPattern},(\\s)*${coordPattern}${projectionPattern}?`;
-  const lonLatRegex = new RegExp(lonLatPattern, 'g');
+export function stringToLonLat(str: string, mapProjection: string): {lonLat: [number, number] | undefined,
+                                                                     message: string,
+                                                                     radius: number | undefined,
+                                                                     conf: number | undefined} {
 
-  if (!lonLatRegex.test(str)) {
-    return undefined;
-  }
+  let lonLat: [number, number];
+  let coordStr: string;
+  let fullCoord: string;
+  let negativeLon: string;
+  let degreesLon: string;
+  let minutesLon: string;
+  let secondsLon: string;
+  let directionLon: string;
+  let decimalLon: string;
+  let negativeLat: string;
+  let degreesLat: string;
+  let minutesLat: string;
+  let secondsLat: string;
+  let directionLat: string;
+  let decimalLat: string;
+  let pattern: string;
+  let timeZone: string;
+  let radius: string;
+  let conf: string;
+  let lon: any;
+  let lat: any;
 
-  let lonLatStr = str;
-  let projectionStr;
-
+  const projectionPattern = '(;[\\d]{4,6})';
+  const toProjection = '4326';
+  let projectionStr: string;
   const projectionRegex = new RegExp(projectionPattern, 'g');
+
+  const lonlatCoord =  '([-+])?([\\d]{1,3})([,.](\\d+))?';
+  const lonLatPattern = `${lonlatCoord}[\\s,.]\\s*${lonlatCoord}`;
+  const lonLatRegex = new RegExp(`^${lonLatPattern}$`, 'g');
+
+  const dmsCoord = '([0-9]{1,2})[:|°]?\\s*([0-9]{1,2})?[:|\'|′|’]?\\s*([0-9]{1,2}(?:\.[0-9]+){0,1})?\\s*["|″|”]?\\s*';
+  const dmsCoordPattern = `${dmsCoord}([N|S]),?\\s*${dmsCoord}([E|W])`;
+  const dmsRegex = new RegExp(`^${dmsCoordPattern}`, 'gi');
+
+  const patternUtmMtm = '(UTM|MTM)\-?(\\d{1,2})[\\s,.]*(\\d+[\\s.,]?\\d+)[\\s,.]+(\\d+[\\s.,]?\\d+)';
+  const utmMtmRegex =  new RegExp(`^${patternUtmMtm}`, 'gi');
+
+  const ddCoord = '([-+])?(\\d{1,3})[,.](\\d+)';
+  const patternDd = `${ddCoord}[,.]?\\s*${ddCoord}`;
+  const ddRegex =  new RegExp(`^${patternDd}`, 'g');
+
+  const dmdCoord = '([-+])?(\\d{1,3})[\\s,.]{1}(\\d{1,2})[\\s,.]{1}(\\d{1,2})[.,]?(\\d{1,5})?';
+  const patternDmd = `${dmdCoord}[,.]?\\s*${dmdCoord}`;
+  const dmdRegex =  new RegExp(`^${patternDmd}`, 'g');
+
+  // tslint:disable:max-line-length
+  const patternBELL = 'LAT\\s*[\\s:]*\\s*([-+])?(\\d{1,2})[\\s.,]?(\\d+)?[\\s.,]?\\s*(\\d{1,2}([.,]\\d+)?)?\\s*(N|S|E|W)?\\s*LONG\\s*[\\s:]*\\s*([-+])?(\\d{1,3})[\\s.,]?(\\d+)?[\\s.,]?\\s*(\\d{1,2}([.,]\\d+)?)?\\s*(N|S|E|W)?\\s*UNC\\s*[\\s:]?\\s*(\\d+)\\s*CONF\\s*[\\s:]?\\s*(\\d{1,3})';
+  const bellRegex =  new RegExp(`^${patternBELL}?`, 'gi');
+
+  const mmCoord = '([-+]?\\d+)[,.]?(\\d+)?';
+  const mmPattern = `${mmCoord}[\\s,.]\\s*${mmCoord}`;
+  const mmRegex =  new RegExp(`^${mmPattern}$`, 'g');
+
+  str = str.toLocaleUpperCase();
+
+  // Extract projection
   if (projectionRegex.test(str)) {
-    [lonLatStr, projectionStr] = str.split(';');
+    [coordStr, projectionStr] = str.split(';');
+  } else {
+    coordStr = str;
   }
 
-  const [lonStr, latStr] = lonLatStr.split(',');
-  const lonLat = [parseFloat(lonStr), parseFloat(latStr)] as [number, number];
+  if (lonLatRegex.test(coordStr)) {
+    let temp1: string;
+    let temp2: string;
+    [fullCoord,
+     negativeLon,
+     lon,
+     temp1,
+     decimalLon,
+     negativeLat,
+     lat,
+     temp2,
+     decimalLat] = coordStr.match(lonLatPattern);
 
-  if (projectionStr !== undefined) {
-    // TODO Reproject coordinates
+    lon = parseFloat((negativeLon ? negativeLon : '') + lon + '.' + decimalLon);
+    lat = parseFloat((negativeLat ? negativeLat : '') + lat + '.' + decimalLat);
+
+  } else if (dmsRegex.test(coordStr)) {
+      [fullCoord,
+       degreesLon,
+       minutesLon,
+       secondsLon,
+       directionLon,
+       degreesLat,
+       minutesLat,
+       secondsLat,
+       directionLat] = coordStr.match(dmsCoordPattern);
+
+      lon = ConvertDMSToDD(parseFloat(degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+      lat = ConvertDMSToDD(parseFloat(degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+
+  } else if (utmMtmRegex.test(coordStr)) {
+      [fullCoord, pattern, timeZone, lon, lat] = coordStr.match(patternUtmMtm);
+      const utm = '+proj=' + pattern + ' +zone=' + timeZone;
+      const wgs84 = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
+      [lon, lat] = proj4(utm.toLocaleLowerCase(), wgs84, [parseFloat(lon), parseFloat(lat)]);
+
+  } else if (dmdRegex.test(coordStr)) {
+    [fullCoord,
+      negativeLon,
+      degreesLon,
+      minutesLon,
+      secondsLon,
+      decimalLon,
+      negativeLat,
+      degreesLat,
+      minutesLat,
+      secondsLat,
+      decimalLat] = coordStr.match(patternDmd);
+
+    lon = ConvertDMSToDD(parseFloat((negativeLon ? negativeLon : '') + degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+    lat = ConvertDMSToDD(parseFloat((negativeLat ? negativeLat : '') + degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+
+  } else if (ddRegex.test(coordStr)) {
+      [fullCoord,
+        negativeLon,
+        degreesLon,
+        decimalLon,
+        negativeLat,
+        degreesLat,
+        decimalLat] = coordStr.match(patternDd);
+
+      lon = ConvertDMSToDD(parseFloat((negativeLon ? negativeLon : '') + degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+      lat = ConvertDMSToDD(parseFloat((negativeLat ? negativeLat : '') + degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+
+  } else if (bellRegex.test(coordStr)) {
+    let temp1: string;
+    let temp2: string;
+
+    [fullCoord,
+      negativeLat,
+      degreesLat,
+      minutesLat,
+      secondsLat,
+      temp2,
+      directionLat,
+      negativeLon,
+      degreesLon,
+      minutesLon,
+      secondsLon,
+      temp1,
+      directionLon,
+      radius,
+      conf] = coordStr.match(patternBELL);
+
+    // Set default value for North America
+    if (!directionLon) {
+      directionLon = 'W';
+    }
+
+    // Check if real minutes or decimals
+    if (minutesLon && minutesLon.length > 2) {
+      lon = parseFloat((negativeLon ? negativeLon : '') + degreesLon + '.' + minutesLon);
+    } else {
+      lon = ConvertDMSToDD(parseFloat(degreesLon), parseFloat(minutesLon), parseFloat(secondsLon), directionLon);
+    }
+
+    if (minutesLat && minutesLat.length > 2) {
+      lat = parseFloat((negativeLat ? negativeLat : '') + degreesLat + '.' + minutesLat);
+    } else {
+      lat = ConvertDMSToDD(parseFloat(degreesLat), parseFloat(minutesLat), parseFloat(secondsLat), directionLat);
+    }
+
+  } else if (mmRegex.test(coordStr)) {
+      [fullCoord, lon, decimalLon, lat, decimalLat] = coordStr.match(mmPattern);
+
+      if (decimalLon) {
+        lon = parseFloat(lon + '.' + decimalLon);
+      }
+
+      if (decimalLat) {
+        lat = parseFloat(lat + '.' + decimalLat);
+      }
+
+  } else {
+    return {lonLat: undefined, message: '', radius: undefined, conf: undefined};
   }
 
-  return lonLat;
+  // Set a negative coordinate for North America zone
+  if (lon > 0 && lat > 0) {
+    if (lon > lat) {
+      lon = -lon;
+    } else {
+      lat = -lat;
+    }
+  }
+
+  // Reverse coordinate to respect lonLat convention
+  if (lon < lat) {
+    lonLat = [lon, lat] as [number, number];
+  } else {
+    lonLat = [lat, lon] as [number, number];
+  }
+
+  // Reproject the coordinate if projection parameter have been set and coord is not 4326
+  if ((projectionStr !== undefined && projectionStr !== toProjection) || (lonLat[0] > 180 || lonLat[0] < -180)) {
+
+    const source = projectionStr ? 'EPSG:' + projectionStr : mapProjection;
+    const dest = 'EPSG:' + toProjection;
+
+    try {
+      lonLat = olproj.transform(lonLat, source, dest);
+    } catch (e) {
+      return {lonLat: undefined, message: 'Projection ' + source + ' not supported', radius: undefined, conf: undefined};
+    }
+  }
+
+  return {lonLat, message: '', radius: radius ? parseInt(radius, 10) : undefined, conf: conf ? parseInt(conf, 10) : undefined};
+}
+
+/**
+ * Convert degrees minutes seconds to dd
+ * @param degrees Degrees
+ * @param minutes Minutes
+ * @param seconds Seconds
+ * @param direction Direction
+ */
+function ConvertDMSToDD(degrees: number, minutes: number, seconds: number, direction: string) {
+  minutes = minutes || 0;
+  seconds = seconds || 0;
+  let dd = degrees + (minutes / 60) + (seconds / 3600);
+
+  if (direction === 'S' || direction === 'W') {
+      dd = -dd;
+  } // Don't do anything for N or E
+  return dd;
 }
 
 /**

--- a/packages/geo/src/lib/search/shared/search.service.ts
+++ b/packages/geo/src/lib/search/shared/search.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { stringToLonLat } from '../../map';
+import { MapService } from '../../map/shared/map.service';
 
 import { SearchSource, TextSearch, ReverseSearch } from './sources/source';
 import { TextSearchOptions, ReverseSearchOptions } from './sources/source.interfaces';
@@ -20,7 +21,7 @@ import { sourceCanSearch, sourceCanReverseSearch } from './search.utils';
 })
 export class SearchService {
 
-  constructor(private searchSourceService: SearchSourceService) {}
+  constructor(private searchSourceService: SearchSourceService, private mapService: MapService) {}
 
   /**
    * Perform a research by text
@@ -32,9 +33,11 @@ export class SearchService {
       return [];
     }
 
-    const lonLat = stringToLonLat(term);
-    if (lonLat !== undefined) {
-      return this.reverseSearch(lonLat);
+    const response = stringToLonLat(term, this.mapService.getMap().projection);
+    if (response.lonLat) {
+      return this.reverseSearch(response.lonLat);
+    } else {
+      console.log(response.message);
     }
 
     const sources = this.searchSourceService.getEnabledSources()


### PR DESCRIPTION
Fix #288 (Reverse coordinate search)
Add a rainbow of possibilities for searching coordinate (multiple formats supported)
Add support for EPSG:32198

**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

With LonLat, now accepting UTM, MTM, DD, DMD, DMS, BELL and MM coordinates

Coordinates will be switch for North America if send LatLon

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
