### PR TITLE
fix(importExport)Skip while exportOptions undefined

### DIFF
--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -23,6 +23,7 @@ import {
 import { StyleService } from '../../layer/shared/style.service';
 import { StyleListService } from '../style-list/style-list.service';
 import { MatTabChangeEvent } from '@angular/material';
+import { skipWhile } from 'rxjs/operators';
 
 @Component({
   selector: 'igo-import-export',
@@ -82,9 +83,11 @@ export class ImportExportComponent implements OnDestroy, OnInit {
       (configFileSizeMb ? configFileSizeMb : 30) * Math.pow(1024, 2);
     this.fileSizeMb = this.clientSideFileSizeMax / Math.pow(1024, 2);
 
-    this.exportOptions$$ = this.exportOptions$.subscribe((exportOptions) => {
-      this.form.patchValue(exportOptions, {emitEvent: false} );
-    });
+    this.exportOptions$$ = this.exportOptions$
+      .pipe(skipWhile(exportOptions => !exportOptions))
+      .subscribe((exportOptions) => {
+        this.form.patchValue(exportOptions, { emitEvent: false });
+      });
 
     this.form$$ = this.form.valueChanges.subscribe(() => {
       this.exportOptionsChange.emit(this.form.value);

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -210,17 +210,17 @@ export class ImportExportComponent implements OnDestroy, OnInit {
     }
 
     if (this.config.getConfig('importExport.formats') !== undefined) {
-      const liste = this.validerListeFormat(
+      const validatedListFormat = this.validateListFormat(
         this.config.getConfig('importExport.formats')
       );
-      this.formats = strEnum(liste);
+      this.formats = strEnum(validatedListFormat);
     } else {
       this.formats = ExportFormat;
     }
   }
 
-  private validerListeFormat(liste: string[]): string[] {
-    return liste
+  private validateListFormat(formats: string[]): string[] {
+    return formats
       .filter(format => {
         if (
           format.toUpperCase() === ExportFormat.CSV.toUpperCase() ||


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When exportOptions is undefined , cause export tool to crash.


**What is the new behavior?**
Skip until exportOptions until the value is not undefined.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
