### PR TITLE
fix(geometry): properly destroy geometry input

### DIFF
--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field-input.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field-input.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { NgControl, ControlValueAccessor } from '@angular/forms';
 
-import { Subject, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 
 import * as OlStyle from 'ol/style';
 import OlGeoJSON from 'ol/format/GeoJSON';

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field-input.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field-input.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { NgControl, ControlValueAccessor } from '@angular/forms';
 
-import { Subscription } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 
 import * as OlStyle from 'ol/style';
 import OlGeoJSON from 'ol/format/GeoJSON';
@@ -123,8 +123,9 @@ export class GeometryFormFieldInputComponent implements OnInit, OnDestroy, Contr
    */
   @Input()
   set value(value: GeoJSONGeometry) {
+    this._value = value;
+
     if (this.ready === false) {
-      this._value = value;
       return;
     }
 
@@ -134,7 +135,6 @@ export class GeometryFormFieldInputComponent implements OnInit, OnDestroy, Contr
       this.olOverlaySource.clear();
     }
 
-    this._value = value;
     this.onChange(value);
     this.toggleControl();
     this.cdRef.detectChanges();
@@ -179,10 +179,12 @@ export class GeometryFormFieldInputComponent implements OnInit, OnDestroy, Contr
     this.createMeasureTooltip();
     this.createDrawControl();
     this.createModifyControl();
+
     if (this.value) {
       this.addGeoJSONToOverlay(this.value);
     }
     this.toggleControl();
+
     this.ready = true;
   }
 
@@ -191,6 +193,12 @@ export class GeometryFormFieldInputComponent implements OnInit, OnDestroy, Contr
    * @internal
    */
   ngOnDestroy() {
+    // This is mandatory when the form control is reused after
+    // this component has been destroyed. It seems like the control
+    // keeps a reference to this component even after it's destroyed
+    // and it attempts to set it's value
+    this.ready = false;
+
     this.deactivateControl();
     this.olOverlaySource.clear();
     this.map.ol.removeLayer(this.olOverlayLayer);
@@ -267,6 +275,7 @@ export class GeometryFormFieldInputComponent implements OnInit, OnDestroy, Contr
    */
   private toggleControl() {
     this.deactivateControl();
+
     if (!this.value && this.geometryType) {
       this.activateControl(this.drawControl);
     } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When this component is destroyed, there is still a reference to it somewhere in the angular forms core. Reusing the same form control after that yields to the value being set twice. This is not a common use case.


**What is the new behavior?**
On destroy, set ready to false to avoid any side-effect.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
