### PR TITLE
fix(TimeFilter): calendar year range, don't reset year range in UI (igo2 #359)

### DIFF
--- a/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.ts
@@ -127,6 +127,13 @@ export class TimeFilterFormComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {
+    // if (this.timeFilterService.yearFilterIsActive) {
+    //   this.startYear = this.timeFilterService.yearsFilteredActive[0];
+    //   this.initStartYear = this.timeFilterService.yearsInitial[0];
+    //   this.endYear = this.timeFilterService.yearsFilteredActive[1];
+    //   this.initEndYear = this.timeFilterService.yearsInitial[1];
+    // }
+
     if (this.startDate === undefined) {
       const utcmin = new Date(this.min);
       this.startDate = new Date(
@@ -142,10 +149,12 @@ export class TimeFilterFormComponent implements OnInit {
     if (this.startYear === undefined) {
       this.startYear = new Date(this.startDate).getFullYear();
       this.initStartYear = this.startYear;
+      // this.timeFilterService.yearsInitial.push(this.initStartYear);
     }
     if (this.endYear === undefined) {
       this.endYear = new Date(this.endDate).getFullYear();
       this.initEndYear = this.endYear;
+      // this.timeFilterService.yearsInitial.push(this.initEndYear);
     }
 
     if (!this.isRange) {
@@ -162,6 +171,7 @@ export class TimeFilterFormComponent implements OnInit {
     }
     this.options.enabled = this.options.enabled === undefined ? true : this.options.enabled;
     this.checkFilterValue();
+    debugger;
     if (this.options.enabled) {
       if (!this.isRange && this.style === 'slider' && this.type === 'year') {
         this.yearChange.emit(this.year);
@@ -189,9 +199,28 @@ export class TimeFilterFormComponent implements OnInit {
       } else {
         this.year = new Date(this.min).getFullYear() + 1;
       }
-    } else {
-      // TODO: FIX THIS for ALL OTHER TYPES STYLES OR RANGE.
+
+    } else if (this.isRange && this.style === TimeFilterStyle.CALENDAR && this.type === TimeFilterType.YEAR) {
+      debugger;
+      if (timeFromWms) {
+        this.startYear = parseInt(timeFromWms.substr(0, 4));
+        this.endYear = parseInt(timeFromWms.substr(5, 4));
+        const newStartListYears: any[] = [];
+        const newEndListYears: any[] = [];
+        for (let i = this.initStartYear; i < this.endYear; i++) {
+          newStartListYears.push(i);
+        }
+        for (let i = this.startYear + 1; i <= this.initEndYear; i++) {
+          newEndListYears.push(i);
+        }
+        this.startListYears = newStartListYears;
+        this.endListYears = newEndListYears;
+        debugger;
+      } else {
+        console.log('time du service est vide...')
+      }
     }
+       // TODO: FIX THIS for ALL OTHER TYPES STYLES OR RANGE.
   }
 
   handleDateChange(event: any) {
@@ -266,6 +295,7 @@ export class TimeFilterFormComponent implements OnInit {
   }
 
   toggleFilterState() {
+    debugger;
     this.options.enabled = !this.options.enabled;
 
     if (this.options.enabled) {
@@ -280,6 +310,7 @@ export class TimeFilterFormComponent implements OnInit {
   }
 
   resetFilter(event: any) {
+    debugger;
     this.date = new Date(this.min);
     this.year = this.date.getFullYear() + 1;
     if (!this.isRange && TimeFilterStyle.SLIDER && this.type === TimeFilterType.YEAR) {
@@ -342,6 +373,7 @@ export class TimeFilterFormComponent implements OnInit {
   }
 
   stopFilter() {
+    debugger;
     if (this.interval) {
       clearInterval(this.interval);
     }

--- a/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-form/time-filter-form.component.ts
@@ -127,12 +127,6 @@ export class TimeFilterFormComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {
-    // if (this.timeFilterService.yearFilterIsActive) {
-    //   this.startYear = this.timeFilterService.yearsFilteredActive[0];
-    //   this.initStartYear = this.timeFilterService.yearsInitial[0];
-    //   this.endYear = this.timeFilterService.yearsFilteredActive[1];
-    //   this.initEndYear = this.timeFilterService.yearsInitial[1];
-    // }
 
     if (this.startDate === undefined) {
       const utcmin = new Date(this.min);
@@ -149,12 +143,10 @@ export class TimeFilterFormComponent implements OnInit {
     if (this.startYear === undefined) {
       this.startYear = new Date(this.startDate).getFullYear();
       this.initStartYear = this.startYear;
-      // this.timeFilterService.yearsInitial.push(this.initStartYear);
     }
     if (this.endYear === undefined) {
       this.endYear = new Date(this.endDate).getFullYear();
       this.initEndYear = this.endYear;
-      // this.timeFilterService.yearsInitial.push(this.initEndYear);
     }
 
     if (!this.isRange) {
@@ -171,7 +163,6 @@ export class TimeFilterFormComponent implements OnInit {
     }
     this.options.enabled = this.options.enabled === undefined ? true : this.options.enabled;
     this.checkFilterValue();
-    debugger;
     if (this.options.enabled) {
       if (!this.isRange && this.style === 'slider' && this.type === 'year') {
         this.yearChange.emit(this.year);
@@ -201,10 +192,9 @@ export class TimeFilterFormComponent implements OnInit {
       }
 
     } else if (this.isRange && this.style === TimeFilterStyle.CALENDAR && this.type === TimeFilterType.YEAR) {
-      debugger;
       if (timeFromWms) {
-        this.startYear = parseInt(timeFromWms.substr(0, 4));
-        this.endYear = parseInt(timeFromWms.substr(5, 4));
+        this.startYear = parseInt(timeFromWms.substr(0, 4), 10);
+        this.endYear = parseInt(timeFromWms.substr(5, 4), 10);
         const newStartListYears: any[] = [];
         const newEndListYears: any[] = [];
         for (let i = this.initStartYear; i < this.endYear; i++) {
@@ -215,9 +205,6 @@ export class TimeFilterFormComponent implements OnInit {
         }
         this.startListYears = newStartListYears;
         this.endListYears = newEndListYears;
-        debugger;
-      } else {
-        console.log('time du service est vide...')
       }
     }
        // TODO: FIX THIS for ALL OTHER TYPES STYLES OR RANGE.
@@ -295,7 +282,6 @@ export class TimeFilterFormComponent implements OnInit {
   }
 
   toggleFilterState() {
-    debugger;
     this.options.enabled = !this.options.enabled;
 
     if (this.options.enabled) {
@@ -310,7 +296,6 @@ export class TimeFilterFormComponent implements OnInit {
   }
 
   resetFilter(event: any) {
-    debugger;
     this.date = new Date(this.min);
     this.year = this.date.getFullYear() + 1;
     if (!this.isRange && TimeFilterStyle.SLIDER && this.type === TimeFilterType.YEAR) {
@@ -373,7 +358,6 @@ export class TimeFilterFormComponent implements OnInit {
   }
 
   stopFilter() {
-    debugger;
     if (this.interval) {
       clearInterval(this.interval);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The years range show in ui reset when the user close the filter detail
https://github.com/infra-geo-ouverte/igo2/issues/359


**What is the new behavior?**
The years doesn't reset when the user close filter detail


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
