### PR TITLE
feat{geometry-form-field}: allow to set symbol

### DIFF
--- a/demo/src/app/geo/geometry/geometry.component.ts
+++ b/demo/src/app/geo/geometry/geometry.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { BehaviorSubject, Subscription } from 'rxjs';
+import * as olstyle from 'ol/style';
 
 import { LanguageService } from '@igo2/core';
 import { Form, FormService } from '@igo2/common';
@@ -70,7 +71,25 @@ export class AppGeometryComponent implements OnInit, OnDestroy {
           geometryType: 'Polygon',
           drawGuideField: true,
           drawGuide: 50,
-          drawGuidePlaceholder: 'Draw Guide'
+          drawGuidePlaceholder: 'Draw Guide',
+          drawStyle: new olstyle.Style({
+            stroke: new olstyle.Stroke({
+              color: [255, 0, 0, 1],
+              width: 2
+            }),
+            fill:  new olstyle.Fill({
+              color: [255, 0, 0, 0.2]
+            }),
+            image: new olstyle.Circle({
+              radius: 8,
+              stroke: new olstyle.Stroke({
+                color: [255, 0, 0, 1]
+              }),
+              fill: new olstyle.Fill({
+                color: [255, 0, 0, 0.2]
+              })
+            })
+          })
         }
       },
       {

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.html
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.html
@@ -3,7 +3,9 @@
   [map]="map"
   [geometryType]="geometryType$ | async"
   [drawGuide]="drawGuide$ | async"
-  [measure]="measure">
+  [measure]="measure"
+  [symbolColor]="symbolColor"
+  [pointIcon]="pointIcon">
 </igo-geometry-form-field-input>
 
 <div *ngIf="geometryTypeField" class="geometry-type-toggle">

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.html
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.html
@@ -4,8 +4,8 @@
   [geometryType]="geometryType$ | async"
   [drawGuide]="drawGuide$ | async"
   [measure]="measure"
-  [symbolColor]="symbolColor"
-  [pointIcon]="pointIcon">
+  [drawStyle]="drawStyle"
+  [overlayStyle]="overlayStyle">
 </igo-geometry-form-field-input>
 
 <div *ngIf="geometryTypeField" class="geometry-type-toggle">

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
@@ -11,6 +11,7 @@ import { FormControl } from '@angular/forms';
 import { BehaviorSubject, Subscription } from 'rxjs';
 
 import OlGeometryType from 'ol/geom/GeometryType';
+import { Style as OlStyle } from 'ol/style';
 
 import { FormFieldComponent } from '@igo2/common';
 
@@ -69,7 +70,7 @@ export class GeometryFormFieldComponent implements OnInit, OnDestroy {
   /**
    * The drawGuide around the mouse pointer to help drawing
    */
-  @Input() drawGuide: number = 0;
+  @Input() drawGuide: number = null;
 
   /**
    * Draw guide placeholder
@@ -80,6 +81,16 @@ export class GeometryFormFieldComponent implements OnInit, OnDestroy {
    * Whether a measure tooltip should be displayed
    */
   @Input() measure: boolean = false;
+
+  /**
+   * Color (R, G, B) for features drawn on the map
+   */
+  @Input() symbolColor: [number, number, number];
+
+  /**
+   * Icon for point geometries drawn on the map
+   */
+  @Input() pointIcon: OlStyle.Icon;
 
   /**
    * The geometry type model
@@ -126,5 +137,4 @@ export class GeometryFormFieldComponent implements OnInit, OnDestroy {
   onDrawGuideChange(value: number) {
     this.drawGuide$.next(value);
   }
-
 }

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
@@ -83,14 +83,15 @@ export class GeometryFormFieldComponent implements OnInit, OnDestroy {
   @Input() measure: boolean = false;
 
   /**
-   * Color (R, G, B) for features drawn on the map
+   * Style for the draw control (applies while the geometry is being drawn)
    */
-  @Input() symbolColor: [number, number, number];
+  @Input() drawStyle: OlStyle;
 
   /**
-   * Icon for point geometries drawn on the map
+   * Style for the overlay layer (applies once the geometry is added to the map)
+   * If not specified, drawStyle applies
    */
-  @Input() pointIcon: OlStyle.Icon;
+  @Input() overlayStyle: OlStyle;
 
   /**
    * The geometry type model

--- a/packages/geo/src/lib/geometry/shared/geometry.utils.ts
+++ b/packages/geo/src/lib/geometry/shared/geometry.utils.ts
@@ -14,24 +14,26 @@ import {
 
 /**
  * Create a default style for draw and modify interactions
+ * @param color Style color (R, G, B)
  * @returns OL style
  */
-export function createDrawInteractionStyle(): olstyle.Style {
+export function createDrawInteractionStyle(color?: [number, number, number]): olstyle.Style {
+  color = color || [0, 153, 255];
   return new olstyle.Style({
     stroke: new olstyle.Stroke({
-      color:  [0, 153, 255, 1],
+      color: color.concat([1]),
       width: 2
     }),
     fill:  new olstyle.Fill({
-      color:  [0, 153, 255, 0.2]
+      color: color.concat([0.2])
     }),
     image: new olstyle.Circle({
-      radius: 5,
+      radius: 8,
       stroke: new olstyle.Stroke({
-        color: [0, 153, 255, 1],
+        color: color.concat([1])
       }),
       fill: new olstyle.Fill({
-        color:  [0, 153, 255, 0.2]
+        color: color.concat([0.2])
       })
     })
   });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

It's not possible to define custom symbol for geometry input draw tool.
Draw tool cannot be deactivated.
When draw guide is undefined, radius is 0 and no point appears when drawing / also point added to map is too small to be noticeable.

**What is the new behavior?**

geometry-form-field and geometry-form-field-input now allows to:

- Set color of symbol
- Set icon as point symbol
- Deactivate draw tool by setting null geometry type
- Apply default circle radius of 8 when no draw guide is defined

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
