### PR TITLE
fix(geo.vector-layer.animation) styleVector don't need label.

### DIFF
--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -117,6 +117,7 @@ export class VectorLayer extends Layer {
           break;
       }
 
+      styleClone.setText('');
       vectorContext.setStyle(styleClone);
       vectorContext.drawGeometry(flashGeom);
 
@@ -150,7 +151,10 @@ export class VectorLayer extends Layer {
     this.dataSource.ol.un(
       'addfeature',
       function(e) {
-        this.flash(e.feature);
+        if (this.visible) {
+          this.flash(e.feature);
+        }
+
       }.bind(this)
     );
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
- animation appear when layer is not visible  
- label is duplicate when animation is on

**What is the new behavior?**
no animation when layer is not visible and erase label from cloned style


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
