### PR TITLE
feat(map): normalize the dpi to 96

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -183,10 +183,7 @@ export class WMSDataSource extends DataSource {
       'SERVICE=wms',
       'FORMAT=image/png',
       'SLD_VERSION=1.1.0',
-      `VERSION=${sourceParams.version || '1.3.0'}`,
-      `DPI=${sourceParams.DPI}`,
-      `MAP_RESOLUTION=${sourceParams.MAP_RESOLUTION}`,
-      `FORMAT_OPTIONS=${sourceParams.FORMAT_OPTIONS}`
+      `VERSION=${sourceParams.version || '1.3.0'}`
     ];
     if (style !== undefined) {
       params.push(`STYLE=${style}`);

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -10,7 +10,6 @@ import { OgcFilterableDataSourceOptions } from '../../../filter/shared/ogc-filte
 import { QueryHtmlTarget } from '../../../query/shared/query.enums';
 import {
   formatWFSQueryString,
-  defaultWfsVersion,
   checkWfsParams,
   defaultFieldNameGeometry
 } from './wms-wfs.utils';
@@ -73,6 +72,11 @@ export class WMSDataSource extends DataSource {
       sourceParams.info_format = sourceParams.INFO_FORMAT;
     }
 
+    const dpi = sourceParams.dpi || 96;
+    sourceParams.DPI = dpi;
+    sourceParams.MAP_RESOLUTION = dpi;
+    sourceParams.FORMAT_OPTIONS = 'dpi:' + dpi;
+
     if (options.refreshIntervalSec && options.refreshIntervalSec > 0) {
       setInterval(() => {
         this.refresh();
@@ -93,6 +97,7 @@ export class WMSDataSource extends DataSource {
         dynamicUrl: this.buildDynamicDownloadUrlFromParamsWFS(options)
       });
     } //  ####   END  if paramsWFS
+
     if (!options.sourceFields || options.sourceFields.length === 0) {
       options.sourceFields = [];
     } else {
@@ -118,6 +123,7 @@ export class WMSDataSource extends DataSource {
         ? false
         : true;
     }
+
     if (
       sourceParams.layers.split(',').length > 1 &&
       initOgcFilters &&
@@ -177,7 +183,10 @@ export class WMSDataSource extends DataSource {
       'SERVICE=wms',
       'FORMAT=image/png',
       'SLD_VERSION=1.1.0',
-      `VERSION=${sourceParams.version || '1.3.0'}`
+      `VERSION=${sourceParams.version || '1.3.0'}`,
+      `DPI=${sourceParams.DPI}`,
+      `MAP_RESOLUTION=${sourceParams.MAP_RESOLUTION}`,
+      `FORMAT_OPTIONS=${sourceParams.FORMAT_OPTIONS}`
     ];
     if (style !== undefined) {
       params.push(`STYLE=${style}`);
@@ -187,7 +196,7 @@ export class WMSDataSource extends DataSource {
     }
 
     legend = layers.map((layer: string) => {
-      const separator = baseUrl.match( /\?/m) ? '&' : '?'
+      const separator = baseUrl.match(/\?/) ? '&' : '?';
       return {
         url: `${baseUrl}${separator}${params.join('&')}&LAYER=${layer}`,
         title: layers.length > 1 ? layer : undefined,

--- a/packages/geo/src/lib/datasource/utils/esri-style-generator.ts
+++ b/packages/geo/src/lib/datasource/utils/esri-style-generator.ts
@@ -26,9 +26,9 @@ export class EsriStyleGenerator {
   }
 
   static _getResolutionForScale(scale, units) {
-    const dpi = 25.4 / 0.28;
+    const dpi = 96;
     const mpu = olproj.METERS_PER_UNIT[units];
-    const inchesPerMeter = 39.37;
+    const inchesPerMeter = 39.3701;
     return parseFloat(scale) / (mpu * inchesPerMeter * dpi);
   }
 

--- a/packages/geo/src/lib/layer/shared/layers/layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.ts
@@ -79,7 +79,9 @@ export abstract class Layer {
     return resolution >= minResolution && resolution <= maxResolution;
   }
 
-  get showInLayerList(): boolean { return this.options.showInLayerList !== false; }
+  get showInLayerList(): boolean {
+    return this.options.showInLayerList !== false;
+  }
 
   constructor(options: LayerOptions) {
     this.options = options;
@@ -98,13 +100,18 @@ export abstract class Layer {
     this.opacity =
       this.options.opacity === undefined ? 1 : this.options.opacity;
 
-    if (this.options.legendOptions && (this.options.legendOptions.url || this.options.legendOptions.html)) {
+    if (
+      this.options.legendOptions &&
+      (this.options.legendOptions.url || this.options.legendOptions.html)
+    ) {
       this.legend = this.dataSource.setLegend(this.options.legendOptions);
     }
 
-    this.legendCollapsed = this.options.legendOptions ?
-                            this.options.legendOptions.collapsed ? this.options.legendOptions.collapsed : true :
-                            true;
+    this.legendCollapsed = this.options.legendOptions
+      ? this.options.legendOptions.collapsed
+        ? this.options.legendOptions.collapsed
+        : true
+      : true;
 
     this.ol.set('_layer', this, true);
   }

--- a/packages/geo/src/lib/map/shared/controllers/view.ts
+++ b/packages/geo/src/lib/map/shared/controllers/view.ts
@@ -145,7 +145,7 @@ export class MapViewController extends MapController {
    * @param dpi Dot per inches
    * @returns View scale
    */
-  getScale(dpi = 72) {
+  getScale(dpi = 96) {
     return getScaleFromResolution(
       this.getResolution(),
       this.getOlProjection().getUnits(),

--- a/packages/geo/src/lib/map/shared/map.utils.ts
+++ b/packages/geo/src/lib/map/shared/map.utils.ts
@@ -284,8 +284,9 @@ export function formatScale(scale) {
  * @param dpi DPI
  * @returns Resolution
  */
-export function getResolutionFromScale(scale: number, dpi: number = 72): number {
-  return scale / (39.37 * dpi);
+export function getResolutionFromScale(scale: number, dpi: number = 96): number {
+  const inchesPerMeter = 39.3701;
+  return scale / (inchesPerMeter * dpi);
 }
 
 /**
@@ -293,8 +294,9 @@ export function getResolutionFromScale(scale: number, dpi: number = 72): number 
  * @param Scale denom
  * @returns Resolution
  */
-export function getScaleFromResolution(resolution: number, unit: string = 'm', dpi: number = 72): number {
-  return resolution * olproj.METERS_PER_UNIT[unit] * 39.37 * dpi;
+export function getScaleFromResolution(resolution: number, unit: string = 'm', dpi: number = 96): number {
+  const inchesPerMeter = 39.3701;
+  return resolution * olproj.METERS_PER_UNIT[unit] * inchesPerMeter * dpi;
 }
 
 /**


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

The dpi of the layers depends on the data source:
- WMS 1.3 standard specifies the pixel width : 0.28 mm. That value gives a resolution of 25.4/0.28 = 90.71 dpi approximately. 
- Only GeoServer respect this standard
- MapServer by default has a dpi of 72 but can be modified in the mapfiles
- ArcGIS Server / Qgis Server by default has a dpi of 96

Some visibility issues are present due to poor resolution.

**What is the new behavior?**

Popular WMS servers extend WMS service with dpi parameters:
- MapServer with MAP_RESOLUTION=value
- GeoServer with FORMAT_OPTIONS=dpi:value
- ArcGIS Server / QGIS Server with DPI=value

Common GIS softwares works with a resolution of 96 dpi. For example, QGIS adds all those parameters at the end of WMS/GetMap queries.

IGO is now doing the same way.
