### PR TITLE
fix: set text center on toggle button

### DIFF
--- a/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.scss
@@ -1,12 +1,10 @@
 
-  .mat-button-toggle-checked {
-    font-weight: bold;
-  }
-
   .mat-button-toggle-group {
     margin: 5px 5px 5px 5px;
-    flex-wrap: wrap;
+  }
 
+  .mat-button-toggle {
+    width: 100%;
   }
 
   ::ng-deep .material-tooltip {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The toggle button sometimes turns to the right and not to the center when navigating the filter option. Sometimes you have to double click on the toggle button to activate or deactivate it.


**What is the new behavior?**
The toggle button remains centered on the navigation of the filter option. And navigation has become stable again.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
