### PR TITLE
ui(query): query results don't have a marker icon anymore

### DIFF
--- a/packages/geo/src/lib/search/shared/search.utils.ts
+++ b/packages/geo/src/lib/search/shared/search.utils.ts
@@ -39,7 +39,7 @@ export function featureToSearchResult(
       dataType: FEATURE,
       id: feature.meta.id as string,
       title: feature.meta.title,
-      icon: 'map-marker'
+      icon: undefined
     }
   };
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Query results could have marker icon (not in IGO because of the way query results are displayed)


**What is the new behavior?**
- They don't have a marker icon  anymore


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
