### PR TITLE
feat(datasource): retrieve query format from capabilities

### DIFF
--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -199,8 +199,7 @@ export class CapabilitiesService {
       QueryFormatMimeType.GML3,
       QueryFormatMimeType.GML2,
       QueryFormatMimeType.JSON,
-      QueryFormatMimeType.HTML,
-      QueryFormatMimeType.TEXT
+      QueryFormatMimeType.HTML
     ];
 
     for (const mimeType of queryFormatMimeTypePriority) {

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -11,6 +11,10 @@ import olAttribution from 'ol/control/Attribution';
 import { ObjectUtils } from '@igo2/utils';
 import { getResolutionFromScale } from '../../map';
 import { EsriStyleGenerator } from '../utils/esri-style-generator';
+import {
+  QueryFormat,
+  QueryFormatMimeType
+} from '../../query/shared/query.enums';
 
 import {
   WMTSDataSourceOptions,
@@ -29,7 +33,8 @@ import {
 } from '../../filter/shared/time-filter.enum';
 
 export enum TypeCapabilities {
-  wms = 'wms', wmts = 'wmts'
+  wms = 'wms',
+  wmts = 'wmts'
 }
 
 export type TypeCapabilitiesStrings = keyof typeof TypeCapabilities;
@@ -182,10 +187,34 @@ export class CapabilitiesService {
     const metadata = layer.DataURL ? layer.DataURL[0] : undefined;
     const abstract = layer.Abstract ? layer.Abstract : undefined;
     const keywordList = layer.KeywordList ? layer.KeywordList : undefined;
-    const queryable = layer.queryable;
+    let queryable = layer.queryable;
     const timeFilter = this.getTimeFilter(layer);
     const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0;
     const legendOptions = layer.Style ? this.getStyle(layer.Style) : undefined;
+
+    let queryFormat: QueryFormat;
+    const queryFormatMimeTypePriority = [
+      QueryFormatMimeType.GEOJSON,
+      QueryFormatMimeType.GEOJSON2,
+      QueryFormatMimeType.GML3,
+      QueryFormatMimeType.GML2,
+      QueryFormatMimeType.JSON,
+      QueryFormatMimeType.HTML,
+      QueryFormatMimeType.TEXT
+    ];
+
+    for (const mimeType of queryFormatMimeTypePriority) {
+      if (capabilities.Capability.Request.GetFeatureInfo.Format.indexOf(mimeType) !== -1) {
+        const keyEnum = Object.keys(QueryFormatMimeType).find(
+          key => QueryFormatMimeType[key] === mimeType
+        );
+        queryFormat = QueryFormat[keyEnum];
+        break;
+      }
+    }
+    if (!queryFormat) {
+      queryable = false;
+    }
 
     const options: WMSDataSourceOptions = ObjectUtils.removeUndefined({
       _layerOptionsFromCapabilities: {
@@ -202,6 +231,7 @@ export class CapabilitiesService {
         legendOptions
       },
       queryable,
+      queryFormat,
       timeFilter: timeFilterable ? timeFilter : undefined,
       timeFilterable: timeFilterable ? true : undefined
     });

--- a/packages/geo/src/lib/query/shared/query.enums.ts
+++ b/packages/geo/src/lib/query/shared/query.enums.ts
@@ -3,10 +3,23 @@ export enum QueryFormat {
   GML3 = 'gml3',
   JSON = 'json',
   GEOJSON = 'geojson',
+  GEOJSON2 = 'geojson2',
   ESRIJSON = 'esrijson',
   TEXT = 'text',
   HTML = 'html',
   HTMLGML2 = 'htmlgml2'
+}
+
+export enum QueryFormatMimeType {
+  GML2 = 'application/vnd.ogc.gml',
+  GML3 = 'application/vnd.ogc.gml/3.1.1',
+  JSON = 'application/json',
+  GEOJSON = 'application/geojson',
+  GEOJSON2 = 'geojson',
+  ESRIJSON = 'application/json',
+  TEXT = 'text/plain',
+  HTML = 'text/html',
+  HTMLGML2 = 'text/html'
 }
 
 export enum QueryHtmlTarget {

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -22,7 +22,11 @@ import {
   WMSDataSourceOptions
 } from '../../datasource';
 
-import { QueryFormat, QueryHtmlTarget } from './query.enums';
+import {
+  QueryFormat,
+  QueryFormatMimeType,
+  QueryHtmlTarget
+} from './query.enums';
 import {
   QueryOptions,
   QueryableDataSource,
@@ -599,33 +603,13 @@ export class QueryService {
     return url;
   }
 
-  private getMimeInfoFormat(queryFormat) {
-    let mime;
-    switch (queryFormat) {
-      case QueryFormat.GML2:
-        mime = 'application/vnd.ogc.gml';
-        break;
-      case QueryFormat.GML3:
-        mime = 'application/vnd.ogc.gml/3.1.1';
-        break;
-      case QueryFormat.JSON:
-        mime = 'application/json';
-        break;
-      case QueryFormat.GEOJSON:
-        mime = 'application/geojson';
-        break;
-      case QueryFormat.TEXT:
-        mime = 'text/plain';
-        break;
-      case QueryFormat.HTML:
-        mime = 'text/html';
-        break;
-      case QueryFormat.HTMLGML2:
-        mime = 'text/html';
-        break;
-      default:
-        mime = 'application/vnd.ogc.gml';
-        break;
+  private getMimeInfoFormat(queryFormat: string) {
+    let mime = 'application/vnd.ogc.gml';
+    const key = Object.keys(QueryFormat).find(
+      key => QueryFormat[key] === queryFormat
+    );
+    if (key) {
+      mime = QueryFormatMimeType[key];
     }
 
     return mime;

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -605,11 +605,11 @@ export class QueryService {
 
   private getMimeInfoFormat(queryFormat: string) {
     let mime = 'application/vnd.ogc.gml';
-    const key = Object.keys(QueryFormat).find(
+    const keyEnum = Object.keys(QueryFormat).find(
       key => QueryFormat[key] === queryFormat
     );
-    if (key) {
-      mime = QueryFormatMimeType[key];
+    if (keyEnum) {
+      mime = QueryFormatMimeType[keyEnum];
     }
 
     return mime;

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -240,6 +240,7 @@ export class QueryService {
         break;
       case QueryFormat.JSON:
       case QueryFormat.GEOJSON:
+      case QueryFormat.GEOJSON2:
         features = this.extractGeoJSONData(res);
         break;
       case QueryFormat.ESRIJSON:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The format of the query must be defined in the context or the GML2 format is used without checking whether the service provides this format.

**What is the new behavior?**
The getCapabilities is used to find the supported formats. The priority of formats is:
GeoJSON: application/geojson or geojson
GML3: application/vnd.ogc.gml/3.1.1
GML2: application/vnd.ogc.gml
JSON: application/json
HTML: text/html

**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**
The geojson format is prioritized in getCapabilities instead of GML2

**Other information**:
