### PR TITLE
Hide all non active legend when allowShowAllLegends is false (on context change)

### DIFF
--- a/packages/integration/src/lib/map/map-legend/map-legend-tool.component.ts
+++ b/packages/integration/src/lib/map/map-legend/map-legend-tool.component.ts
@@ -114,11 +114,15 @@ export class MapLegendToolComponent implements OnInit, OnDestroy {
         );
       });
 
-    this.mapState.showAllLegendsValue =
-      this.mapState.showAllLegendsValue !== undefined
-        ? this.mapState.showAllLegendsValue
-        : this.showAllLegendsValue || false;
-    this.showAllLegendsValue$.next(this.mapState.showAllLegendsValue);
+    if (this.allowShowAllLegends) {
+      this.mapState.showAllLegendsValue =
+        this.mapState.showAllLegendsValue !== undefined
+          ? this.mapState.showAllLegendsValue
+          : this.showAllLegendsValue || false;
+      this.showAllLegendsValue$.next(this.mapState.showAllLegendsValue);
+    } else {
+      this.showAllLegendsValue$.next(false);
+    }
 
     // prevent message to be shown too quickly. Waiting for layers
     setTimeout(() => {

--- a/packages/integration/src/lib/map/map-tools/map-tools.component.ts
+++ b/packages/integration/src/lib/map/map-tools/map-tools.component.ts
@@ -177,11 +177,16 @@ export class MapToolsComponent implements OnInit, OnDestroy {
         );
       });
 
-    this.mapState.showAllLegendsValue =
-      this.mapState.showAllLegendsValue !== undefined
-        ? this.mapState.showAllLegendsValue
-        : this.showAllLegendsValue || false;
-    this.showAllLegendsValue$.next(this.mapState.showAllLegendsValue);
+    if (this.allowShowAllLegends) {
+      this.mapState.showAllLegendsValue =
+        this.mapState.showAllLegendsValue !== undefined
+          ? this.mapState.showAllLegendsValue
+          : this.showAllLegendsValue || false;
+      this.showAllLegendsValue$.next(this.mapState.showAllLegendsValue);
+    } else {
+      this.showAllLegendsValue$.next(false);
+    }
+
 
     // prevent message to be shown too quickly. Waiting for layers
     setTimeout(() => (this.delayedShowEmptyMapContent = true), 250);

--- a/packages/integration/src/lib/map/map-tools/map-tools.component.ts
+++ b/packages/integration/src/lib/map/map-tools/map-tools.component.ts
@@ -187,7 +187,6 @@ export class MapToolsComponent implements OnInit, OnDestroy {
       this.showAllLegendsValue$.next(false);
     }
 
-
     // prevent message to be shown too quickly. Waiting for layers
     setTimeout(() => (this.delayedShowEmptyMapContent = true), 250);
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
On context change, the configurated value for allowShowAllLegends was not kept. Then on context change, the previous context values were use. Resulting for large contexte to call ALL the legends despite of the configurated value.... 


**What is the new behavior?**
Fix previous. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```