### PR TITLE
fix(spatial-filter): fix polygon/line layer display

### DIFF
--- a/packages/integration/src/lib/filter/spatial-filter-tool/spatial-filter-tool.component.ts
+++ b/packages/integration/src/lib/filter/spatial-filter-tool/spatial-filter-tool.component.ts
@@ -369,7 +369,7 @@ export class SpatialFilterToolComponent {
    */
   private tryAddLayerToMap(features: Feature[], id) {
     let i = 1;
-    if (features.length > 1) {
+    if (features.length) {
       if (this.map === undefined) {
         return;
       }


### PR DESCRIPTION
Fix polygon/line layer display. Wasn't entering the if condition when there was only one feature, so the layer was never added to the map.
