### PR TITLE
fix: display ogc-filter-button:

### DIFF
--- a/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filter-toggle-button/ogc-filter-toggle-button.component.scss
@@ -1,10 +1,11 @@
 
   .mat-button-toggle-group {
     margin: 5px 5px 5px 5px;
+    flex-wrap: wrap;
   }
 
   .mat-button-toggle {
-    width: 100%;
+    display: inline-flex;
   }
 
   ::ng-deep .material-tooltip {

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.scss
@@ -8,6 +8,10 @@
   display: inline-block;
 }
 
+.mat-list-item {
+  height: auto;
+}
+
 mat-icon.disabled {
   color: rgba(0,0,0,.38);
 }

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.scss
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.scss
@@ -34,6 +34,8 @@
 .igo-layer-button-group {
   float: right;
   padding: 0 $igo-list-item-padding;
+  display: contents; /* ie11: display: ruby-base; */
+  max-width: 100%;
 
   @include mobile {
     float: none;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The toggle button not displaying correctly in ie11.  The style flex option is not applied. (link with pullRequest https://github.com/infra-geo-ouverte/igo2-lib/pull/414)

**What is the new behavior?**
- The toggle button now displaying correctly in ie11.
- Space saving to around the pushButton
```
- fix ie11:
	.mat-button-toggle { display: inline-flex; }
	.igo-layer-button-group { max-width: 100%; }
- ajust style (space saving): .mat-list-item { height: auto; }
- ajust style (space saving): .igo-layer-button-group { contents; } /* Note: ie11 equivalent: display: ruby-base; ... no polyfills found */
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
