### PR TITLE
Provide operator at the field scale

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -1,5 +1,6 @@
 import olSource from 'ol/source/Source';
 import { DownloadOptions } from '../../../download/shared/download.interface';
+import { OgcFilterOperatorType } from '../../../filter/shared/ogc-filter.enum';
 
 export interface DataSourceOptions {
   type?:
@@ -32,6 +33,7 @@ export interface SourceFieldsOptionsParams {
   alias?: any;
   values?: any;
   excludeFromOgcFilters?: boolean;
+  allowedOperatorsType?: OgcFilterOperatorType;
 }
 
 export interface Legend {

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
@@ -3,8 +3,8 @@
   <div class="igo-col igo-col-90 igo-col-100-m">
     <mat-select class="logical" [disabled]="!currentFilter.active" (selectionChange)="refreshFilters()" [(ngModel)]="currentFilter.parentLogical"
       *ngIf="activeFilters.indexOf(currentFilter) !== 0 && currentFilter.active===true">
-      <mat-option value="And">{{'igo.geo.operators.And' | translate}}</mat-option>
-      <mat-option value="Or">{{'igo.geo.operators.Or' | translate}}</mat-option>
+      <mat-option tooltip-position="above" matTooltipShowDelay="500" [matTooltip]="'igo.geo.operators.tooltip.And' | translate" value="And">{{'igo.geo.operators.And' | translate}}</mat-option>
+      <mat-option tooltip-position="above" matTooltipShowDelay="500" [matTooltip]="'igo.geo.operators.tooltip.Or' | translate" value="Or">{{'igo.geo.operators.Or' | translate}}</mat-option>
     </mat-select>
   </div>
   <!-- NON SPATIAL -->
@@ -33,7 +33,7 @@
     <mat-select 
     tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.geo.filter.selectOperator' | translate"
     [disabled]="!currentFilter.active" [(ngModel)]="currentFilter.operator" (selectionChange)="changeOperator(currentFilter)">
-      <mat-option *ngFor="let operator of (ogcFilterOperators$ | async) | keyvalue" [value]="operator.key">{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
+      <mat-option *ngFor="let operator of (ogcFilterOperators$ | async) | keyvalue" [value]="operator.key" tooltip-position="above" matTooltipShowDelay="500" [matTooltip]="('igo.geo.operators.tooltip.'+ operator.key) | translate" >{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
     </mat-select>
   </div>
 
@@ -169,7 +169,7 @@
     <mat-select  
       matTooltipShowDelay="500" [matTooltip]="'igo.geo.filter.selectOperator' | translate" tooltip-position="below"
       [disabled]="!currentFilter.active" [(ngModel)]="currentFilter.operator" (selectionChange)="changeOperator(currentFilter)">
-      <mat-option *ngFor="let operator of (ogcFilterOperators$ | async) | keyvalue" [value]="operator.key">{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
+      <mat-option *ngFor="let operator of (ogcFilterOperators$ | async) | keyvalue" [value]="operator.key"  tooltip-position="above" matTooltipShowDelay="500" [matTooltip]="('igo.geo.operators.tooltip.'+ operator.key) | translate" >{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
     </mat-select>
   </div>
   <div class="igo-col igo-col-90 igo-col-100-m" *ngIf="(currentFilter.operator === 'Intersects' || currentFilter.operator === 'Contains' || currentFilter.operator === 'Within')">

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
@@ -196,6 +196,10 @@
   </div>
   <!-- PropertySpatial  -->
 
+  <!-- <mat-checkbox labelPosition='before' (change)="changeCaseSensitive($event)" [(ngModel)]="currentFilter.matchCase">
+    {{('igo.geo.operators.caseSensitive') | translate}}
+  </mat-checkbox> -->
+
   <div class="igo-col igo-col-100 igo-col-100-m">
     <div class="igo-layer-button-group">
       <mat-slide-toggle class="example-margin" (change)="toggleFilterState($event,currentFilter,'active')" tooltip-position="below"

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.html
@@ -9,14 +9,14 @@
   </div>
   <!-- NON SPATIAL -->
   <div class="igo-col igo-col-90 igo-col-100-m" *ngIf="(currentFilter.operator !== 'Intersects' && currentFilter.operator !== 'Contains' && currentFilter.operator !== 'Within')">
-    <span *ngIf="fields && fields.length > 0 && fields[0].name !== ''">
+    <span *ngIf="(fields$ | async) && (fields$| async).length > 0 && (fields$| async)[0].name !== ''">
       <mat-select [disabled]="!currentFilter.active" *ngIf="['Contains','Intersects','Within'].indexOf(currentFilter.operator) === -1"
         [(ngModel)]="currentFilter.propertyName" tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.geo.sourceFields.selectField' | translate"
         (selectionChange)="updateField()">
-        <mat-option *ngFor="let field of fields" [value]="field.name">{{field.alias}}</mat-option>
+        <mat-option *ngFor="let field of  (fields$| async)" [value]="field.name">{{field.alias}}</mat-option>
       </mat-select>
     </span>
-    <span *ngIf="fields && fields.length === 1 && fields[0].name === ''">
+    <span *ngIf=" (fields$| async) &&  (fields$| async).length === 1 &&  (fields$| async)[0].name === ''">
       <mat-form-field>
         <input [disabled]="!currentFilter.active" matInput #fieldPerUser (keyup)="changeProperty(currentFilter,'propertyName',fieldPerUser.value)"
           (blur)="changeProperty(currentFilter,'propertyName',fieldPerUser.value)" [(ngModel)]="currentFilter.propertyName">
@@ -33,7 +33,7 @@
     <mat-select 
     tooltip-position="below" matTooltipShowDelay="500" [matTooltip]="'igo.geo.filter.selectOperator' | translate"
     [disabled]="!currentFilter.active" [(ngModel)]="currentFilter.operator" (selectionChange)="changeOperator(currentFilter)">
-      <mat-option *ngFor="let operator of ogcFilterOperators | keyvalue" [value]="operator.key">{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
+      <mat-option *ngFor="let operator of (ogcFilterOperators$ | async) | keyvalue" [value]="operator.key">{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
     </mat-select>
   </div>
 
@@ -169,7 +169,7 @@
     <mat-select  
       matTooltipShowDelay="500" [matTooltip]="'igo.geo.filter.selectOperator' | translate" tooltip-position="below"
       [disabled]="!currentFilter.active" [(ngModel)]="currentFilter.operator" (selectionChange)="changeOperator(currentFilter)">
-      <mat-option *ngFor="let operator of ogcFilterOperators | keyvalue" [value]="operator.key">{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
+      <mat-option *ngFor="let operator of (ogcFilterOperators$ | async) | keyvalue" [value]="operator.key">{{('igo.geo.operators.'+ operator.key) | translate}}</mat-option>
     </mat-select>
   </div>
   <div class="igo-col igo-col-90 igo-col-100-m" *ngIf="(currentFilter.operator === 'Intersects' || currentFilter.operator === 'Contains' || currentFilter.operator === 'Within')">

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
@@ -12,8 +12,9 @@ import {
 import { OgcFilterWriter } from '../../filter/shared/ogc-filter';
 import { WktService } from '../../wkt/shared/wkt.service';
 import { IgoMap } from '../../map';
-import { OgcFilterOperatorType } from '../../filter/shared/ogc-filter.enum';
 import { FloatLabelType } from '@angular/material';
+import { BehaviorSubject } from 'rxjs';
+import { SourceFieldsOptionsParams } from '../../datasource/shared/datasources/datasource.interface';
 
 @Component({
   selector: 'igo-ogc-filter-form',
@@ -21,16 +22,19 @@ import { FloatLabelType } from '@angular/material';
   styleUrls: ['./ogc-filter-form.component.scss']
 })
 export class OgcFilterFormComponent implements OnInit {
-  public ogcFilterOperators;
+  public allOgcFilterOperators;
+  public ogcFilterOperators$ = new BehaviorSubject<{[key: string]: any}>(undefined);
   public igoSpatialSelectors;
   public value = '';
   public inputOperator;
-  public fields: any[];
+  // public fields: any[];
+  public fields$ = new BehaviorSubject<SourceFieldsOptionsParams[]>([]);
   public values: any[];
   public color = 'primary';
   public snrc = '';
   public disabled;
   public baseOverlayName = 'ogcFilterOverlay_';
+  public currentFilter$ = new BehaviorSubject<any>(undefined);
 
   @Input() refreshFilters: () => void;
 
@@ -38,12 +42,17 @@ export class OgcFilterFormComponent implements OnInit {
 
   @Input() map: IgoMap;
 
-  @Input() currentFilter: any;
+  @Input()
+  set currentFilter(currentFilter: any) {
+    this.currentFilter$.next(currentFilter);
+  }
+  get currentFilter(): any {
+    return this.currentFilter$.value;
+  }
 
   @Input() floatLabel: FloatLabelType = 'never';
 
   get activeFilters() {
-    this.updateField();
     return this.datasource.options.ogcFilters.interfaceOgcFilters.filter(
       f => f.active === true
     );
@@ -56,7 +65,8 @@ export class OgcFilterFormComponent implements OnInit {
     // Need to work on regex on XML capabilities because
     // comaparison operator's name varies between WFS servers...
     // Ex: IsNull vs PropertyIsNull vs IsNil ...
-    this.ogcFilterOperators = new OgcFilterWriter().operators;
+    this.allOgcFilterOperators = new OgcFilterWriter().operators;
+    this.ogcFilterOperators$.next(this.allOgcFilterOperators);
     this.igoSpatialSelectors = [
       {
         type: 'fixedExtent'
@@ -69,73 +79,27 @@ export class OgcFilterFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.computeAllowedOperators();
-  }
-
-  computeAllowedOperators() {
-    let allowedOperators = this.datasource.options.ogcFilters.allowedOperatorsType;
-    let effectiveOperators: {} = {};
-
-    if (!allowedOperators)  {
-      allowedOperators = OgcFilterOperatorType.BasicAndSpatial;
-    }
-
-    switch (allowedOperators.toLowerCase()) {
-      case 'all':
-        effectiveOperators = this.ogcFilterOperators;
-        break;
-      case 'spatial':
-        effectiveOperators = {
-          Intersects: { spatial: true, fieldRestrict: [] },
-          Within: { spatial: true, fieldRestrict: [] },
-        };
-        break;
-      case 'basicandspatial':
-        effectiveOperators = {
-          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
-          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] },
-          Intersects: { spatial: true, fieldRestrict: [] },
-          Within: { spatial: true, fieldRestrict: [] },
-        };
-        break;
-      case 'basic':
-        effectiveOperators = {
-          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
-          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] }
-        };
-        break;
-      case 'basicnumeric':
-        effectiveOperators = {
-          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
-          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] },
-          PropertyIsGreaterThan: { spatial: false, fieldRestrict: ['number'] },
-          PropertyIsGreaterThanOrEqualTo: { spatial: false, fieldRestrict: ['number'] },
-          PropertyIsLessThan: { spatial: false, fieldRestrict: ['number'] },
-          PropertyIsLessThanOrEqualTo: { spatial: false, fieldRestrict: ['number'] },
-        };
-        break;
-      default:
-        effectiveOperators = {
-          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
-          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] },
-          Intersects: { spatial: true, fieldRestrict: [] },
-          Within: { spatial: true, fieldRestrict: [] },
-        };
-    }
-
-    this.ogcFilterOperators = effectiveOperators;
+    this.updateField();
   }
 
   updateField() {
     if (!this.datasource.options.sourceFields) {
       return;
     }
-    this.fields = this.datasource.options.sourceFields
-    .filter(sf => (sf.excludeFromOgcFilters === undefined || !sf.excludeFromOgcFilters));
-    this.fields.filter(f => f.name === this.currentFilter.propertyName)
+    const fields = this.datasource.options.sourceFields
+      .filter(sf => (sf.excludeFromOgcFilters === undefined || !sf.excludeFromOgcFilters));
+    fields.filter(f => f.name === this.currentFilter.propertyName)
       .forEach(element => {
         this.values = element.values !== undefined ? element.values.sort() : [];
       });
+
+    this.fields$.next(fields);
+    const allowedOperators = new OgcFilterWriter().computeAllowedOperators(fields, this.currentFilter.propertyName);
+    this.ogcFilterOperators$.next(allowedOperators);
+    if (Object.keys(allowedOperators).indexOf(this.currentFilter$.value.operator) === -1) {
+      this.currentFilter$.value.operator = Object.keys(allowedOperators)[0];
+    }
+    this.refreshFilters();
   }
 
   toggleFilterState(event, filter: OgcInterfaceFilterOptions, property) {
@@ -182,7 +146,7 @@ export class OgcFilterFormComponent implements OnInit {
   }
 
   changeOperator(filter) {
-    if (this.ogcFilterOperators[filter.operator].spatial === false) {
+    if (this.ogcFilterOperators$.value[filter.operator].spatial === false) {
       this.removeOverlayByID(filter.filterid);
     }
     this.refreshFilters();

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
@@ -155,6 +155,13 @@ export class OgcFilterFormComponent implements OnInit {
     this.refreshFilters();
   }
 
+  // Issue with mapserver 7.2 and Postgis layers. Fixed in 7.4
+  // Due to this issue, the checkbox is hide.
+  changeCaseSensitive(matchCase) {
+    this.currentFilter.matchCase = matchCase.checked;
+    this.refreshFilters();
+  }
+
   changeProperty(filter: OgcInterfaceFilterOptions, property, value) {
     this.datasource.options.ogcFilters.interfaceOgcFilters
       .filter(f => f.filterid === filter.filterid)

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
@@ -23,7 +23,7 @@ import { SourceFieldsOptionsParams } from '../../datasource/shared/datasources/d
 })
 export class OgcFilterFormComponent implements OnInit {
   public allOgcFilterOperators;
-  public ogcFilterOperators$ = new BehaviorSubject<{[key: string]: any}>(undefined);
+  public ogcFilterOperators$ = new BehaviorSubject<{ [key: string]: any }>(undefined);
   public igoSpatialSelectors;
   public value = '';
   public inputOperator;
@@ -94,7 +94,10 @@ export class OgcFilterFormComponent implements OnInit {
       });
 
     this.fields$.next(fields);
-    const allowedOperators = new OgcFilterWriter().computeAllowedOperators(fields, this.currentFilter.propertyName);
+    const allowedOperators = new OgcFilterWriter().computeAllowedOperators(
+      fields,
+      this.currentFilter.propertyName,
+      this.datasource.options.ogcFilters.allowedOperatorsType);
     this.ogcFilterOperators$.next(allowedOperators);
     if (Object.keys(allowedOperators).indexOf(this.currentFilter$.value.operator) === -1) {
       this.currentFilter$.value.operator = Object.keys(allowedOperators)[0];

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -120,8 +120,10 @@ export class OgcFilterableItemComponent implements OnInit {
         .fieldNameGeometry;
     }
     const status = arr.length === 0 ? true : false;
-
-    const allowedOperators = this.ogcFilterWriter.computeAllowedOperators(this.datasource.options.sourceFields, firstFieldName);
+    const allowedOperators = this.ogcFilterWriter.computeAllowedOperators(
+      this.datasource.options.sourceFields,
+      firstFieldName,
+      this.datasource.options.ogcFilters.allowedOperatorsType);
     const firstOperatorName = Object.keys(allowedOperators)[0];
 
     arr.push(

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -30,6 +30,8 @@ export class OgcFilterableItemComponent implements OnInit {
   public hasPushButton: boolean = false;
   showLegend$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
+  private ogcFilterWriter;
+
   @Input() layer: Layer;
 
   @Input() map: IgoMap;
@@ -51,7 +53,9 @@ export class OgcFilterableItemComponent implements OnInit {
   constructor(
     private ogcFilterService: OGCFilterService,
     private downloadService: DownloadService
-  ) {}
+  ) {
+    this.ogcFilterWriter = new OgcFilterWriter();
+  }
 
   ngOnInit() {
     const ogcFilters = this.datasource.options.ogcFilters;
@@ -116,11 +120,15 @@ export class OgcFilterableItemComponent implements OnInit {
         .fieldNameGeometry;
     }
     const status = arr.length === 0 ? true : false;
+
+    const allowedOperators = this.ogcFilterWriter.computeAllowedOperators(this.datasource.options.sourceFields, firstFieldName);
+    const firstOperatorName = Object.keys(allowedOperators)[0];
+
     arr.push(
-      new OgcFilterWriter().addInterfaceFilter(
+      this.ogcFilterWriter.addInterfaceFilter(
         {
           propertyName: firstFieldName,
-          operator: 'PropertyIsEqualTo',
+          operator: firstOperatorName,
           active: status,
           igoSpatialSelector: 'fixedExtent',
           srsName: this.map.projection,
@@ -142,7 +150,6 @@ export class OgcFilterableItemComponent implements OnInit {
       this.lastRunOgcFilter = undefined;
     }
     const ogcFilters: OgcFiltersOptions = this.datasource.options.ogcFilters;
-    const ogcFilterWriter = new OgcFilterWriter();
     const activeFilters = ogcFilters.interfaceOgcFilters.filter(
       f => f.active === true
     );
@@ -169,7 +176,7 @@ export class OgcFilterableItemComponent implements OnInit {
       if (this.layer.dataSource.options.type === 'wfs') {
         const ogcDataSource: any = this.layer.dataSource;
         const ogcLayer: OgcFiltersOptions = ogcDataSource.options.ogcFilters;
-        ogcLayer.filters = ogcFilterWriter.rebuiltIgoOgcFilterObjectFromSequence(
+        ogcLayer.filters = this.ogcFilterWriter.rebuiltIgoOgcFilterObjectFromSequence(
           activeFilters
         );
         this.layer.dataSource.ol.clear();
@@ -181,10 +188,10 @@ export class OgcFilterableItemComponent implements OnInit {
         if (activeFilters.length >= 1) {
           const ogcDataSource: any = this.layer.dataSource;
           const ogcLayer: OgcFiltersOptions = ogcDataSource.options.ogcFilters;
-          ogcLayer.filters = ogcFilterWriter.rebuiltIgoOgcFilterObjectFromSequence(
+          ogcLayer.filters = this.ogcFilterWriter.rebuiltIgoOgcFilterObjectFromSequence(
             activeFilters
           );
-          rebuildFilter = ogcFilterWriter.buildFilter(
+          rebuildFilter = this.ogcFilterWriter.buildFilter(
             ogcLayer.filters,
             undefined,
             undefined,

--- a/packages/geo/src/lib/filter/shared/ogc-filter.enum.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.enum.ts
@@ -3,5 +3,6 @@ export enum OgcFilterOperatorType {
     Basic = 'Basic',
     BasicAndSpatial = 'BasicAndSpatial',
     Spatial = 'Spatial',
-    All = 'All'
+    All = 'All',
+    Time = 'time'
 }

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -19,6 +19,8 @@ import {
   PushButtonGroup,
   OgcPushButtonBundle
 } from './ogc-filter.interface';
+import { OgcFilterOperatorType } from './ogc-filter.enum';
+import { SourceFieldsOptionsParams } from '../../datasource/shared/datasources/datasource.interface';
 
 export class OgcFilterWriter {
   private filterSequence: OgcInterfaceFilterOptions[] = [];
@@ -270,6 +272,66 @@ export class OgcFilterWriter {
       }
     }
     return this.filterSequence;
+  }
+
+  public computeAllowedOperators(fields?: SourceFieldsOptionsParams[], propertyName?: string) {
+    let effectiveOperators: {} = {};
+    let allowedOperators;
+    if (fields && propertyName) {
+      const srcField = fields.find(field => field.name === propertyName);
+      allowedOperators = srcField && srcField.allowedOperatorsType ?
+        srcField.allowedOperatorsType : OgcFilterOperatorType.BasicAndSpatial;
+    }
+
+    switch (allowedOperators.toLowerCase()) {
+      case 'all':
+        effectiveOperators = this.operators;
+        break;
+      case 'spatial':
+        effectiveOperators = {
+          Intersects: { spatial: true, fieldRestrict: [] },
+          Within: { spatial: true, fieldRestrict: [] },
+        };
+        break;
+      case 'basicandspatial':
+        effectiveOperators = {
+          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
+          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] },
+          Intersects: { spatial: true, fieldRestrict: [] },
+          Within: { spatial: true, fieldRestrict: [] },
+        };
+        break;
+      case 'basic':
+        effectiveOperators = {
+          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
+          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] }
+        };
+        break;
+        case 'time':
+          effectiveOperators = {
+            During: { spatial: false, fieldRestrict: [] },
+          };
+          break;
+      case 'basicnumeric':
+        effectiveOperators = {
+          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
+          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] },
+          PropertyIsGreaterThan: { spatial: false, fieldRestrict: ['number'] },
+          PropertyIsGreaterThanOrEqualTo: { spatial: false, fieldRestrict: ['number'] },
+          PropertyIsLessThan: { spatial: false, fieldRestrict: ['number'] },
+          PropertyIsLessThanOrEqualTo: { spatial: false, fieldRestrict: ['number'] },
+        };
+        break;
+      default:
+        effectiveOperators = {
+          PropertyIsEqualTo: { spatial: false, fieldRestrict: [] },
+          PropertyIsNotEqualTo: { spatial: false, fieldRestrict: [] },
+          Intersects: { spatial: true, fieldRestrict: [] },
+          Within: { spatial: true, fieldRestrict: [] },
+        };
+    }
+
+    return effectiveOperators;
   }
 
   public addInterfaceFilter(

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -277,7 +277,7 @@ export class OgcFilterWriter {
   public computeAllowedOperators(
     fields?: SourceFieldsOptionsParams[],
     propertyName?: string,
-    defaultOperatorsType: OgcFilterOperatorType = OgcFilterOperatorType.BasicAndSpatial ) {
+    defaultOperatorsType?: OgcFilterOperatorType ) {
     let effectiveOperators: {} = {};
     let allowedOperators;
     if (fields && propertyName) {
@@ -285,6 +285,8 @@ export class OgcFilterWriter {
       allowedOperators = srcField && srcField.allowedOperatorsType ?
         srcField.allowedOperatorsType : defaultOperatorsType;
     }
+
+    allowedOperators = allowedOperators ? allowedOperators : 'basicandspatial';
 
     switch (allowedOperators.toLowerCase()) {
       case 'all':

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -274,13 +274,16 @@ export class OgcFilterWriter {
     return this.filterSequence;
   }
 
-  public computeAllowedOperators(fields?: SourceFieldsOptionsParams[], propertyName?: string) {
+  public computeAllowedOperators(
+    fields?: SourceFieldsOptionsParams[],
+    propertyName?: string,
+    defaultOperatorsType: OgcFilterOperatorType = OgcFilterOperatorType.BasicAndSpatial ) {
     let effectiveOperators: {} = {};
     let allowedOperators;
     if (fields && propertyName) {
       const srcField = fields.find(field => field.name === propertyName);
       allowedOperators = srcField && srcField.allowedOperatorsType ?
-        srcField.allowedOperatorsType : OgcFilterOperatorType.BasicAndSpatial;
+        srcField.allowedOperatorsType : defaultOperatorsType;
     }
 
     switch (allowedOperators.toLowerCase()) {

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -81,9 +81,26 @@
         "PropertyIsBetween": "between",
         "During": "during",
         "PropertyIsNull": "is null",
-        "Intersects": "intersects",
-        "Within": "within",
-        "Contains": "contains"
+        "Intersects": "intersects (spatial)",
+        "Within": "within (spatial)",
+        "Contains": "contains (spatial)",
+        "tooltip": {
+          "And": "Logical operator between filters where both conditions must be true",
+          "Or": "Logical operator between filters where at least one (1) condition must be true",
+          "PropertyIsEqualTo": "Operator that compares if the attribute match to the provided value (case sensitive)",
+          "PropertyIsNotEqualTo": "Operator that compares if the attribute is different to the provided value (case sensitive)",
+          "PropertyIsLike": "Comparison operator based on pattern matching. wildCard ='*', singleChar = '.' escapeChar = '!' (case sensitive)",
+          "PropertyIsGreaterThan": "Operator that checks that attribute is greater than its second subexpression.",
+          "PropertyIsGreaterThanOrEqualTo": "Operator that checks if attribute is greater or equal to its second subexpression.",
+          "PropertyIsLessThan": "Operator that checks that attribute is less than its second subexpression.",
+          "PropertyIsLessThanOrEqualTo": "Operator that checks that attribute is less or equal to its second subexpression.",
+          "PropertyIsBetween": "Apply a range check between the lower and upper boundary (values are included)",
+          "During": "Apply a range check for time attributes",
+          "PropertyIsNull": "Return features where the attribute is null",
+          "Intersects": "Return features in geometric intersection with the provided geometry",
+          "Within": "Return feature which are completely contained by the provided geometry",
+          "Contains": "Return feature completely containing by the provided geometry"
+        }
       },
       "sourceFields": {
         "selectField": "Choose a field"

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -87,21 +87,21 @@
         "Contains": "contains (spatial)",
         "tooltip": {
           "And": "Logical operator between filters where both conditions must be true",
-          "Or": "Logical operator between filters where at least one (1) condition must be true",
-          "PropertyIsEqualTo": "Operator that compares if the attribute match to the provided value (case sensitive)",
-          "PropertyIsNotEqualTo": "Operator that compares if the attribute is different to the provided value (case sensitive)",
-          "PropertyIsLike": "Comparison operator based on pattern matching. wildCard ='*', singleChar = '.' escapeChar = '!' (case sensitive)",
-          "PropertyIsGreaterThan": "Operator that checks that attribute is greater than its second subexpression.",
-          "PropertyIsGreaterThanOrEqualTo": "Operator that checks if attribute is greater or equal to its second subexpression.",
-          "PropertyIsLessThan": "Operator that checks that attribute is less than its second subexpression.",
-          "PropertyIsLessThanOrEqualTo": "Operator that checks that attribute is less or equal to its second subexpression.",
-          "PropertyIsBetween": "Apply a range check between the lower and upper boundary (values are included)",
-          "During": "Apply a range check for time attributes",
-          "PropertyIsNull": "Return features where the attribute is null",
-          "Intersects": "Return features in geometric intersection with the provided geometry",
-          "Within": "Return feature which are completely contained by the provided geometry",
-          "Contains": "Return feature completely containing by the provided geometry"
-        }
+          "Or": "Logical operator between filters where at least one (1) condition must be true",
+          "PropertyIsEqualTo": "Identical (case sensitive)",
+          "PropertyIsNotEqualTo": "Different(case sensitive)",
+          "PropertyIsLike": "Like Example: *road* Finds any values that have 'road' in any position. road* Finds any values that begin by 'road'. wildCard ='*', singleChar = '.' escapeChar = '!' (case sensitive)",
+          "PropertyIsGreaterThan": "Greater than",
+          "PropertyIsGreaterThanOrEqualTo": "Greater than or equal to ",
+          "PropertyIsLessThan": "Lesser than",
+          "PropertyIsLessThanOrEqualTo": "Lesser than or equal to",
+          "PropertyIsBetween": "Apply a range check between the lower and upper boundary (values are included)",
+          "During": "Apply a range check for time attributes",
+          "PropertyIsNull": "Return features where the attribute is null",
+          "Intersects": "Return features in geometric intersection with the provided geometry",
+          "Within": "Return feature which are completely contained by the provided geometry",
+          "Contains": "Return feature completely containing by the provided geometry"
+        }
       },
       "sourceFields": {
         "selectField": "Choose a field"

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -80,7 +80,7 @@
         "PropertyIsLessThan": "<",
         "PropertyIsLessThanOrEqualTo": "<=",
         "PropertyIsBetween": "between",
-        "During": "during",
+        "During": "during (temporal)",
         "PropertyIsNull": "is null",
         "Intersects": "intersects (spatial)",
         "Within": "within (spatial)",

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -69,6 +69,7 @@
         "importShpZip": "Shapefiles must be zipped."
       },
       "operators": {
+        "caseSensitive": "Case sensitive",
         "And": "And",
         "Or": "Or",
         "PropertyIsEqualTo": "=",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -69,6 +69,7 @@
         "importShpZip": "Les shapefiles doivent être compressés (zippés)"
       },
       "operators": {
+        "caseSensitive": "Sensible à la case",
         "And": "Et",
         "Or": "Ou",
         "PropertyIsEqualTo": "=",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -81,9 +81,26 @@
         "PropertyIsBetween": "entre",
         "During": "durant",
         "PropertyIsNull": "est nul",
-        "Intersects": "intersecte",
-        "Within": "contenu dans",
-        "Contains": "contient"
+        "Intersects": "intersecte (géométrique)",
+        "Within": "contenu dans (géométrique)",
+        "Contains": "contient (géométrique)",
+        "tooltip": {
+          "And": "Opérateur logique entre les filtres où les deux conditions doivent être remplies",
+          "Or": "Opérateur logique entre les filtres où au moins une (1) condition doit être vraie",
+          "PropertyIsEqualTo": "Opérateur qui compare si l'attribut correspond à la valeur fournie (sensible à la case)",
+          "PropertyIsNotEqualTo": "Opérateur qui compare si l'attribut est différent de la valeur fournie (sensible à la case)",
+          "PropertyIsLike": "Opérateur de comparaison par modèle. wildCard = '*', singleChar = '.' escapeChar = '!' (sensible à la case)",
+          "PropertyIsGreaterThan": "Opérateur qui vérifie que cet attribut est supérieur à la valeur fournie",
+          "PropertyIsGreaterThanOrEqualTo": "Opérateur qui vérifie si l'attribut est supérieur ou égal à la valeur fournie",
+          "PropertyIsLessThan": "Opérateur qui vérifie que cet attribut est inférieur à la valeur fournie",
+          "PropertyIsLessThanOrEqualTo": "Opérateur qui vérifie que cet attribut est inférieur ou égal à la valeur fournie",
+          "PropertyIsBetween": "Doit être contenu entre les limites inférieure et supérieure (les valeurs sont incluses)",
+          "During": "Doit être contenu entre les périodes de temps spécifiées",
+          "PropertyIsNull": "Dont l'attribut est nul",
+          "Intersects": "Retourne les entités étant en intersection géométrique avec la géométrie fournie",
+          "Within": "Retourne les entités étant entièrement contenue par la géométrie fournie (Within)",
+          "Contains": "Retourne les entités complètement contenues par la géométrie fournie (Contains)"
+        }
       },
       "sourceFields": {
         "selectField": "Choisir un champ"

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -87,21 +87,21 @@
         "Contains": "contient (géométrique)",
         "tooltip": {
           "And": "Opérateur logique entre les filtres où les deux conditions doivent être remplies",
-          "Or": "Opérateur logique entre les filtres où au moins une (1) condition doit être vraie",
-          "PropertyIsEqualTo": "Opérateur qui compare si l'attribut correspond à la valeur fournie (sensible à la case)",
-          "PropertyIsNotEqualTo": "Opérateur qui compare si l'attribut est différent de la valeur fournie (sensible à la case)",
-          "PropertyIsLike": "Opérateur de comparaison par modèle. wildCard = '*', singleChar = '.' escapeChar = '!' (sensible à la case)",
-          "PropertyIsGreaterThan": "Opérateur qui vérifie que cet attribut est supérieur à la valeur fournie",
-          "PropertyIsGreaterThanOrEqualTo": "Opérateur qui vérifie si l'attribut est supérieur ou égal à la valeur fournie",
-          "PropertyIsLessThan": "Opérateur qui vérifie que cet attribut est inférieur à la valeur fournie",
-          "PropertyIsLessThanOrEqualTo": "Opérateur qui vérifie que cet attribut est inférieur ou égal à la valeur fournie",
-          "PropertyIsBetween": "Doit être contenu entre les limites inférieure et supérieure (les valeurs sont incluses)",
-          "During": "Doit être contenu entre les périodes de temps spécifiées",
-          "PropertyIsNull": "Dont l'attribut est nul",
-          "Intersects": "Retourne les entités étant en intersection géométrique avec la géométrie fournie",
-          "Within": "Retourne les entités étant entièrement contenue par la géométrie fournie (Within)",
-          "Contains": "Retourne les entités complètement contenues par la géométrie fournie (Contains)"
-        }
+          "Or": "Opérateur logique entre les filtres où au moins une (1) condition doit être vraie",
+          "PropertyIsEqualTo": "Identique (sensible à la case)",
+          "PropertyIsNotEqualTo": "Différent (sensible à la case)",
+          "PropertyIsLike": "Comme. Exemple: *route* trouve toutes les valeurs contenent 'route', peu importe sa position dans l’attribut. route* trouve toutes les valeurs commencant par 'route'. Options avancées : wildCard ='*', singleChar = '.' escapeChar = '!' (case sensitive)",
+          "PropertyIsGreaterThan": "Plus grand",
+          "PropertyIsGreaterThanOrEqualTo": "Plus grand ou égal",
+          "PropertyIsLessThan": "Plus petit",
+          "PropertyIsLessThanOrEqualTo": "Plus petit ou égal",
+          "PropertyIsBetween": "Doit être contenu entre les limites inférieure et supérieure (les valeurs sont incluses)",
+          "During": "Doit être contenu entre les périodes de temps spécifiées",
+          "PropertyIsNull": "Dont l'attribut est nul",
+          "Intersects": "Retourne les entités étant en intersection géométrique avec la géométrie fournie",
+          "Within": "Retourne les entités étant entièrement contenue par la géométrie fournie (Within)",
+          "Contains": "Retourne les entités complètement contenues par la géométrie fournie (Contains)"
+        }
       },
       "sourceFields": {
         "selectField": "Choisir un champ"

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -80,7 +80,7 @@
         "PropertyIsLessThan": "<",
         "PropertyIsLessThanOrEqualTo": "<=",
         "PropertyIsBetween": "entre",
-        "During": "durant",
+        "During": "durant (temporel)",
         "PropertyIsNull": "est nul",
         "Intersects": "intersecte (géométrique)",
         "Within": "contenu dans (géométrique)",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Allowed operator were defined for all the fields


**What is the new behavior?**
Allowed types are  : 

- 'all' = PropertyIsEqualTo, PropertyIsNotEqualTo, PropertyIsLike, PropertyIsGreaterThan, PropertyIsGreaterThanOrEqualTo, PropertyIsLessThan, PropertyIsLessThanOrEqualTo, PropertyIsBetween, During, PropertyIsNull, Intersects, Within, Contains
- 'spatial' = Intersects and Within
- 'basicandspatial' = PropertyIsEqualTo,PropertyIsNotEqualTo,Intersects and Within 
**(Default value if none provided)**
- 'basic' = PropertyIsEqualTo,PropertyIsNotEqualTo
- 'time' = During
- 'basicnumeric' = PropertyIsEqualTo, PropertyIsNotEqualTo, PropertyIsGreaterThan, - PropertyIsGreaterThanOrEqualTo, PropertyIsLessThan, PropertyIsLessThanOrEqualTo,

     
Now, we can define the allowed filter type for all fields or at the level field. 


```
"sourceFields": [
          { "name": "code_municipalite", "alias": "# de la municipalitée" },
          { "name": "date_observation", "allowedOperatorsType": "time" },
          { "name": "urgence", "allowedOperatorsType": "basic" }
        ],
        "ogcFilters": {
          "allowedOperatorsType": "all",
          "enabled": true,
          "editable": true,
          "filters": {
            "operator": "PropertyIsEqualTo",
            "propertyName": "code_municipalite",
            "expression": "10043"
          }
        },
```


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
