### PR TITLE
Legend tool translations and catalog empty property.

### DIFF
--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
@@ -87,7 +87,8 @@ export class CatalogBrowserComponent implements OnInit, OnDestroy {
       });
     }
 
-    this.catalogAllowLegend = this.catalog.showLegend ? this.catalog.showLegend : this.catalogAllowLegend;
+    const catalogShowLegend = this.catalog ? this.catalog.showLegend : false;
+    this.catalogAllowLegend = catalogShowLegend ? catalogShowLegend : this.catalogAllowLegend;
 
     this.watcher = new EntityStoreWatcher(this.store, this.cdRef);
 

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -155,10 +155,10 @@
         "legend": {
           "default": "Défaut",
           "loadingLegendText": "Chargement de la légende",
-          "noLegendText": "Aucune légende disponible pour cette couche",
-          "noLegendScale": "Aucune légende disponible pour cette échelle",
+          "noLegendText": "Aucune symbologie disponible pour cette couche",
+          "noLegendScale": "Aucune symbologie disponible pour cette échelle",
           "selectStyle": "Sélectionner le style de la légende",
-          "showAll" : "Montrer toutes les légendes (non visible et hors échelle)",
+          "showAll" : "Montrer toutes les couches (non visible et hors échelle)",
           "noLayersVisibleWithShowAllButton": "Aucune couche actuellement visible. Activez le bouton ci haut pour voir toutes les légendes.",
           "noLayersVisibleWithShowAllButtonButZoom": "Aucune couche actuellement visible. Si vous zoomez dans la carte, certaines couches apparaîtront OU activez le bouton ci haut pour voir toutes les légendes.",
           "noLayersVisible": "Aucune couche actuellement visible.",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
[The demo](https://infra-geo-ouverte.github.io/igo2-lib/#/catalog) crash on an empty property


**What is the new behavior?**
1- translation in french are modified
2- Trap the undefined catalog in the catalog-browser-component


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
