### PR TITLE
feat(QueryService): Add create geom for mapTag when geom is null on extractData #617

### DIFF
--- a/demo/src/app/geo/query/query.component.ts
+++ b/demo/src/app/geo/query/query.component.ts
@@ -67,12 +67,11 @@ export class AppQueryComponent {
     this.dataSourceService
       .createAsyncDataSource({
         type: 'wms',
-        url: 'https://servicescarto.mern.gouv.qc.ca/pes/services/Forets/STF_WMS/MapServer/WMSServer',
+        url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/swtq',
         queryable: true,
-        queryFormat: QueryFormat.GEOJSON,
-        queryTitle: 'Numéro',
+        queryTitle: 'num_rts',
         params: {
-          layers: 'Refuge biologique - p',
+          layers: 'bgr_v_sous_route_res_sup_act',
           version: '1.3.0'
         }
       } as QueryableDataSourceOptions)
@@ -84,28 +83,7 @@ export class AppQueryComponent {
             sourceOptions: dataSource.options
           })
         );
-    });
-
-    // this.dataSourceService
-    //   .createAsyncDataSource({
-    //     type: 'wms',
-    //     url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/swtq',
-    //     queryable: true,
-    //     queryTitle: 'num_rts',
-    //     params: {
-    //       layers: 'bgr_v_sous_route_res_sup_act',
-    //       version: '1.3.0'
-    //     }
-    //   } as QueryableDataSourceOptions)
-    //   .subscribe(dataSource => {
-    //     this.map.addLayer(
-    //       this.layerService.createLayer({
-    //         title: 'WMS',
-    //         source: dataSource,
-    //         sourceOptions: dataSource.options
-    //       })
-    //     );
-    //   });
+      });
 
     this.dataSourceService
       .createAsyncDataSource({

--- a/demo/src/app/geo/query/query.component.ts
+++ b/demo/src/app/geo/query/query.component.ts
@@ -67,11 +67,12 @@ export class AppQueryComponent {
     this.dataSourceService
       .createAsyncDataSource({
         type: 'wms',
-        url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/swtq',
+        url: 'https://servicescarto.mern.gouv.qc.ca/pes/services/Forets/STF_WMS/MapServer/WMSServer',
         queryable: true,
-        queryTitle: 'num_rts',
+        queryFormat: QueryFormat.GEOJSON,
+        queryTitle: 'Numéro',
         params: {
-          layers: 'bgr_v_sous_route_res_sup_act',
+          layers: 'Refuge biologique - p',
           version: '1.3.0'
         }
       } as QueryableDataSourceOptions)
@@ -83,7 +84,28 @@ export class AppQueryComponent {
             sourceOptions: dataSource.options
           })
         );
-      });
+    });
+
+    // this.dataSourceService
+    //   .createAsyncDataSource({
+    //     type: 'wms',
+    //     url: 'https://geoegl.msp.gouv.qc.ca/apis/ws/swtq',
+    //     queryable: true,
+    //     queryTitle: 'num_rts',
+    //     params: {
+    //       layers: 'bgr_v_sous_route_res_sup_act',
+    //       version: '1.3.0'
+    //     }
+    //   } as QueryableDataSourceOptions)
+    //   .subscribe(dataSource => {
+    //     this.map.addLayer(
+    //       this.layerService.createLayer({
+    //         title: 'WMS',
+    //         source: dataSource,
+    //         sourceOptions: dataSource.options
+    //       })
+    //     );
+    //   });
 
     this.dataSourceService
       .createAsyncDataSource({

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -270,6 +270,15 @@ export class QueryService {
         break;
     }
 
+    if (features.length > 0 && features[0].geometry == null) {
+      console.log('geom est null!!');
+      const geomToAdd = this.createGeometryFromUrlClick(url);
+
+      for (const feature of features) {
+        feature.geometry = geomToAdd;
+      }
+    }
+
     return features.map((feature: Feature, index: number) => {
       const mapLabel = feature.properties[queryDataSource.mapLabel];
 
@@ -304,6 +313,72 @@ export class QueryService {
             : options.projection
       });
     });
+  }
+
+  private createGeometryFromUrlClick(url) {
+
+    const searchParams: any = this.getQueryParams(url.toLowerCase());
+    const bboxRaw = searchParams.bbox;
+    const width = parseInt(searchParams.width, 10);
+    const height = parseInt(searchParams.height, 10);
+    const xPosition = parseInt(searchParams.i || searchParams.x, 10);
+    const yPosition = parseInt(searchParams.j || searchParams.y, 10);
+    const projection = searchParams.crs || searchParams.srs || 'EPSG:3857';
+
+    const bbox = bboxRaw.split(',');
+    let threshold =
+      (Math.abs(parseFloat(bbox[0])) - Math.abs(parseFloat(bbox[2]))) * 0.05;
+
+    // for context in degree (EPSG:4326,4269...)
+    if (Math.abs(parseFloat(bbox[0])) < 180) {
+      threshold = 0.045;
+    }
+    const clickx =
+      parseFloat(bbox[0]) +
+      (Math.abs(parseFloat(bbox[0]) - parseFloat(bbox[2])) * xPosition) /
+        width -
+      threshold;
+    const clicky =
+      parseFloat(bbox[1]) +
+      (Math.abs(parseFloat(bbox[1]) - parseFloat(bbox[3])) * yPosition) /
+        height -
+      threshold;
+    const clickx1 = clickx + threshold * 2;
+    const clicky1 = clicky + threshold * 2;
+
+    const wktPoly =
+      'POLYGON((' +
+      clickx +
+      ' ' +
+      clicky +
+      ', ' +
+      clickx +
+      ' ' +
+      clicky1 +
+      ', ' +
+      clickx1 +
+      ' ' +
+      clicky1 +
+      ', ' +
+      clickx1 +
+      ' ' +
+      clicky +
+      ', ' +
+      clickx +
+      ' ' +
+      clicky +
+      '))';
+
+    const format = new olformat.WKT();
+    const tenPercentWidthGeom = format.readFeature(wktPoly);
+    const f = tenPercentWidthGeom.getGeometry() as any;
+
+    const newGeom = {
+          type: f.getType(),
+          coordinates: f.getCoordinates()
+    };
+
+    return newGeom;
   }
 
   private extractGML2Data(res, zIndex, allowedFieldsAndAlias?) {
@@ -364,61 +439,63 @@ export class QueryService {
   ) {
     // _blank , iframe or undefined
     const searchParams: any = this.getQueryParams(url.toLowerCase());
-    const bboxRaw = searchParams.bbox;
-    const width = parseInt(searchParams.width, 10);
-    const height = parseInt(searchParams.height, 10);
-    const xPosition = parseInt(searchParams.i || searchParams.x, 10);
-    const yPosition = parseInt(searchParams.j || searchParams.y, 10);
+    // const bboxRaw = searchParams.bbox;
+    // const width = parseInt(searchParams.width, 10);
+    // const height = parseInt(searchParams.height, 10);
+    // const xPosition = parseInt(searchParams.i || searchParams.x, 10);
+    // const yPosition = parseInt(searchParams.j || searchParams.y, 10);
     const projection = searchParams.crs || searchParams.srs || 'EPSG:3857';
 
-    const bbox = bboxRaw.split(',');
-    let threshold =
-      (Math.abs(parseFloat(bbox[0])) - Math.abs(parseFloat(bbox[2]))) * 0.05;
+    // const bbox = bboxRaw.split(',');
+    // let threshold =
+    //   (Math.abs(parseFloat(bbox[0])) - Math.abs(parseFloat(bbox[2]))) * 0.05;
 
-    // for context in degree (EPSG:4326,4269...)
-    if (Math.abs(parseFloat(bbox[0])) < 180) {
-      threshold = 0.045;
-    }
+    // // for context in degree (EPSG:4326,4269...)
+    // if (Math.abs(parseFloat(bbox[0])) < 180) {
+    //   threshold = 0.045;
+    // }
 
-    const clickx =
-      parseFloat(bbox[0]) +
-      (Math.abs(parseFloat(bbox[0]) - parseFloat(bbox[2])) * xPosition) /
-        width -
-      threshold;
-    const clicky =
-      parseFloat(bbox[1]) +
-      (Math.abs(parseFloat(bbox[1]) - parseFloat(bbox[3])) * yPosition) /
-        height -
-      threshold;
-    const clickx1 = clickx + threshold * 2;
-    const clicky1 = clicky + threshold * 2;
+    // const clickx =
+    //   parseFloat(bbox[0]) +
+    //   (Math.abs(parseFloat(bbox[0]) - parseFloat(bbox[2])) * xPosition) /
+    //     width -
+    //   threshold;
+    // const clicky =
+    //   parseFloat(bbox[1]) +
+    //   (Math.abs(parseFloat(bbox[1]) - parseFloat(bbox[3])) * yPosition) /
+    //     height -
+    //   threshold;
+    // const clickx1 = clickx + threshold * 2;
+    // const clicky1 = clicky + threshold * 2;
 
-    const wktPoly =
-      'POLYGON((' +
-      clickx +
-      ' ' +
-      clicky +
-      ', ' +
-      clickx +
-      ' ' +
-      clicky1 +
-      ', ' +
-      clickx1 +
-      ' ' +
-      clicky1 +
-      ', ' +
-      clickx1 +
-      ' ' +
-      clicky +
-      ', ' +
-      clickx +
-      ' ' +
-      clicky +
-      '))';
+    // const wktPoly =
+    //   'POLYGON((' +
+    //   clickx +
+    //   ' ' +
+    //   clicky +
+    //   ', ' +
+    //   clickx +
+    //   ' ' +
+    //   clicky1 +
+    //   ', ' +
+    //   clickx1 +
+    //   ' ' +
+    //   clicky1 +
+    //   ', ' +
+    //   clickx1 +
+    //   ' ' +
+    //   clicky +
+    //   ', ' +
+    //   clickx +
+    //   ' ' +
+    //   clicky +
+    //   '))';
 
-    const format = new olformat.WKT();
-    const tenPercentWidthGeom = format.readFeature(wktPoly);
-    const f = tenPercentWidthGeom.getGeometry() as any;
+    // const format = new olformat.WKT();
+    // const tenPercentWidthGeom = format.readFeature(wktPoly);
+    // const f = tenPercentWidthGeom.getGeometry() as any;
+
+    const geomToAdd = this.createGeometryFromUrlClick(url);
 
     if (
       htmlTarget !== QueryHtmlTarget.BLANK &&
@@ -440,10 +517,11 @@ export class QueryService {
         type: FEATURE,
         projection,
         properties: { target: htmlTarget, body: res, url },
-        geometry: imposedGeometry || {
-          type: f.getType(),
-          coordinates: f.getCoordinates()
-        }
+        geometry: imposedGeometry || geomToAdd
+        // {
+        //   type: f.getType(),
+        //   coordinates: f.getCoordinates()
+        // }
       }
     ];
   }

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -437,64 +437,9 @@ export class QueryService {
     url,
     imposedGeometry?
   ) {
-    // _blank , iframe or undefined
+
     const searchParams: any = this.getQueryParams(url.toLowerCase());
-    // const bboxRaw = searchParams.bbox;
-    // const width = parseInt(searchParams.width, 10);
-    // const height = parseInt(searchParams.height, 10);
-    // const xPosition = parseInt(searchParams.i || searchParams.x, 10);
-    // const yPosition = parseInt(searchParams.j || searchParams.y, 10);
     const projection = searchParams.crs || searchParams.srs || 'EPSG:3857';
-
-    // const bbox = bboxRaw.split(',');
-    // let threshold =
-    //   (Math.abs(parseFloat(bbox[0])) - Math.abs(parseFloat(bbox[2]))) * 0.05;
-
-    // // for context in degree (EPSG:4326,4269...)
-    // if (Math.abs(parseFloat(bbox[0])) < 180) {
-    //   threshold = 0.045;
-    // }
-
-    // const clickx =
-    //   parseFloat(bbox[0]) +
-    //   (Math.abs(parseFloat(bbox[0]) - parseFloat(bbox[2])) * xPosition) /
-    //     width -
-    //   threshold;
-    // const clicky =
-    //   parseFloat(bbox[1]) +
-    //   (Math.abs(parseFloat(bbox[1]) - parseFloat(bbox[3])) * yPosition) /
-    //     height -
-    //   threshold;
-    // const clickx1 = clickx + threshold * 2;
-    // const clicky1 = clicky + threshold * 2;
-
-    // const wktPoly =
-    //   'POLYGON((' +
-    //   clickx +
-    //   ' ' +
-    //   clicky +
-    //   ', ' +
-    //   clickx +
-    //   ' ' +
-    //   clicky1 +
-    //   ', ' +
-    //   clickx1 +
-    //   ' ' +
-    //   clicky1 +
-    //   ', ' +
-    //   clickx1 +
-    //   ' ' +
-    //   clicky +
-    //   ', ' +
-    //   clickx +
-    //   ' ' +
-    //   clicky +
-    //   '))';
-
-    // const format = new olformat.WKT();
-    // const tenPercentWidthGeom = format.readFeature(wktPoly);
-    // const f = tenPercentWidthGeom.getGeometry() as any;
-
     const geomToAdd = this.createGeometryFromUrlClick(url);
 
     if (
@@ -518,10 +463,6 @@ export class QueryService {
         projection,
         properties: { target: htmlTarget, body: res, url },
         geometry: imposedGeometry || geomToAdd
-        // {
-        //   type: f.getType(),
-        //   coordinates: f.getCoordinates()
-        // }
       }
     ];
   }

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -271,7 +271,6 @@ export class QueryService {
     }
 
     if (features.length > 0 && features[0].geometry == null) {
-      console.log('geom est null!!');
       const geomToAdd = this.createGeometryFromUrlClick(url);
 
       for (const feature of features) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
#617 


**What is the new behavior?**
When the geom is null, create a new geom from urlClick, a square polgone around click, and put it in geometry of features.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
