### PR TITLE
Zoom to behavior on feature select/zoomto

### DIFF
--- a/packages/geo/src/lib/map/shared/controllers/view.ts
+++ b/packages/geo/src/lib/map/shared/controllers/view.ts
@@ -326,8 +326,8 @@ export class MapViewController extends MapController {
     const moySize = (toSize + fromSize) / 2;
     const xSize = distCenter / moySize;
 
-    const maxZoom = action === MapViewAction.Move ? zoom : 17;
-    console.log(this.padding);
+    let maxZoom = action === MapViewAction.Move ? zoom : zoom > 19 ? zoom : 19;
+
     olView.fit(extent, {
       maxZoom,
       padding: this.padding,

--- a/packages/geo/src/lib/map/shared/controllers/view.ts
+++ b/packages/geo/src/lib/map/shared/controllers/view.ts
@@ -326,7 +326,7 @@ export class MapViewController extends MapController {
     const moySize = (toSize + fromSize) / 2;
     const xSize = distCenter / moySize;
 
-    let maxZoom = action === MapViewAction.Move ? zoom : zoom > 19 ? zoom : 19;
+    const maxZoom = action === MapViewAction.Move ? zoom : zoom > 19 ? zoom : 19;
 
     olView.fit(extent, {
       maxZoom,

--- a/packages/geo/src/lib/overlay/shared/overlay.utils.ts
+++ b/packages/geo/src/lib/overlay/shared/overlay.utils.ts
@@ -117,7 +117,7 @@ export function createOverlayMarkerStyle(
       src: './assets/igo2/geo/icons/place_' + iconColor + '_36px.svg',
       opacity,
       imgSize: [36, 36], // for ie
-      anchor: [0.5, 1]
+      anchor: [0.5, 0.92]
     }),
     text: new olstyle.Text({
       text,

--- a/packages/geo/src/lib/overlay/shared/overlay.utils.ts
+++ b/packages/geo/src/lib/overlay/shared/overlay.utils.ts
@@ -117,7 +117,7 @@ export function createOverlayMarkerStyle(
       src: './assets/igo2/geo/icons/place_' + iconColor + '_36px.svg',
       opacity,
       imgSize: [36, 36], // for ie
-      anchor: [0.5, 0.92]
+      anchor: [0.5, 1]
     }),
     text: new olstyle.Text({
       text,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1- Beyond zoom level 17, when selecting a feature, the zoomto action was zooming out to the feature
2- Vertical offset between the pin and the real position.


**What is the new behavior?**
1- Non prevent to zoom out and set the custom zoom level a level 19.
2- Reducing the offset.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```