### PR TITLE
fix(catalog): apply regex layers of the first level

### DIFF
--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -432,9 +432,11 @@ export class CatalogService {
         break;
       } else {
         // layer without group
-        const layerItem = this.prepareCatalogItemLayer(item, catalog.id, layersQueryFormat,
-          catalog, catalogQueryParams, catalogSourceOptions, catalogTooltipType);
-        itemsPrepare.push(layerItem);
+        if (this.testLayerRegexes(item.Name, regexes) !== false) {
+          const layerItem = this.prepareCatalogItemLayer(item, catalog.id, layersQueryFormat,
+            catalog, catalogQueryParams, catalogSourceOptions, catalogTooltipType);
+          itemsPrepare.push(layerItem);
+        }
       }
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The regular expression is not applied to layers without group of wms catalog for the first level of the catalog.

**What is the new behavior?**
Apply regular expression on layers of first level of catalog.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
refer to issues #598
