### PR TITLE
feat(entity-table): add option to choose button style

### DIFF
--- a/packages/common/src/lib/entity/entity-table/entity-table.component.html
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.html
@@ -66,13 +66,22 @@
           <ng-container *ngIf="columnRenderer === entityTableColumnRenderer.ButtonGroup">
             <td mat-cell *matCellDef="let entity" class="mat-cell-text"
               [ngClass]="getCellClass(entity, column)">
-              <button *ngFor="let button of getValue(entity, column)"
-                mat-mini-fab
-                igoStopPropagation
-                [color]="button.color"
-                (click)="onButtonClick(button.click, entity)">
-                <mat-icon svgIcon="{{button.icon}}"></mat-icon>
-              </button>
+              <span *ngFor="let button of getValue(entity, column)">
+                <button *ngIf="button.style === 'mat-icon-button'"
+                  igoStopPropagation
+                  mat-icon-button
+                  [color]="button.color"
+                  (click)="onButtonClick(button.click, entity)">
+                  <mat-icon svgIcon="{{button.icon}}"></mat-icon>
+                </button>
+                <button *ngIf="button.style !== 'mat-icon-button'"
+                  igoStopPropagation
+                  mat-mini-fab
+                  [color]="button.color"
+                  (click)="onButtonClick(button.click, entity)">
+                  <mat-icon svgIcon="{{button.icon}}"></mat-icon>
+                </button>
+              </span>
             </td>
           </ng-container>
       </ng-container>

--- a/packages/common/src/lib/entity/shared/entity.interfaces.ts
+++ b/packages/common/src/lib/entity/shared/entity.interfaces.ts
@@ -92,4 +92,5 @@ export interface EntityTableButton {
   icon: string;
   click: (entity: object) => void;
   color?: 'primary' | 'accent' | 'warn';
+  style?: 'mat-mini-fab' | 'mat-icon-button';
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x  ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

Material buttons in Entity Table are of type mat-mini-fab

**What is the new behavior?**

Can now choose between mat-mini-fab and mat-icon-button style (mat-mini-fab stays default)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
