### PR TITLE
feat(search-source)New search by 'cadastre' number

### DIFF
--- a/demo/src/app/geo/search/search.module.ts
+++ b/demo/src/app/geo/search/search.module.ts
@@ -24,7 +24,8 @@ import {
   provideILayerSearchSource,
   provideNominatimSearchSource,
   provideIChercheReverseSearchSource,
-  provideCoordinatesReverseSearchSource
+  provideCoordinatesReverseSearchSource,
+  provideCadastreSearchSource
 } from '@igo2/geo';
 
 import { IgoAppSearchModule } from '@igo2/integration';
@@ -53,6 +54,7 @@ import { AppSearchRoutingModule } from './search-routing.module';
   exports: [AppSearchComponent],
   providers: [
     provideCoordinatesReverseSearchSource(),
+    provideCadastreSearchSource(),
     provideIChercheSearchSource(),
     provideILayerSearchSource(),
     provideNominatimSearchSource(),

--- a/packages/geo/src/lib/search/shared/sources/cadastre.providers.ts
+++ b/packages/geo/src/lib/search/shared/sources/cadastre.providers.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+
+import { ConfigService } from '@igo2/core';
+
+import { SearchSource } from './source';
+import { CadastreSearchSource } from './cadastre';
+
+/**
+ * Cadastre search source factory
+ * @ignore
+ */
+export function cadastreSearchSourceFactory(
+  http: HttpClient,
+  config: ConfigService
+) {
+  return new CadastreSearchSource(
+    http,
+    config.getConfig(`searchSources.${CadastreSearchSource.id}`),
+  );
+}
+
+/**
+ * Function that returns a provider for the Cadastre search source
+ */
+export function provideCadastreSearchSource() {
+  return {
+    provide: SearchSource,
+    useFactory: cadastreSearchSourceFactory,
+    multi: true,
+    deps: [HttpClient, ConfigService]
+  };
+}

--- a/packages/geo/src/lib/search/shared/sources/cadastre.ts
+++ b/packages/geo/src/lib/search/shared/sources/cadastre.ts
@@ -1,0 +1,139 @@
+import { Injectable, Inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import olWKT from 'ol/format/WKT';
+
+import { FEATURE, Feature, FeatureGeometry } from '../../../feature';
+
+import { SearchResult } from '../search.interfaces';
+import { SearchSource, TextSearch } from './source';
+import { SearchSourceOptions, TextSearchOptions } from './source.interfaces';
+import { WktService } from '../../../wkt/shared/wkt.service';
+
+/**
+ * Cadastre search source
+ */
+@Injectable()
+export class CadastreSearchSource extends SearchSource implements TextSearch {
+  static id = 'cadastre';
+  static type = FEATURE;
+
+  constructor(
+    private http: HttpClient,
+    @Inject('options') options: SearchSourceOptions
+  ) {
+    super(options);
+  }
+
+  getId(): string {
+    return CadastreSearchSource.id;
+  }
+
+  getType(): string {
+    return CadastreSearchSource.type;
+  }
+
+  /*
+   * Source : https://wiki.openstreetmap.org/wiki/Key:amenity
+   */
+  protected getDefaultOptions(): SearchSourceOptions {
+    return {
+      title: 'Cadastre (Québec)',
+      searchUrl: 'https://carto.cptaq.gouv.qc.ca/php/find_lot_v1.php?',
+    };
+  }
+
+  /**
+   * Search a place by name
+   * @param term Place name
+   * @returns Observable of <SearchResult<Feature>[]
+   */
+  search(
+    term: string | undefined,
+    options?: TextSearchOptions
+  ): Observable<SearchResult<Feature>[]> {
+
+    term = term.endsWith(',') ? term.slice(0, -1) : term;
+    term = term.startsWith(',') ? term.substr(1) : term;
+
+    const params = this.computeSearchRequestParams(term, options || {});
+    if (!params.get('numero')) {
+      return of([]);
+    }
+    return this.http
+      .get(this.searchUrl, { params, responseType: 'text' })
+      .pipe(map((response: string) => this.extractResults(response)));
+  }
+
+  private computeSearchRequestParams(
+    term: string,
+    options: TextSearchOptions
+  ): HttpParams {
+    return new HttpParams({
+      fromObject: Object.assign(
+        {
+          numero: term,
+          epsg: '4326'
+        },
+        this.params,
+        options.params || {}
+      )
+    });
+  }
+
+  private extractResults(response: string): SearchResult<Feature>[] {
+
+    return response.split('<br />')
+    .filter((lot: string) => lot.length > 0)
+    .map((lot: string) => this.dataToResult(lot));
+  }
+
+  private dataToResult(data: string): SearchResult<Feature> {
+    const lot = data.split(';');
+
+    console.log(data, lot);
+    const numero = lot[0];
+    const wkt = lot[7];
+
+    const geometry = this.computeGeometry(wkt);
+
+    const properties = { NoLot : numero };
+
+    const id = [this.getId(), 'cadastre', numero].join('.');
+
+    return {
+      source: this,
+      meta: {
+        dataType: FEATURE,
+        id,
+        title: numero,
+        icon: 'map-marker'
+      },
+      data: {
+        type: FEATURE,
+        projection: 'EPSG:4326',
+        geometry,
+        properties,
+        meta: {
+          id,
+          title: numero
+        }
+      }
+    };
+  }
+
+  private computeGeometry(wkt: string): FeatureGeometry {
+    const feature = new olWKT().readFeature(wkt, {
+      dataProjection: 'EPSG:4326',
+      featureProjection: 'EPSG:4326'
+    });
+    return {
+      type: feature.getGeometry().getType(),
+      coordinates: feature.getGeometry().getCoordinates()
+    };
+  }
+
+}

--- a/packages/geo/src/lib/search/shared/sources/cadastre.ts
+++ b/packages/geo/src/lib/search/shared/sources/cadastre.ts
@@ -11,7 +11,6 @@ import { FEATURE, Feature, FeatureGeometry } from '../../../feature';
 import { SearchResult } from '../search.interfaces';
 import { SearchSource, TextSearch } from './source';
 import { SearchSourceOptions, TextSearchOptions } from './source.interfaces';
-import { WktService } from '../../../wkt/shared/wkt.service';
 
 /**
  * Cadastre search source
@@ -93,15 +92,10 @@ export class CadastreSearchSource extends SearchSource implements TextSearch {
 
   private dataToResult(data: string): SearchResult<Feature> {
     const lot = data.split(';');
-
-    console.log(data, lot);
     const numero = lot[0];
     const wkt = lot[7];
-
     const geometry = this.computeGeometry(wkt);
-
     const properties = { NoLot : numero };
-
     const id = [this.getId(), 'cadastre', numero].join('.');
 
     return {

--- a/packages/geo/src/lib/search/shared/sources/index.ts
+++ b/packages/geo/src/lib/search/shared/sources/index.ts
@@ -1,3 +1,5 @@
+export * from './cadastre';
+export * from './cadastre.providers';
 export * from './source';
 export * from './source.interfaces';
 export * from './icherche';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
New search source. 

The service allow to search for many specific number. At this moment, when separating numbers by comma, IGO2 'detect' the term as coordinates. Then IGO2 do not trigger the search by term.

10000,100000000 trigger nothing.


The search source only allow to search for 1 cadastre number at each time. 
10000 work properly.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
