### PR TITLE
Unify filter access

### DIFF
--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -24,7 +24,7 @@
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-download-button [layer]="layer"></igo-download-button>
         <igo-ogc-filter-button [header]="true" [layer]="layer"></igo-ogc-filter-button>
-        <igo-time-filter-button [layer]="layer"></igo-time-filter-button>
+        <igo-time-filter-button [header]="true" [layer]="layer"></igo-time-filter-button>
         <igo-track-feature-button [layer]="layer" [trackFeature]="true"></igo-track-feature-button>
       </ng-template>
 

--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -23,7 +23,7 @@
       <ng-template #igoLayerItemToolbar let-layer="layer">
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-download-button [layer]="layer"></igo-download-button>
-        <igo-ogc-filter-button [ogcFiltersInLayers]="true" [layer]="layer"></igo-ogc-filter-button>
+        <igo-ogc-filter-button [header]="true" [layer]="layer"></igo-ogc-filter-button>
         <igo-time-filter-button [layer]="layer"></igo-time-filter-button>
         <igo-track-feature-button [layer]="layer" [trackFeature]="true"></igo-track-feature-button>
       </ng-template>

--- a/demo/src/app/geo/layer/layer.component.html
+++ b/demo/src/app/geo/layer/layer.component.html
@@ -24,6 +24,7 @@
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-download-button [layer]="layer"></igo-download-button>
         <igo-ogc-filter-button [ogcFiltersInLayers]="true" [layer]="layer"></igo-ogc-filter-button>
+        <igo-time-filter-button [layer]="layer"></igo-time-filter-button>
         <igo-track-feature-button [layer]="layer" [trackFeature]="true"></igo-track-feature-button>
       </ng-template>
 

--- a/packages/geo/src/lib/filter/filter.module.ts
+++ b/packages/geo/src/lib/filter/filter.module.ts
@@ -34,6 +34,7 @@ import {
 
 import { FilterableDataSourcePipe } from './shared/filterable-datasource.pipe';
 import { IgoLayerModule } from '../layer/layer.module';
+import { TimeFilterButtonComponent } from './time-filter-button/time-filter-button.component';
 import { TimeFilterFormComponent } from './time-filter-form/time-filter-form.component';
 import { TimeFilterItemComponent } from './time-filter-item/time-filter-item.component';
 import { TimeFilterListBindingDirective } from './time-filter-list/time-filter-list-binding.directive';
@@ -79,6 +80,7 @@ import { OgcFilterToggleButtonComponent } from './ogc-filter-toggle-button/ogc-f
   ],
   exports: [
     FilterableDataSourcePipe,
+    TimeFilterButtonComponent,
     TimeFilterFormComponent,
     TimeFilterItemComponent,
     TimeFilterListComponent,
@@ -93,6 +95,7 @@ import { OgcFilterToggleButtonComponent } from './ogc-filter-toggle-button/ogc-f
   ],
   declarations: [
     FilterableDataSourcePipe,
+    TimeFilterButtonComponent,
     TimeFilterFormComponent,
     TimeFilterItemComponent,
     TimeFilterListComponent,

--- a/packages/geo/src/lib/filter/filter.module.ts
+++ b/packages/geo/src/lib/filter/filter.module.ts
@@ -33,6 +33,7 @@ import {
 } from '@igo2/common';
 
 import { FilterableDataSourcePipe } from './shared/filterable-datasource.pipe';
+import { IgoLayerModule } from '../layer/layer.module';
 import { TimeFilterFormComponent } from './time-filter-form/time-filter-form.component';
 import { TimeFilterItemComponent } from './time-filter-item/time-filter-item.component';
 import { TimeFilterListBindingDirective } from './time-filter-list/time-filter-list-binding.directive';
@@ -71,6 +72,7 @@ import { OgcFilterToggleButtonComponent } from './ogc-filter-toggle-button/ogc-f
     MatDatetimepickerModule,
     MatNativeDatetimeModule,
     IgoLanguageModule,
+    IgoLayerModule,
     IgoCollapsibleModule,
     IgoListModule,
     IgoKeyValueModule

--- a/packages/geo/src/lib/filter/index.ts
+++ b/packages/geo/src/lib/filter/index.ts
@@ -8,3 +8,4 @@ export * from './ogc-filterable-list';
 export * from './ogc-filter-form';
 export * from './ogc-filter-toggle-button';
 export * from './ogc-filter-button';
+export * from './time-filter-button';

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.html
@@ -7,8 +7,7 @@
   [matTooltip]="'igo.geo.filter.filterBy' | translate"
   [color]="color"
   (click)="toggleOgcFilter()">
-  <mat-icon
-    [ngClass]='{disabled: !layer.isInResolutionsRange}'svgIcon="filter"></mat-icon>
+  <mat-icon svgIcon="filter"></mat-icon>
 </button>
 
 <div #ogcFilter class="igo-layer-actions-container"

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.html
@@ -1,4 +1,4 @@
-<button *ngIf="ogcFiltersInLayers && options.ogcFilters && (options.ogcFilters.enabled
+<button *ngIf="header && options.ogcFilters && (options.ogcFilters.enabled
 && options.ogcFilters.editable)"
   mat-icon-button
   collapsibleButton
@@ -16,7 +16,7 @@
   <igo-ogc-filterable-item
     *ngIf="ogcFilterCollapse && options.ogcFilters.enabled"
     igoListItem
-    [ogcFiltersHeaderShown]="false"
+    [header]="false"
     [map]="layer.map"
     [layer]="layer">
   </igo-ogc-filterable-item>

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, OnInit } from '@angular/core';
 
 import { Layer } from '../../layer/shared/layers/layer';
 import { IgoMap } from '../../map';
@@ -10,7 +10,9 @@ import { OgcFilterableDataSourceOptions } from '../shared/ogc-filter.interface';
   styleUrls: ['./ogc-filter-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OgcFilterButtonComponent {
+export class OgcFilterButtonComponent implements OnInit {
+
+  public options: OgcFilterableDataSourceOptions;
 
   @Input() layer: Layer;
 
@@ -20,16 +22,13 @@ export class OgcFilterButtonComponent {
 
   @Input() ogcFiltersInLayers: boolean;
 
-  get options(): OgcFilterableDataSourceOptions {
-    if (!this.layer) {
-      return;
-    }
-    return this.layer.dataSource.options;
-  }
-
   public ogcFilterCollapse = false;
 
   constructor() {}
+
+  ngOnInit() {
+    this.options = this.layer.dataSource.options as OgcFilterableDataSourceOptions;
+  }
 
   toggleOgcFilter() {
       this.ogcFilterCollapse = !this.ogcFilterCollapse;

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
@@ -20,7 +20,7 @@ export class OgcFilterButtonComponent implements OnInit {
 
   @Input() color: string = 'primary';
 
-  @Input() ogcFiltersInLayers: boolean;
+  @Input() header: boolean;
 
   public ogcFilterCollapse = false;
 

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
@@ -1,7 +1,7 @@
 <mat-list-item>
 
   <mat-icon 
-    *ngIf="ogcFiltersHeaderShown" 
+    *ngIf="header" 
     class="igo-chevron" 
     mat-list-avatar 
     igoCollapse [target]="ogcFilters"
@@ -9,10 +9,10 @@
     (click)="toggleFiltersCollapsed()" 
     svgIcon="chevron-up">
   </mat-icon>
-  <h4 (click)="toggleLegendOnClick()" *ngIf="ogcFiltersHeaderShown" [ngStyle]="{'cursor': filtersCollapsed ? 'default' : 'pointer'}" matLine [matTooltip]="layer.title" matTooltipShowDelay="500">{{layer.title}}</h4>
-  <h4 *ngIf="!ogcFiltersHeaderShown" matLine></h4>
+  <h4 (click)="toggleLegendOnClick()" *ngIf="header" [ngStyle]="{'cursor': filtersCollapsed ? 'default' : 'pointer'}" matLine [matTooltip]="layer.title" matTooltipShowDelay="500">{{layer.title}}</h4>
+  <h4 *ngIf="!header" matLine></h4>
 
-  <span *ngIf="downloadable && ogcFiltersHeaderShown">
+  <span *ngIf="downloadable && header">
     <button mat-icon-button tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.geo.download.action' | translate"
       [color]="color" (click)="openDownload()">
       <mat-icon svgIcon="download"></mat-icon>
@@ -22,14 +22,14 @@
     [matTooltip]="'igo.geo.filter.addFilter' | translate" [color]="color" (click)="addFilterToSequence()">
     <mat-icon svgIcon="plus"></mat-icon>
   </button>
-  <button *ngIf="!layer.visible && ogcFiltersHeaderShown" mat-icon-button tooltip-position="below"
+  <button *ngIf="!layer.visible && header" mat-icon-button tooltip-position="below"
     matTooltipShowDelay="500" [matTooltip]="'igo.geo.layer.showLayer' | translate" color="warn" (click)="setVisible()">
     <mat-icon svgIcon="alert-circle-outline"></mat-icon>
   </button>
 </mat-list-item>
 
 <div #ogcFilters class="igo-datasource-filters-container">
-    <div *ngIf="ogcFiltersHeaderShown" #legend class="igo-layer-legend-container">
+    <div *ngIf="header" #legend class="igo-layer-legend-container">
       <igo-layer-legend *ngIf="showLegend$ | async" [layer]="layer">
       </igo-layer-legend>
     </div>

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.html
@@ -1,8 +1,15 @@
 <mat-list-item>
 
-  <mat-icon *ngIf="ogcFiltersHeaderShown" class="igo-chevron" mat-list-avatar igoCollapse [target]="ogcFilters" [collapsed]="filtersCollapsed" svgIcon="chevron-up">
+  <mat-icon 
+    *ngIf="ogcFiltersHeaderShown" 
+    class="igo-chevron" 
+    mat-list-avatar 
+    igoCollapse [target]="ogcFilters"
+    [collapsed]="filtersCollapsed"
+    (click)="toggleFiltersCollapsed()" 
+    svgIcon="chevron-up">
   </mat-icon>
-  <h4 *ngIf="ogcFiltersHeaderShown" matLine [matTooltip]="layer.title" matTooltipShowDelay="500">{{layer.title}}</h4>
+  <h4 (click)="toggleLegendOnClick()" *ngIf="ogcFiltersHeaderShown" [ngStyle]="{'cursor': filtersCollapsed ? 'default' : 'pointer'}" matLine [matTooltip]="layer.title" matTooltipShowDelay="500">{{layer.title}}</h4>
   <h4 *ngIf="!ogcFiltersHeaderShown" matLine></h4>
 
   <span *ngIf="downloadable && ogcFiltersHeaderShown">
@@ -22,6 +29,10 @@
 </mat-list-item>
 
 <div #ogcFilters class="igo-datasource-filters-container">
+    <div *ngIf="ogcFiltersHeaderShown" #legend class="igo-layer-legend-container">
+      <igo-layer-legend *ngIf="showLegend$ | async" [layer]="layer">
+      </igo-layer-legend>
+    </div>
   <igo-ogc-filterable-form [datasource]="datasource" [map]="map" [refreshFilters]="refreshFunc">
   </igo-ogc-filterable-form>
 

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.scss
@@ -12,6 +12,11 @@
   height: auto;
 }
 
+.igo-layer-legend-container {
+  padding-left: 1.125em;
+  width: calc(100% - 18px);
+}
+
 mat-icon.disabled {
   color: rgba(0,0,0,.38);
 }

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -15,6 +15,7 @@ import {
 import { OGCFilterService } from '../shared/ogc-filter.service';
 import { IgoMap } from '../../map';
 import { OgcFilterWriter } from '../shared/ogc-filter';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'igo-ogc-filterable-item',
@@ -29,6 +30,7 @@ export class OgcFilterableItemComponent implements OnInit {
   public filtersAreEditable = true;
   public filtersCollapsed = true;
   public hasPushButton: boolean = false;
+  showLegend$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   @Input() layer: Layer;
 
@@ -229,5 +231,20 @@ export class OgcFilterableItemComponent implements OnInit {
     if (isAdvancedOgcFilters.checked) {
       this.refreshFilters(true);
     }
+  }
+
+  private toggleLegend(collapsed: boolean) {
+    this.layer.legendCollapsed = collapsed;
+    this.showLegend$.next(!collapsed);
+  }
+
+  toggleLegendOnClick() {
+    if (!this.filtersCollapsed) {
+      this.toggleLegend(this.showLegend$.value);
+    }
+  }
+
+  toggleFiltersCollapsed() {
+    this.filtersCollapsed = !this.filtersCollapsed;
   }
 }

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -36,6 +36,8 @@ export class OgcFilterableItemComponent implements OnInit {
 
   @Input() map: IgoMap;
 
+  @Input() header: boolean = true;
+  
   get refreshFunc() {
     return this.refreshFilters.bind(this);
   }
@@ -43,8 +45,6 @@ export class OgcFilterableItemComponent implements OnInit {
   get datasource(): OgcFilterableDataSource {
     return this.layer.dataSource as OgcFilterableDataSource;
   }
-
-  @Input() ogcFiltersHeaderShown: boolean = true;
 
   get downloadable() {
     return (this.datasource.options as any).download;

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -44,7 +44,7 @@ export class OgcFilterableItemComponent implements OnInit {
     return this.layer.dataSource as OgcFilterableDataSource;
   }
 
-  @Input() ogcFiltersHeaderShown: boolean;
+  @Input() ogcFiltersHeaderShown: boolean = true;
 
   get downloadable() {
     return (this.datasource.options as any).download;

--- a/packages/geo/src/lib/filter/ogc-filterable-list/ogc-filterable-list.component.html
+++ b/packages/geo/src/lib/filter/ogc-filterable-list/ogc-filterable-list.component.html
@@ -1,6 +1,6 @@
 <igo-list [navigation]="false" [selection]="false">
   <ng-template ngFor let-layer [ngForOf]="layers | filterableDataSource: 'ogc'">
-    <igo-ogc-filterable-item igoListItem [ogcFiltersHeaderShown]="true" [layer]="layer" 
+    <igo-ogc-filterable-item igoListItem [header]="true" [layer]="layer" 
     [map]="layer.map" ></igo-ogc-filterable-item>
   </ng-template>
 </igo-list>

--- a/packages/geo/src/lib/filter/time-filter-button/index.ts
+++ b/packages/geo/src/lib/filter/time-filter-button/index.ts
@@ -1,0 +1,1 @@
+export * from './time-filter-button.component';

--- a/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.html
+++ b/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.html
@@ -1,0 +1,20 @@
+<button *ngIf="timeFilterInLayers && options.timeFilterable && options.timeFilter"
+  mat-icon-button
+  collapsibleButton
+  tooltip-position="below"
+  matTooltipShowDelay="500"
+  [matTooltip]="'igo.geo.filter.filterBy' | translate"
+  [color]="color"
+  (click)="toggleTimeFilter()">
+  <mat-icon svgIcon="history"></mat-icon>
+</button>
+
+<div #ogcFilter class="igo-layer-actions-container"
+*ngIf="timeFilterInLayers && options.timeFilterable && options.timeFilter">
+  <igo-time-filter-item
+    *ngIf="timeFilterCollapse && options.timeFilter"
+    igoListItem
+    [timeFiltersHeaderShown]="false"
+    [layer]="layer">
+  </igo-time-filter-item>
+</div>

--- a/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.html
+++ b/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.html
@@ -1,4 +1,4 @@
-<button *ngIf="timeFilterInLayers && options.timeFilterable && options.timeFilter"
+<button *ngIf="header && options.timeFilterable && options.timeFilter"
   mat-icon-button
   collapsibleButton
   tooltip-position="below"
@@ -10,11 +10,11 @@
 </button>
 
 <div #ogcFilter class="igo-layer-actions-container"
-*ngIf="timeFilterInLayers && options.timeFilterable && options.timeFilter">
+*ngIf="header && options.timeFilterable && options.timeFilter">
   <igo-time-filter-item
     *ngIf="timeFilterCollapse && options.timeFilter"
     igoListItem
-    [timeFiltersHeaderShown]="false"
+    [header]="false"
     [layer]="layer">
   </igo-time-filter-item>
 </div>

--- a/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.ts
@@ -21,7 +21,7 @@ export class TimeFilterButtonComponent implements OnInit {
 
   @Input() color: string = 'primary';
 
-  @Input() timeFilterInLayers: boolean = true;
+  @Input() header: boolean = true;
 
   public timeFilterCollapse = false;
 

--- a/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input, ChangeDetectionStrategy, OnInit } from '@angular/core';
+
+import { Layer } from '../../layer/shared/layers/layer';
+import { IgoMap } from '../../map';
+import { TimeFilterableDataSourceOptions } from '../shared/time-filter.interface';
+import { WMSDataSourceOptions } from '../../datasource/shared/datasources/wms-datasource.interface';
+
+@Component({
+  selector: 'igo-time-filter-button',
+  templateUrl: './time-filter-button.component.html',
+  styleUrls: ['./time-filter-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TimeFilterButtonComponent implements OnInit {
+
+  public options: TimeFilterableDataSourceOptions;
+
+  @Input() layer: Layer;
+
+  @Input() map: IgoMap;
+
+  @Input() color: string = 'primary';
+
+  @Input() timeFilterInLayers: boolean = true;
+
+  public timeFilterCollapse = false;
+
+  constructor() {}
+
+  ngOnInit() {
+    this.options = this.layer.dataSource.options as WMSDataSourceOptions;
+  }
+
+  toggleTimeFilter() {
+      this.timeFilterCollapse = !this.timeFilterCollapse;
+  }
+}

--- a/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.html
+++ b/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.html
@@ -99,10 +99,6 @@
     <span>{{endYear}}</span>
     <p *ngIf= "options.enabled" class="date-below">{{year}}</p>
     <div #actions class="igo-layer-actions-container">
-      <button *ngIf="!layer.visible" mat-icon-button tooltip-position="below" matTooltipShowDelay="500"
-      [matTooltip]="'igo.geo.layer.showLayer' | translate" color="warn" (click)="setVisible($event)">
-        <mat-icon svgIcon="alert-circle"></mat-icon>
-      </button>
       <mat-slide-toggle (change)="toggleFilterState()" tooltip-position="below" matTooltipShowDelay="500"
         [matTooltip]="'igo.geo.filter.toggleFilterState' | translate" [color]="color" [checked]="options.enabled"
         [disabled]="!layer.visible">

--- a/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.ts
@@ -489,8 +489,4 @@ export class TimeFilterFormComponent implements OnInit {
   getStepDefinition(step) {
     return moment.duration(step).asMilliseconds();
   }
-
-  setVisible(event: any) {
-    this.layer.visible = true;
-  }
 }

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.html
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.html
@@ -1,4 +1,4 @@
-<mat-list-item>
+<mat-list-item *ngIf="timeFiltersHeaderShown">
   <mat-icon
     class="igo-chevron"
     mat-list-avatar

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.html
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.html
@@ -4,13 +4,24 @@
     mat-list-avatar
     igoCollapse
     [target]="filters"
-    [collapsed]="false"
+    [collapsed]="filtersCollapsed"
+    (click)="toggleFiltersCollapsed()"
     svgIcon="chevron-up" >
   </mat-icon>
-  <h4 matLine>{{layer.title}}</h4>
+  <h4 (click)="toggleLegendOnClick()" [ngStyle]="{'cursor': filtersCollapsed ? 'default' : 'pointer'}"  matLine>{{layer.title}}</h4>
+  
+  <button *ngIf="!layer.visible" mat-icon-button tooltip-position="below" matTooltipShowDelay="500"
+    [matTooltip]="'igo.geo.layer.showLayer' | translate" color="warn" (click)="setVisible()">
+    <mat-icon svgIcon="alert-circle-outline"></mat-icon>
+  </button>
+
 </mat-list-item>
 
 <div #filters class="igo-datasource-filters-container">
+  <div #legend class="igo-layer-legend-container">
+    <igo-layer-legend *ngIf="showLegend$ | async" [layer]="layer">
+    </igo-layer-legend>
+  </div>
   <igo-time-filter-form
     [layer]= "layer"
     [options]="datasource.options.timeFilter"

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.html
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.html
@@ -1,4 +1,4 @@
-<mat-list-item *ngIf="timeFiltersHeaderShown">
+<mat-list-item *ngIf="header">
   <mat-icon
     class="igo-chevron"
     mat-list-avatar

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.scss
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.scss
@@ -7,3 +7,8 @@
   width: 100%;
   display: inline-block;
 }
+
+.igo-layer-legend-container {
+  padding-left: 1.125em;
+  width: calc(100% - 18px);
+}

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
@@ -16,7 +16,7 @@ export class TimeFilterItemComponent {
 
   filtersCollapsed: boolean = false;
 
-  @Input() timeFiltersHeaderShown: boolean = true;
+  @Input() header: boolean = true;
 
   @Input() layer: Layer;
 

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
@@ -3,6 +3,7 @@ import { Component, Input } from '@angular/core';
 import { Layer } from '../../layer/shared/layers/layer';
 import { TimeFilterableDataSource } from '../shared/time-filter.interface';
 import { TimeFilterService } from '../shared/time-filter.service';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'igo-time-filter-item',
@@ -10,6 +11,11 @@ import { TimeFilterService } from '../shared/time-filter.service';
   styleUrls: ['./time-filter-item.component.scss']
 })
 export class TimeFilterItemComponent {
+
+  showLegend$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+
+  @Input() filtersCollapsed: boolean = false;
+
   @Input() layer: Layer;
 
   get datasource(): TimeFilterableDataSource {
@@ -23,5 +29,24 @@ export class TimeFilterItemComponent {
 
   handleDateChange(date: Date | [Date, Date]) {
     this.timeFilterService.filterByDate(this.datasource, date);
+  }
+
+  private toggleLegend(collapsed: boolean) {
+    this.layer.legendCollapsed = collapsed;
+    this.showLegend$.next(!collapsed);
+  }
+
+  toggleLegendOnClick() {
+    if (!this.filtersCollapsed) {
+      this.toggleLegend(this.showLegend$.value);
+    }
+  }
+
+  public setVisible() {
+    this.layer.visible = true;
+  }
+
+  toggleFiltersCollapsed() {
+    this.filtersCollapsed = !this.filtersCollapsed;
   }
 }

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
@@ -14,7 +14,9 @@ export class TimeFilterItemComponent {
 
   showLegend$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
-  @Input() filtersCollapsed: boolean = false;
+  filtersCollapsed: boolean = false;
+
+  @Input() timeFiltersHeaderShown: boolean = true;
 
   @Input() layer: Layer;
 

--- a/packages/geo/src/lib/filter/time-filter-list/time-filter-list.component.html
+++ b/packages/geo/src/lib/filter/time-filter-list/time-filter-list.component.html
@@ -1,5 +1,5 @@
 <igo-list [navigation]="false" [selection]="false">
   <ng-template ngFor let-layer [ngForOf]="layers | filterableDataSource: 'time'">
-    <igo-time-filter-item [timeFiltersHeaderShown]="true" igoListItem [layer]="layer"></igo-time-filter-item>
+    <igo-time-filter-item [header]="true" igoListItem [layer]="layer"></igo-time-filter-item>
   </ng-template>
 </igo-list>

--- a/packages/geo/src/lib/filter/time-filter-list/time-filter-list.component.html
+++ b/packages/geo/src/lib/filter/time-filter-list/time-filter-list.component.html
@@ -1,5 +1,5 @@
 <igo-list [navigation]="false" [selection]="false">
   <ng-template ngFor let-layer [ngForOf]="layers | filterableDataSource: 'time'">
-    <igo-time-filter-item igoListItem [layer]="layer"></igo-time-filter-item>
+    <igo-time-filter-item [timeFiltersHeaderShown]="true" igoListItem [layer]="layer"></igo-time-filter-item>
   </ng-template>
 </igo-list>

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -11,8 +11,8 @@
   <ng-template #igoLayerItemToolbar let-layer="layer">
     <igo-download-button [layer]="layer"></igo-download-button>
     <igo-metadata-button [layer]="layer"></igo-metadata-button>
-    <igo-ogc-filter-button [ogcFiltersInLayers]="ogcFiltersInLayers" [layer]="layer"></igo-ogc-filter-button>
-    <igo-time-filter-button [timeFilterInLayers]="timeFilterInLayers" [layer]="layer"></igo-time-filter-button>
+    <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"></igo-ogc-filter-button>
+    <igo-time-filter-button [header]="timeButton" [layer]="layer"></igo-time-filter-button>
     <igo-track-feature-button [trackFeature]="true" [layer]="layer"></igo-track-feature-button>
   </ng-template>
 

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -12,6 +12,7 @@
     <igo-download-button [layer]="layer"></igo-download-button>
     <igo-metadata-button [layer]="layer"></igo-metadata-button>
     <igo-ogc-filter-button [ogcFiltersInLayers]="ogcFiltersInLayers" [layer]="layer"></igo-ogc-filter-button>
+    <igo-time-filter-button [timeFilterInLayers]="timeFilterInLayers" [layer]="layer"></igo-time-filter-button>
     <igo-track-feature-button [trackFeature]="true" [layer]="layer"></igo-track-feature-button>
   </ng-template>
 

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
@@ -23,6 +23,8 @@ export class MapDetailsToolComponent {
 
   @Input() ogcFiltersInLayers: boolean = true;
 
+  @Input() timeFilterInLayers: boolean = true;
+
   @Input() layerListControls: LayerListControlsOptions = {};
 
   @Input() queryBadge: boolean = false;

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
@@ -21,9 +21,9 @@ export class MapDetailsToolComponent {
 
   @Input() updateLegendOnResolutionChange: boolean = false;
 
-  @Input() ogcFiltersInLayers: boolean = true;
+  @Input() ogcButton: boolean = true;
 
-  @Input() timeFilterInLayers: boolean = true;
+  @Input() timeButton: boolean = true;
 
   @Input() layerListControls: LayerListControlsOptions = {};
 

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -15,6 +15,7 @@
         <igo-download-button [layer]="layer"></igo-download-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-ogc-filter-button [ogcFiltersInLayers]="ogcFiltersInLayers" [layer]="layer"></igo-ogc-filter-button>
+        <igo-time-filter-button [timeFilterInLayers]="timeFilterInLayers" [layer]="layer"></igo-time-filter-button>
         <igo-track-feature-button [trackFeature]="true" [layer]="layer"></igo-track-feature-button>
       </ng-template>
 

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -14,8 +14,8 @@
       <ng-template #igoLayerItemToolbar let-layer="layer">
         <igo-download-button [layer]="layer"></igo-download-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
-        <igo-ogc-filter-button [ogcFiltersInLayers]="ogcFiltersInLayers" [layer]="layer"></igo-ogc-filter-button>
-        <igo-time-filter-button [timeFilterInLayers]="timeFilterInLayers" [layer]="layer"></igo-time-filter-button>
+        <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"></igo-ogc-filter-button>
+        <igo-time-filter-button [header]="timeButton" [layer]="layer"></igo-time-filter-button>
         <igo-track-feature-button [trackFeature]="true" [layer]="layer"></igo-track-feature-button>
       </ng-template>
 

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.ts
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.ts
@@ -26,9 +26,9 @@ export class MapToolComponent {
 
   @Input() updateLegendOnResolutionChange: boolean = false;
 
-  @Input() ogcFiltersInLayers: boolean = true;
+  @Input() ogcButton: boolean = true;
 
-  @Input() timeFilterInLayers: boolean = true;
+  @Input() timeButton: boolean = true;
 
   @Input() layerListControls: LayerListControlsOptions = {};
 

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.ts
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.ts
@@ -28,6 +28,8 @@ export class MapToolComponent {
 
   @Input() ogcFiltersInLayers: boolean = true;
 
+  @Input() timeFilterInLayers: boolean = true;
+
   @Input() layerListControls: LayerListControlsOptions = {};
 
   @Input() queryBadge: boolean = false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
OGC filters are accessed from ogcFilter tool and from the layer list as a layer option.
Time filters are accessed from timeFilter tool only.

From the ogcFilter tool and  timeFilter tool, if the user want to see the legend, he have to navigate to map/mapDetails tool.

**What is the new behavior?**
1- Provide time filter button in layer list for time enabled layer.
3- Add a legend ogcFilter tool and  timeFilter tool by clicking on the layer title. 




**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

**MINOR BREAKING CHANGE** 
The integration tool options for mapDetails / map is now renamed from 
ogcFiltersInLayers to ogcButton


**Other information**:
