### PR TITLE
Fix ogcFilters Push buttons

### DIFF
--- a/packages/context/src/lib/share-map/share-map/share-map.component.html
+++ b/packages/context/src/lib/share-map/share-map/share-map.component.html
@@ -62,6 +62,8 @@
       <mat-icon svgIcon="content-copy"></mat-icon>
       {{ 'igo.context.shareMap.copy' | translate }}
     </button>
+  </div>
+  <div *ngIf="!hasApi">
     <br/>
     <section class="mat-typography">
         <h4>{{'igo.context.shareMap.included' | translate}}</h4>

--- a/packages/geo/src/lib/download/shared/download.service.ts
+++ b/packages/geo/src/lib/download/shared/download.service.ts
@@ -57,7 +57,11 @@ export class DownloadService {
 
         let filterQueryString;
         filterQueryString = new OgcFilterWriter()
-        .handleOgcFiltersAppliedValue(layer.dataSource.options, ogcFilters.geometryName);
+        .handleOgcFiltersAppliedValue(
+          layer.dataSource.options,
+          ogcFilters.geometryName,
+          layer.map.getExtent(),
+          new olProjection({ code: layer.map.projection }));
         if (!filterQueryString) {
           // Prevent getting all the features for empty filter
             filterQueryString = new OgcFilterWriter().buildFilter(
@@ -67,10 +71,10 @@ export class DownloadService {
             ogcFilters.geometryName
           );
         } else {
-          filterQueryString = 'filter=' + filterQueryString;
+          filterQueryString = 'filter=' + encodeURIComponent(filterQueryString);
         }
         window.open(
-          `${baseurl}&${encodeURIComponent(filterQueryString)}&${outputFormatDownload}`,
+          `${baseurl}&${filterQueryString}&${outputFormatDownload}`,
           '_blank'
         );
       } else if (DSOptions.download) {

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.html
@@ -1,5 +1,4 @@
-<button *ngIf="header && options.ogcFilters && (options.ogcFilters.enabled
-&& options.ogcFilters.editable)"
+<button *ngIf="header && options.ogcFilters && options.ogcFilters.enabled"
   mat-icon-button
   collapsibleButton
   tooltip-position="below"
@@ -11,8 +10,7 @@
 </button>
 
 <div #ogcFilter class="igo-layer-actions-container"
-*ngIf="options.ogcFilters && (options.ogcFilters.enabled
-&& options.ogcFilters.editable)">
+*ngIf="options.ogcFilters && options.ogcFilters.enabled">
   <igo-ogc-filterable-item
     *ngIf="ogcFilterCollapse && options.ogcFilters.enabled"
     igoListItem

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -3,6 +3,8 @@ import olFormatWKT from 'ol/format/WKT';
 import olFormatWFS from 'ol/format/WFS';
 import olGeometry from 'ol/geom/Geometry';
 
+import olProjection from 'ol/proj/Projection';
+
 import { uuid, ObjectUtils } from '@igo2/utils';
 
 import {
@@ -427,6 +429,9 @@ export class OgcFilterWriter {
   }
 
   private computeIgoPushButton(pushButtons: IgoPushButton): IgoPushButton {
+    if (pushButtons.groups.every(group => group.computedButtons !== undefined)) {
+      return pushButtons;
+    }
     let pb: IgoPushButton;
     if (pushButtons.groups && pushButtons.bundles) {
       if (!pushButtons.bundles.every(bundle => bundle.id !== undefined)) {
@@ -457,7 +462,11 @@ export class OgcFilterWriter {
     return pb;
   }
 
-  public handleOgcFiltersAppliedValue(options: OgcFilterableDataSourceOptions, fieldNameGeometry: string) {
+  public handleOgcFiltersAppliedValue(
+    options: OgcFilterableDataSourceOptions, 
+    fieldNameGeometry: string, 
+    extent?: [number, number, number, number],
+    proj?: olProjection): string{
     const ogcFilters = options.ogcFilters;
     if (!ogcFilters) {
       return;
@@ -481,7 +490,8 @@ export class OgcFilterWriter {
       });
       if (conditions.length >= 1) {
         filterQueryStringPushButton = this.buildFilter(
-            conditions.length === 1 ? conditions[0] : { logical: 'And', filters: conditions }
+            conditions.length === 1 ? conditions[0] : { logical: 'And', filters: conditions },
+            extent, proj, ogcFilters.geometryName
           );
       }
     }
@@ -489,7 +499,7 @@ export class OgcFilterWriter {
     if (ogcFilters.enabled && ogcFilters.filters) {
       ogcFilters.geometryName = ogcFilters.geometryName || fieldNameGeometry;
       const igoFilters = ogcFilters.filters;
-      filterQueryStringAdvancedFilters = this.buildFilter(igoFilters);
+      filterQueryStringAdvancedFilters = this.buildFilter(igoFilters,extent,proj, ogcFilters.geometryName);
     }
 
     let filterQueryString = ogcFilters.advancedOgcFilters ? filterQueryStringAdvancedFilters : filterQueryStringPushButton;

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -491,7 +491,9 @@ export class OgcFilterWriter {
       if (conditions.length >= 1) {
         filterQueryStringPushButton = this.buildFilter(
             conditions.length === 1 ? conditions[0] : { logical: 'And', filters: conditions },
-            extent, proj, ogcFilters.geometryName
+            extent,
+            proj,
+            ogcFilters.geometryName
           );
       }
     }
@@ -499,7 +501,7 @@ export class OgcFilterWriter {
     if (ogcFilters.enabled && ogcFilters.filters) {
       ogcFilters.geometryName = ogcFilters.geometryName || fieldNameGeometry;
       const igoFilters = ogcFilters.filters;
-      filterQueryStringAdvancedFilters = this.buildFilter(igoFilters,extent,proj, ogcFilters.geometryName);
+      filterQueryStringAdvancedFilters = this.buildFilter(igoFilters, extent, proj, ogcFilters.geometryName);
     }
 
     let filterQueryString = ogcFilters.advancedOgcFilters ? filterQueryStringAdvancedFilters : filterQueryStringPushButton;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1-Share map notice was not properly aligned
2- Download data from Pushbuttons (ogc-filters) was not equal to the map data. The applied filter for download data was the initial filter (on layer initialisation).
3- For a filterable layer with pushbuttons, if the ogcfilter was not editable, all the filters section was not available in the ui.

**What is the new behavior?**
Fix


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```