### PR TITLE
fix(auth): Fix IE11 authentification interceptor bug

### DIFF
--- a/packages/auth/src/lib/shared/auth.interceptor.ts
+++ b/packages/auth/src/lib/shared/auth.interceptor.ts
@@ -36,6 +36,9 @@ export class AuthInterceptor implements HttpInterceptor {
     const token = this.tokenService.get();
     const element = document.createElement('a');
     element.href = req.url;
+    if (element.host === '') {
+      element.href = element.href; // FIX IE11, DO NOT REMOVE
+    }
 
     if (!token || this.trustHosts.indexOf(element.hostname) === -1) {
       return next.handle(req);


### PR DESCRIPTION
In IE11, the hostname of the current element wasn't correctly set. Cause the authentification interceptor to fail.

With resetting the href attribute, the hostname is now correctly set
 
