### PR TITLE
fix(modify): when drawing a hole and CTRL is released, finish drawing…

### DIFF
--- a/packages/geo/src/lib/geometry/shared/controls/modify.ts
+++ b/packages/geo/src/lib/geometry/shared/controls/modify.ts
@@ -435,16 +435,22 @@ export class ModifyControl {
    * Subscribe to CTRL key up to deactivate the draw control
    */
   private subscribeToDrawKeyUp() {
-    this.drawKeyUp$$ = fromEvent(document, 'keyup').subscribe((event: KeyboardEvent) => {
-      if (event.keyCode !== 17) { return; }
+    this.drawKeyUp$$ = fromEvent(document, 'keyup')
+      .subscribe((event: KeyboardEvent) => {
+        if (event.keyCode !== 17) {
+          return;
+        }
 
-      this.unsubscribeToDrawKeyUp();
-      this.subscribeToDrawKeyDown();
+        this.unsubscribeToDrawKeyUp();
+        this.unsubscribeToKeyDown();
+        this.deactivateDrawInteraction();
 
-      this.deactivateDrawInteraction();
-      this.activateModifyInteraction();
-      this.activateTranslateInteraction();
-    });
+        this.activateModifyInteraction();
+        this.activateTranslateInteraction();
+        this.subscribeToDrawKeyDown();
+
+        this.end$.next(this.getOlGeometry());
+      });
   }
 
   /**


### PR DESCRIPTION
… like the user double-clicked

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When drawing a hole and the CTRL key si released, the hole appears but 'drawend' is not triggered

**What is the new behavior?**
When drawing a hole and the CTRL key si released, the hole appears and 'drawend' is triggered as if the user double-clicked



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
