### PR TITLE
feat(geometry): when drawing or modifying a geometry, pressing space …

### DIFF
--- a/packages/geo/src/lib/geometry/shared/controls/modify.ts
+++ b/packages/geo/src/lib/geometry/shared/controls/modify.ts
@@ -22,7 +22,11 @@ import { unByKey } from 'ol/Observable';
 
 import { Subject, Subscription, fromEvent } from 'rxjs';
 
-import { addLinearRingToOlPolygon, createDrawHoleInteractionStyle } from '../geometry.utils';
+import {
+  addLinearRingToOlPolygon,
+  createDrawHoleInteractionStyle,
+  getMousePositionFromOlGeometryEvent
+} from '../geometry.utils';
 
 export interface ModifyControlOptions {
   source?: OlVectorSource;
@@ -68,6 +72,8 @@ export class ModifyControl {
   private onDrawEndKey: string;
   private onDrawKey: string;
   private olDrawInteractionIsActive: boolean = false;
+
+  private mousePosition: [number, number];
 
   private keyDown$$: Subscription;
   private drawKeyUp$$: Subscription;
@@ -273,8 +279,10 @@ export class ModifyControl {
     const olGeometry = event.features.item(0).getGeometry();
     this.start$.next(olGeometry);
     this.onModifyKey = olGeometry.on('change', (olGeometryEvent: OlGeometryEvent) => {
+      this.mousePosition = getMousePositionFromOlGeometryEvent(olGeometryEvent);
       this.changes$.next(olGeometryEvent.target);
     });
+    this.subscribeToKeyDown();
   }
 
   /**
@@ -286,6 +294,7 @@ export class ModifyControl {
       unByKey(this.onModifyKey);
     }
     this.end$.next(event.features.item(0).getGeometry());
+    this.unsubscribeToKeyDown();
   }
 
   /**
@@ -293,9 +302,13 @@ export class ModifyControl {
    */
   private subscribeToKeyDown() {
     this.keyDown$$ = fromEvent(document, 'keydown').subscribe((event: KeyboardEvent) => {
-      // On ESC key down, remove the last vertex
-      if (event.keyCode === 27 && this.olDrawInteractionIsActive === true) {
-        this.olDrawInteraction.removeLastPoint();
+      if (event.keyCode === 32) {
+        // On space bar, pan to the current mouse position
+        this.olMap.getView().animate({
+          center: this.mousePosition,
+          duration: 0
+        });
+        return;
       }
     });
   }

--- a/packages/geo/src/lib/geometry/shared/geometry.utils.ts
+++ b/packages/geo/src/lib/geometry/shared/geometry.utils.ts
@@ -2,6 +2,7 @@ import * as olstyle from 'ol/style';
 import OlLineString from 'ol/geom/LineString';
 import OlLinearRing from 'ol/geom/LinearRing';
 import OlPolygon from 'ol/geom/Polygon';
+import { GeometryEvent as OlGeometryEvent } from 'ol/geom/Geometry';
 import OlGeoJSON from 'ol/format/GeoJSON';
 import lineIntersect from '@turf/line-intersect';
 import { lineString } from '@turf/helpers';
@@ -140,4 +141,14 @@ export function sliceOlPolygon(olPolygon: OlPolygon, olSlicer: OlLineString): Ol
 export function addLinearRingToOlPolygon(olPolygon: OlPolygon, olLinearRing: OlLinearRing ): OlPolygon {
   // TODO: make some validation and support updating an existing linear ring
   olPolygon.appendLinearRing(olLinearRing);
+}
+
+export function getMousePositionFromOlGeometryEvent(
+  olEvent: OlGeometryEvent
+): [number, number] {
+  const olGeometry = olEvent.target;
+  if (olGeometry instanceof OlPolygon) {
+    return olGeometry.flatCoordinates.slice(-4, -2);
+  }
+  return olGeometry.flatCoordinates.slice(-2);
 }


### PR DESCRIPTION
…centers the map on the mouse position

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When drawing, the only way to move the map around is to pan.


**What is the new behavior?**
By pressing the space bar, the map is centered on the mouse position.


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
