### PR TITLE
better handling grouped layers

### DIFF
--- a/packages/context/src/lib/share-map/shared/share-map.service.ts
+++ b/packages/context/src/lib/share-map/shared/share-map.service.ts
@@ -93,7 +93,8 @@ export class ShareMapService {
     )) {
       if (contextLayersID.indexOf(layer.id) === -1) {
         const wmsUrl = (layer.dataSource.options as any).url;
-        const addedLayer = encodeURIComponent((layer.dataSource.options as any).params.LAYERS);
+        // Replacing grouped layers ex: layer1,layer2 by layer1+layer2 for avoid splitting on url interpreting.
+        const addedLayer = encodeURIComponent((layer.dataSource.options as any).params.LAYERS.replace(/,/g, '+'));
         const addedLayerPosition = `${addedLayer}:igoz${layer.zIndex}`;
 
         if (

--- a/packages/context/src/lib/share-map/shared/share-map.service.ts
+++ b/packages/context/src/lib/share-map/shared/share-map.service.ts
@@ -93,8 +93,7 @@ export class ShareMapService {
     )) {
       if (contextLayersID.indexOf(layer.id) === -1) {
         const wmsUrl = (layer.dataSource.options as any).url;
-        // Replacing grouped layers ex: layer1,layer2 by layer1+layer2 for avoid splitting on url interpreting.
-        const addedLayer = encodeURIComponent((layer.dataSource.options as any).params.LAYERS.replace(/,/g, '+'));
+        const addedLayer = encodeURIComponent((layer.dataSource.options as any).params.LAYERS);
         const addedLayerPosition = `${addedLayer}:igoz${layer.zIndex}`;
 
         if (

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -536,6 +536,7 @@ export class OgcFilterWriter {
         appliedFilter = `${appliedFilter}(${processedFilter.replace('filter=', '')})`;
       });
     }
+    appliedFilter = appliedFilter.replace(/\(\)/g, '');
     const filterValue = appliedFilter.length > 0 ? appliedFilter.replace('filter=', '') : undefined;
     return filterValue;
   }

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -172,7 +172,12 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
 
   onChangeStyle() {
     this.updateLegend();
-    this.layer.dataSource.ol.updateParams({STYLES: this.currentStyle});
+    let STYLES = '';
+    this.layer.dataSource.ol.getParams().LAYERS.split(',').map(layer =>
+      STYLES += this.currentStyle + ','
+    );
+    STYLES = STYLES.slice(0, -1);
+    this.layer.dataSource.ol.updateParams({STYLES});
   }
 
   onLoadImage(id: string) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
With some grouped layers having common styles and/or filters, causing igo to crash on layer call.
```
LAYERS: "layer1,layer2"
```

**What is the new behavior?**
Prevent empty filters params AND duplicate (or + depending the number of layers in the grouped layer) the style param for grouped layers.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```