### PR TITLE
fix (wfs-datasource) support more OL formats and clarify variable nam…

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -1,6 +1,5 @@
 import olSourceVector from 'ol/source/Vector';
 import * as OlLoadingStrategy from 'ol/loadingstrategy';
-import * as OlFormat from 'ol/format';
 
 import { DataSource } from './datasource';
 import { WFSDataSourceOptions } from './wfs-datasource.interface';
@@ -13,7 +12,8 @@ import {
   defaultFieldNameGeometry,
   gmlRegex,
   jsonRegex,
-  checkWfsParams
+  checkWfsParams,
+  getFormatFromOptions
 } from './wms-wfs.utils';
 
 export class WFSDataSource extends DataSource {
@@ -38,7 +38,7 @@ export class WFSDataSource extends DataSource {
   protected createOlSource(): olSourceVector {
 
     return new olSourceVector({
-      format: this.getFormatFromOptions(),
+      format: getFormatFromOptions(this.options),
       overlaps: false,
       url: (extent, resolution, proj) => {
         return this.buildUrl(
@@ -73,24 +73,6 @@ export class WFSDataSource extends DataSource {
     baseUrl = patternFilter.test(paramsWFS.xmlFilter) ? `${baseUrl}&${paramsWFS.xmlFilter}` : baseUrl;
     this.options.download = Object.assign({}, this.options.download, { dynamicUrl: baseUrl });
     return baseUrl.replace(/&&/g, '&');
-  }
-
-  private getFormatFromOptions() {
-    let olFormatCls;
-
-    let outputFormat;
-    if (this.options.paramsWFS.outputFormat) {
-      outputFormat = this.options.paramsWFS.outputFormat.toLowerCase();
-    }
-
-    if (jsonRegex.test(outputFormat)) {
-      olFormatCls = OlFormat.GeoJSON;
-    }
-    if (gmlRegex.test(outputFormat) || !outputFormat) {
-      olFormatCls = OlFormat.WFS;
-    }
-
-    return new olFormatCls();
   }
 
   public onUnwatch() {}


### PR DESCRIPTION
fix #396

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

the format check was causing error when it was not standard 
ex: 'geojson_utf8'

**What is the new behavior?**

no more error and support of multiple OL format. 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
[x] Maybe
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:

only tested with 'outputFormat' : 'gml3' and 'geojson_utf8' 