### PR TITLE
Apply restrictions programatically to search sources

### DIFF
--- a/packages/geo/src/lib/query/shared/query-search-source.ts
+++ b/packages/geo/src/lib/query/shared/query-search-source.ts
@@ -20,6 +20,10 @@ export class QuerySearchSource extends SearchSource {
     return QuerySearchSource.id;
   }
 
+  getType(): string {
+    return QuerySearchSource.type;
+  }
+
   protected getDefaultOptions(): SearchSourceOptions {
     return {
       title: 'Carte'

--- a/packages/geo/src/lib/routing/routing-form/routing-form.component.ts
+++ b/packages/geo/src/lib/routing/routing-form/routing-form.component.ts
@@ -923,7 +923,7 @@ export class RoutingFormComponent implements OnInit, AfterViewInit, OnDestroy {
   private handleTermChanged(term: string) {
     if (term !== undefined || term.length !== 0) {
       const searchProposals = [];
-      const researches = this.searchService.search(term);
+      const researches = this.searchService.search(term, {searchType: 'Feature'});
       researches.map(res =>
         this.routesQueries$$.push(
           res.request.subscribe(results => {

--- a/packages/geo/src/lib/search/shared/search.service.ts
+++ b/packages/geo/src/lib/search/shared/search.service.ts
@@ -46,12 +46,19 @@ export class SearchService {
     }
 
     let sources = this.searchSourceService
-      .getEnabledSources()
-      .filter(sourceCanSearch)
+      .getEnabledSources();
 
-    if (options && options.searchType) {
-      sources = sources.filter(source => source.getType() === options.searchType )
+    if (options) {
+      if (options.getEnabledOnly || options.getEnabledOnly === undefined) {
+        sources = this.searchSourceService.getEnabledSources();
+      } else {
+        sources = this.searchSourceService.getSources();
+      }
+      if (options.searchType) {
+        sources = sources.filter(source => source.getType() === options.searchType);
+      }
     }
+    sources = sources.filter(sourceCanSearch);
     return this.searchSources(sources, term, options || {});
   }
 

--- a/packages/geo/src/lib/search/shared/search.service.ts
+++ b/packages/geo/src/lib/search/shared/search.service.ts
@@ -45,10 +45,13 @@ export class SearchService {
       console.log(response.message);
     }
 
-    const sources = this.searchSourceService
+    let sources = this.searchSourceService
       .getEnabledSources()
-      .filter(sourceCanSearch);
+      .filter(sourceCanSearch)
 
+    if (options && options.searchType) {
+      sources = sources.filter(source => source.getType() === options.searchType )
+    }
     return this.searchSources(sources, term, options || {});
   }
 

--- a/packages/geo/src/lib/search/shared/sources/coordinates.ts
+++ b/packages/geo/src/lib/search/shared/sources/coordinates.ts
@@ -48,6 +48,10 @@ export class CoordinatesReverseSearchSource extends SearchSource
     return CoordinatesReverseSearchSource.id;
   }
 
+  getType(): string {
+    return CoordinatesReverseSearchSource.type;
+  }
+
   protected getDefaultOptions(): SearchSourceOptions {
     return {
       title: 'igo.geo.search.coordinates.name',

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -66,6 +66,10 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
     return IChercheSearchSource.id;
   }
 
+  getType(): string {
+    return IChercheSearchSource.type;
+  }
+
   protected getDefaultOptions(): SearchSourceOptions {
     return {
       title: 'iCherche',
@@ -394,6 +398,10 @@ export class IChercheReverseSearchSource extends SearchSource
     return IChercheReverseSearchSource.id;
   }
 
+  getType(): string {
+    return IChercheReverseSearchSource.type;
+  }
+  
   protected getDefaultOptions(): SearchSourceOptions {
     return {
       title: 'Territoire (Géocodage inversé)',

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -401,7 +401,7 @@ export class IChercheReverseSearchSource extends SearchSource
   getType(): string {
     return IChercheReverseSearchSource.type;
   }
-  
+
   protected getDefaultOptions(): SearchSourceOptions {
     return {
       title: 'Territoire (Géocodage inversé)',

--- a/packages/geo/src/lib/search/shared/sources/ilayer.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.ts
@@ -82,6 +82,10 @@ export class ILayerSearchSource extends SearchSource implements TextSearch {
     return ILayerSearchSource.id;
   }
 
+  getType(): string {
+    return ILayerSearchSource.type;
+  }
+
   protected getDefaultOptions(): ILayerSearchSourceOptions {
     return {
       title: 'igo.geo.search.ilayer.name',

--- a/packages/geo/src/lib/search/shared/sources/nominatim.ts
+++ b/packages/geo/src/lib/search/shared/sources/nominatim.ts
@@ -30,6 +30,10 @@ export class NominatimSearchSource extends SearchSource implements TextSearch {
     return NominatimSearchSource.id;
   }
 
+  getType(): string {
+    return NominatimSearchSource.type;
+  }
+
   /*
    * Source : https://wiki.openstreetmap.org/wiki/Key:amenity
    */

--- a/packages/geo/src/lib/search/shared/sources/source.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/sources/source.interfaces.ts
@@ -29,6 +29,7 @@ export interface SettingOptions {
 export interface TextSearchOptions {
   params?: { [key: string]: string };
   searchType?: 'Feature' | 'Layer'; // refer to search.enum.ts SEARCH_TYPES = [FEATURE, LAYER];
+  getEnabledOnly?: boolean;
 }
 
 export interface ReverseSearchOptions {

--- a/packages/geo/src/lib/search/shared/sources/source.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/sources/source.interfaces.ts
@@ -28,6 +28,7 @@ export interface SettingOptions {
 
 export interface TextSearchOptions {
   params?: { [key: string]: string };
+  searchType?: 'Feature' | 'Layer'; // refer to search.enum.ts SEARCH_TYPES = [FEATURE, LAYER];
 }
 
 export interface ReverseSearchOptions {

--- a/packages/geo/src/lib/search/shared/sources/source.ts
+++ b/packages/geo/src/lib/search/shared/sources/source.ts
@@ -37,6 +37,13 @@ export class SearchSource {
   getId(): string {
     throw new Error('You have to implement the method "getId".');
   }
+  /**
+   * Get search source's type
+   * @returns Search source's type
+   */
+  getType(): string {
+    throw new Error('You have to implement the method "getType".');
+  }
 
   /**
    * Get search source's default options

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -88,6 +88,10 @@ export class StoredQueriesSearchSource extends SearchSource implements TextSearc
     return StoredQueriesSearchSource.id;
   }
 
+  getType(): string {
+    return StoredQueriesSearchSource.type;
+  }
+
   protected getDefaultOptions(): SearchSourceOptions {
     return {
       title: 'Stored Queries',
@@ -293,6 +297,10 @@ export class StoredQueriesReverseSearchSource extends SearchSource
 
   getId(): string {
     return StoredQueriesReverseSearchSource.id;
+  }
+
+  getType(): string {
+    return StoredQueriesReverseSearchSource.type;
   }
 
   protected getDefaultOptions(): SearchSourceOptions {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When a search is triggered programmatically, there is no way to control which source is used. 
The hashtag has been tested but not interesting because hashtag is linked to search result.


**What is the new behavior?**
adding an option property the filter the sources BEFORE the call. 

2 properties added to TextSearchOptions interface
```
  searchType?: 'Feature' | 'Layer'; // refer to search.enum.ts SEARCH_TYPES = [FEATURE, LAYER];
  getEnabledOnly?: boolean;
```
searchType refer the the search source type
getEnabledOnly is to bypass or not the user's defined enabled sources. 


Use https://github.com/infra-geo-ouverte/igo2-lib/pull/418/commits/fce7278844a4bd532801570ce126fdb21da64f83 as an example.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
