### PR TITLE
WMS datasource url containing ? crash getlegendgraphic recomposition

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -187,8 +187,9 @@ export class WMSDataSource extends DataSource {
     }
 
     legend = layers.map((layer: string) => {
+      const separator = baseUrl.match( /\?/m) ? '&' : '?'
       return {
-        url: `${baseUrl}?${params.join('&')}&LAYER=${layer}`,
+        url: `${baseUrl}${separator}${params.join('&')}&LAYER=${layer}`,
         title: layers.length > 1 ? layer : undefined,
         currentStyle: !style ? undefined : style as string
       };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Url containing ? inside their url cause getlegendgraphics recomposition to fail by putting 2 ? into the composed url. 

exemple for mapserver
http://mydomain/cgi-bin/mapserv?map=/home/www/mapserverstuff/mymapfile.map


**What is the new behavior?**
If the defined url contain a ?, the url/param separator is now a & instead of a ?


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
