### PR TITLE
feat(about-tool, ogc-filter-toggle-button): management of multi-lines

### DIFF
--- a/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.html
@@ -2,8 +2,8 @@
         <mat-button-toggle-group appearance="legacy" vertical={{bundleIsVertical(bundle)}} multiple="true">
             <mat-button-toggle [ngStyle]="getButtonColor(ogcPushButton)" [checked]="ogcPushButton.enabled"
                 (change)="applyFilters(ogcPushButton)" tooltip-position="below" matTooltipShowDelay="500"
-                [matTooltip]="getToolTip(ogcPushButton)" *ngFor="let ogcPushButton of bundle.ogcPushButtons"
-                [value]="ogcPushButton">{{ogcPushButton.title}}
+                [matTooltip]="getToolTip(ogcPushButton)" matTooltipClass="material-tooltip" 
+                *ngFor="let ogcPushButton of bundle.ogcPushButtons" [value]="ogcPushButton">{{ogcPushButton.title}}
             </mat-button-toggle>
         </mat-button-toggle-group>
 </ng-container>

--- a/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.scss
@@ -8,3 +8,7 @@
     flex-wrap: wrap;
 
   }
+
+  ::ng-deep .material-tooltip {
+    white-space: pre-line;
+  }

--- a/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.ts
@@ -52,7 +52,11 @@ export class OgcFilterToggleButtonComponent implements OnInit {
   getToolTip(pb: OgcPushButton): string  {
     let tt;
     if (pb.tooltip) {
-      tt = pb.tooltip;
+      if (Array.isArray(pb.tooltip)) {
+        tt = pb.tooltip.join('\n');
+      } else {
+        tt = pb.tooltip;
+      }
     }
     return tt || '';
   }

--- a/packages/integration/src/lib/about/about-tool/about-tool.component.ts
+++ b/packages/integration/src/lib/about/about-tool/about-tool.component.ts
@@ -12,19 +12,6 @@ import { ToolComponent } from '@igo2/common';
   templateUrl: './about-tool.component.html'
 })
 export class AboutToolComponent {
-  // @Input() html: string = `
-  //   <h1>About IGO</h1>
-  //   <p>IGO (for Open GIS Infrastructure) is a Free Open Source Software
-  //   for Geospatial (FOSS4G) developed by organisations in the government
-  //   of Quebec in Canada. The objective is to make it open, common,
-  //   modular, based on open governance model supported by multiple
-  //   organisations. IGO is a Web GIS software with a client & server
-  //   component to manage and publish massive amount of Geospatial data.
-  //   </p>
-  //   </hr>
-  //   <a href='mailto:info@igouverte.org' target='_top'>info[@]igouverte.org</a>
-  //   </br>
-  //   <a href='http://www.igouverte.org' target='_blank'>www.igouverte.org</A>`;
 
   @Input()
   get html() {

--- a/packages/integration/src/lib/about/about-tool/about-tool.component.ts
+++ b/packages/integration/src/lib/about/about-tool/about-tool.component.ts
@@ -12,7 +12,30 @@ import { ToolComponent } from '@igo2/common';
   templateUrl: './about-tool.component.html'
 })
 export class AboutToolComponent {
-  @Input() html: string = `
+  // @Input() html: string = `
+  //   <h1>About IGO</h1>
+  //   <p>IGO (for Open GIS Infrastructure) is a Free Open Source Software
+  //   for Geospatial (FOSS4G) developed by organisations in the government
+  //   of Quebec in Canada. The objective is to make it open, common,
+  //   modular, based on open governance model supported by multiple
+  //   organisations. IGO is a Web GIS software with a client & server
+  //   component to manage and publish massive amount of Geospatial data.
+  //   </p>
+  //   </hr>
+  //   <a href='mailto:info@igouverte.org' target='_top'>info[@]igouverte.org</a>
+  //   </br>
+  //   <a href='http://www.igouverte.org' target='_blank'>www.igouverte.org</A>`;
+
+  @Input()
+  get html() {
+    return this._html;
+  }
+  set html(value: string) {
+    this._html = Array.isArray(value)
+      ? value.join('\n')
+      : value;
+    }
+  private _html: string = `
     <h1>About IGO</h1>
     <p>IGO (for Open GIS Infrastructure) is a Free Open Source Software
     for Geospatial (FOSS4G) developed by organisations in the government


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] New feature


**What is the current behavior?** (You can also link to an open issue here)
- the return of line is not managed on the tooltip of ogc filter toggle for the display.
- the multilines is not managed on the about tool and the tooltip of ogc filter toggle in JSON configuration.


**What is the new behavior?**
On about-tool component
- add the possibility to use a string array in the JSON configuration for the html.

```
   {
      "name": "about",
      "options": {
        "html": [
          "This is a",
          "IGO"]
      }
    }
```

On ogc-filter-toggle-button componet
- add the management of the return of line on the tooltip;
```
   "tooltip": "Barrière,\nCaméras,\nCinémomètre"
```
- add the possibility to use a string array in the JSON configuration for the tooltip. 
Note: The return of line is automatically added between each line for the display.

```
   "tooltip": [
      "Barrière,",
      "Caméras,",
      "Cinémomètre"],
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
