### PR TITLE
fix: collapse push button when the layer is not inResolutionRange

### DIFF
--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
@@ -32,8 +32,6 @@ export class OgcFilterButtonComponent {
   constructor() {}
 
   toggleOgcFilter() {
-    if (this.layer.isInResolutionsRange) {
       this.ogcFilterCollapse = !this.ogcFilterCollapse;
-    }
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
the collapse is not available on the push button when the layer is not inResolutionRange


**What is the new behavior?**
to remove the deactivation of the collapse on the push button when the layer is not inResolutionRange


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
