### PR TITLE
fix(search-results): features-details stays with tool deactivation

### DIFF
--- a/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
+++ b/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
@@ -108,6 +108,12 @@ export class SearchResultsToolComponent implements OnInit {
         this.term = searchTerm;
       }
     });
+
+    for (const res of this.store.entities$.value) {
+      if (this.store.state.get(res).selected === true) {
+        this.topPanelState = 'collapsed';
+      }
+    }
   }
   /**
    * Try to add a feature to the map when it's being focused


### PR DESCRIPTION
- When a search-result is selected with his top panel (feature-details) and the search tool is deactivate, the panel is still there (collapsed) when we reactivate the search tool