### PR TITLE
Group title emphasis opacity from 0.8 to 0.9

### DIFF
--- a/packages/common/src/lib/list/list.component.scss
+++ b/packages/common/src/lib/list/list.component.scss
@@ -42,7 +42,7 @@ mat-list {
 
 :host >>> .mat-list ::ng-deep igo-collapsible > .mat-list-item > .mat-list-item-content > .mat-list-text > .mat-line {
   font-weight: bold;
-  opacity: 0.8;
+  opacity: 0.9;
 }
 
 :host

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.scss
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.scss
@@ -1,6 +1,6 @@
 .igo-catalog-group-title  {
   cursor: pointer;
-  opacity: 0.8;
+  opacity: 0.9;
 }
 
 #catalog-group-title {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Low emphasis due to opacity.
Related to https://github.com/infra-geo-ouverte/igo2-lib/pull/542


**What is the new behavior?**
Better emphasis

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
