### PR TITLE
fix(integration.map.tool) add button when track a feature

### DIFF
--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -24,6 +24,7 @@
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-download-button [layer]="layer"></igo-download-button>
         <igo-ogc-filter-button [ogcFiltersInLayers]="true" [layer]="layer"></igo-ogc-filter-button>
+        <igo-track-feature-button [layer]="layer" [trackFeature]="true"></igo-track-feature-button>
       </ng-template>
 
     </igo-layer-list>

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -12,6 +12,7 @@
     <igo-download-button [layer]="layer"></igo-download-button>
     <igo-metadata-button [layer]="layer"></igo-metadata-button>
     <igo-ogc-filter-button [ogcFiltersInLayers]="ogcFiltersInLayers" [layer]="layer"></igo-ogc-filter-button>
+    <igo-track-feature-button [trackFeature]="true" [layer]="layer"></igo-track-feature-button>
   </ng-template>
 
 </igo-layer-list>

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -15,6 +15,7 @@
         <igo-download-button [layer]="layer"></igo-download-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-ogc-filter-button [ogcFiltersInLayers]="ogcFiltersInLayers" [layer]="layer"></igo-ogc-filter-button>
+        <igo-track-feature-button [trackFeature]="true" [layer]="layer"></igo-track-feature-button>
       </ng-template>
 
     </igo-layer-list>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When tracking a feature with #422 the button to stop tracking is not in the layer's option


**What is the new behavior?**
the button is there


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
