### PR TITLE
Catalog legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ IGO2 library is divided into several elements:
 
 - @igo2/context : Library of components uniting @igo2/geo and @igo2/auth
 
-- @igo2/tools : Library integrate basic components
+- @igo2/integration : Library integrate basic components
 
 ## Demo
 

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.html
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.html
@@ -44,6 +44,7 @@
         igoListItem
         [layer]="item"
         [resolution]="resolution"
+        [catalogAllowLegend]="catalogAllowLegend"
         [added]="state.get(item).added"
         (addedLayerIsPreview)="onLayerPreview($event)"
         (addedChange)="onLayerAddedChange($event)">

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.ts
@@ -67,6 +67,8 @@ export class CatalogBrowserGroupComponent implements OnInit, OnDestroy {
 
   @Input() resolution: number;
 
+  @Input() catalogAllowLegend = false;
+
   /**
    * Whether the group can be toggled when it's collapsed
    */

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.html
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.html
@@ -1,7 +1,6 @@
 <mat-list-item>
   <mat-icon mat-list-avatar svgIcon="blank"></mat-icon>
-  <h4 mat-line matTooltipShowDelay="500" [matTooltip]="title">{{title}}</h4>
-
+  <h4 mat-line matTooltipShowDelay="500" [ngClass]="(catalogAllowLegend)?'igo-cataloglayer-title':''" (click)="askForLegend($event)" [matTooltip]="title">{{title}}</h4>
   <igo-metadata-button [layer]="layer"></igo-metadata-button>
 
   <button
@@ -24,3 +23,10 @@
   </button>
 
 </mat-list-item>
+
+<div #legend class="igo-cataloglayer-legend-container">
+  <igo-layer-legend
+    *ngIf="(layerLegendShown$ | async) && (igoLayer$ | async) && catalogAllowLegend"
+    [layer]="igoLayer$ | async">
+  </igo-layer-legend>
+</div>

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.scss
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.scss
@@ -1,4 +1,16 @@
+@import '../../../../../core/src/style/partial/core.variables';
+
 .mat-badge-small .mat-badge-content {
     color: rgba(0, 0, 0, 0.38);
   }
+
+  .igo-cataloglayer-title  {
+    cursor: pointer;
+  }
   
+
+  .igo-cataloglayer-legend-container {
+    padding-left: 18px;
+    width: calc(100% - 18px);
+    margin-left: $igo-icon-size;
+  }

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.ts
@@ -11,6 +11,9 @@ import { getEntityTitle, getEntityIcon } from '@igo2/common';
 
 import { CatalogItemLayer } from '../shared';
 import { BehaviorSubject } from 'rxjs';
+import { LayerService } from '../../layer/shared/layer.service';
+import { first } from 'rxjs/operators';
+import { Layer } from '../../layer/shared/layers';
 
 /**
  * Catalog browser layer item
@@ -27,7 +30,12 @@ export class CatalogBrowserLayerComponent implements OnInit {
 
   private lastTimeoutRequest;
 
+  public layerLegendShown$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public igoLayer$ = new BehaviorSubject<Layer>(undefined);
+
   @Input() resolution: number;
+
+  @Input() catalogAllowLegend = false;
 
   /**
    * Catalog layer
@@ -63,7 +71,7 @@ export class CatalogBrowserLayerComponent implements OnInit {
     return getEntityIcon(this.layer) || 'layers';
   }
 
-  constructor() {}
+  constructor(private layerService: LayerService ) {}
 
   ngOnInit(): void {
     this.isInResolutionsRange();
@@ -76,6 +84,12 @@ export class CatalogBrowserLayerComponent implements OnInit {
    */
   onMouseEvent(event) {
     this.onToggleClick(event);
+  }
+
+  askForLegend(event) {
+    this.layerLegendShown$.next(!this.layerLegendShown$.value);
+    this.layerService.createAsyncLayer(this.layer.options).pipe(first())
+    .subscribe(layer => this.igoLayer$.next(layer));
   }
 
   /**

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.html
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.html
@@ -6,6 +6,7 @@
         [group]="item"
         [state]="store.state"
         [resolution]="resolution$ | async"
+        [catalogAllowLegend]="catalogAllowLegend"
         [toggleCollapsed]="toggleCollapsedGroup"
         (addedChange)="onGroupAddedChange($event)"
         (layerAddedChange)="onLayerAddedChange($event)">
@@ -17,6 +18,7 @@
         igoListItem
         [layer]="item"
         [resolution]="resolution$ | async"
+        [catalogAllowLegend]="catalogAllowLegend"
         [added]="store.state.get(item).added"
         (addedChange)="onLayerAddedChange($event)">
       </igo-catalog-browser-layer>

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
@@ -41,6 +41,8 @@ export class CatalogBrowserComponent implements OnInit, OnDestroy {
 
   get resolution$(): BehaviorSubject<number> { return this.map.viewController.resolution$; }
 
+  @Input() catalogAllowLegend = false;
+
   /**
    * Catalog
    */
@@ -84,6 +86,9 @@ export class CatalogBrowserComponent implements OnInit, OnDestroy {
         valueAccessor: (item: CatalogItem) => item.title
       });
     }
+
+    this.catalogAllowLegend = this.catalog.showLegend ? this.catalog.showLegend : this.catalogAllowLegend;
+
     this.watcher = new EntityStoreWatcher(this.store, this.cdRef);
 
   }

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.module.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.module.ts
@@ -20,6 +20,7 @@ import { IgoMetadataModule } from './../../metadata/metadata.module';
 import { CatalogBrowserComponent } from './catalog-browser.component';
 import { CatalogBrowserLayerComponent } from './catalog-browser-layer.component';
 import { CatalogBrowserGroupComponent } from './catalog-browser-group.component';
+import { IgoLayerModule } from '../../layer/layer.module';
 
 /**
  * @ignore
@@ -36,7 +37,8 @@ import { CatalogBrowserGroupComponent } from './catalog-browser-group.component'
     IgoLanguageModule,
     IgoListModule,
     IgoCollapsibleModule,
-    IgoMetadataModule
+    IgoMetadataModule,
+    IgoLayerModule
   ],
   exports: [
     CatalogBrowserComponent

--- a/packages/geo/src/lib/catalog/shared/catalog.interface.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.interface.ts
@@ -26,6 +26,7 @@ export interface Catalog {
   tooltipType?: TooltipType.ABSTRACT | TooltipType.TITLE;
   sortDirection?: 'asc' | 'desc';
   setCrossOriginAnonymous?: boolean;
+  showLegend?: boolean;
 }
 
 export interface CatalogItem {

--- a/packages/geo/src/lib/filter/shared/spatial-filter.service.ts
+++ b/packages/geo/src/lib/filter/shared/spatial-filter.service.ts
@@ -96,7 +96,7 @@ export class SpatialFilterService {
                 'igo.geo.terrapi.' + name
               );
             } catch (e) {
-              item.name = name.substring(0,1).toUpperCase() + name.substring(1, name.length - 1);
+              item.name = name.substring(0, 1).toUpperCase() + name.substring(1, name.length - 1);
             }
 
             try {
@@ -104,7 +104,7 @@ export class SpatialFilterService {
                 'igo.geo.spatialFilter.group.' + substr
               );
             } catch (e) {
-              item.group = substr.substring(0,1).toUpperCase() + substr.substring(1, name.length - 1);
+              item.group = substr.substring(0, 1).toUpperCase() + substr.substring(1, name.length - 1);
             }
 
             items.push(item);
@@ -119,9 +119,9 @@ export class SpatialFilterService {
                 item.name = this.languageService.translate.instant(
                     'igo.geo.terrapi.' + name);
               } catch (e) {
-                item.name = name.substring(0,1).toUpperCase() + name.substring(1, name.length - 1);
+                item.name = name.substring(0, 1).toUpperCase() + name.substring(1, name.length - 1);
               }
-              item.source = type
+              item.source = type;
 
               items.push(item);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Add the possibility to visualize legend from the catalog browser.

By defaut, legend will not be available into the catalog browser.

At the catalog definition level (config.json or environnement./.ts) you must define if the catalog allow or not to show legend.

```
        {
          id: 'glace',
          title: 'Carte de glace',
          url: '/apis/ws/radarsat.fcgi',
          showLegend: true
        },
```


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```