### PR TITLE
Fix layerList.Name is undefined

### DIFF
--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -198,7 +198,7 @@ export class CatalogService {
       // TODO: Slice that into multiple methods
       // Define object of group layer
       const groupItem = {
-        id: `catalog.group.${layerList.Name}`,
+        id: `catalog.group.${layerList.Name || group.Name}`,
         type: CatalogItemType.Group,
         title: layerList.Title,
         items: layerList.Layer.reduce(


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:

The value of `layerList.Name` is `undefined` when `groupItem` is created with a layergroup with multiple levels (exemple geomet). `groupItem.id` always has a value of `catalog.group.undefined`

When many `groupItem` are added, they have all this same `id` so, only the last added will be display.

In this case, we use `group.Name` instead.
