### PR TITLE
Export by url

### DIFF
--- a/packages/geo/src/lib/import-export/export-button/export-button.component.html
+++ b/packages/geo/src/lib/import-export/export-button/export-button.component.html
@@ -1,0 +1,11 @@
+<button
+  *ngIf="layerIsExportable()"
+  mat-icon-button
+  tooltip-position="below"
+  matTooltipShowDelay="500"
+  [matTooltip]="'igo.geo.download.action' | translate"
+  [color]="color">
+  <!-- (click)="openDownload(layer)"> -->
+  <mat-icon svgIcon="file-export"></mat-icon>
+</button>
+

--- a/packages/geo/src/lib/import-export/export-button/export-button.component.ts
+++ b/packages/geo/src/lib/import-export/export-button/export-button.component.ts
@@ -1,0 +1,48 @@
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+
+import { Layer } from '../../layer/shared/layers/layer';
+
+import { LayerOptions, VectorLayer } from '../../layer';
+
+@Component({
+  selector: 'igo-export-button',
+  templateUrl: './export-button.component.html',
+  styleUrls: ['./export-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ExportButtonComponent {
+  @Input()
+  get layer(): Layer {
+    return this._layer;
+  }
+  set layer(value: Layer) {
+    this._layer = value;
+  }
+  private _layer: Layer;
+
+  @Input()
+  get color() {
+    return this._color;
+  }
+  set color(value: string) {
+    this._color = value;
+  }
+  private _color = 'primary';
+
+  constructor() {}
+
+  get options(): LayerOptions {
+    if (!this.layer) {
+      return;
+    }
+    return this.layer.dataSource.options;
+  }
+
+  layerIsExportable(): boolean {
+    if ((this.layer instanceof VectorLayer && this.layer.exportable === true) ||
+      (this.layer.dataSource.options.download && this.layer.dataSource.options.download.url)) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/geo/src/lib/import-export/export-button/index.ts
+++ b/packages/geo/src/lib/import-export/export-button/index.ts
@@ -1,0 +1,1 @@
+export * from './export-button.component';

--- a/packages/geo/src/lib/import-export/import-export.module.ts
+++ b/packages/geo/src/lib/import-export/import-export.module.ts
@@ -8,18 +8,23 @@ import {
   MatOptionModule,
   MatFormFieldModule,
   MatInputModule,
-  MatSlideToggleModule
+  MatSlideToggleModule,
+  MatIconModule,
+  MatTooltipModule
 } from '@angular/material';
 
 import { IgoLanguageModule } from '@igo2/core';
 import { IgoKeyValueModule, IgoDrapDropModule, IgoSpinnerModule } from '@igo2/common';
 
+import { ExportButtonComponent } from './export-button/export-button.component';
 import { ImportExportComponent } from './import-export/import-export.component';
 import { DropGeoFileDirective } from './shared/drop-geo-file.directive';
 import { IgoStyleListModule } from './style-list/style-list.module';
 
 @NgModule({
   imports: [
+    MatIconModule,
+    MatTooltipModule,
     FormsModule,
     ReactiveFormsModule,
     CommonModule,
@@ -36,8 +41,8 @@ import { IgoStyleListModule } from './style-list/style-list.module';
     IgoDrapDropModule,
     IgoStyleListModule.forRoot()
   ],
-  exports: [ImportExportComponent, DropGeoFileDirective, IgoStyleListModule],
-  declarations: [ImportExportComponent, DropGeoFileDirective]
+  exports: [ImportExportComponent, DropGeoFileDirective, IgoStyleListModule, ExportButtonComponent],
+  declarations: [ImportExportComponent, DropGeoFileDirective, ExportButtonComponent]
 })
 export class IgoImportExportModule {
   static forRoot(): ModuleWithProviders {

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.html
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.html
@@ -66,13 +66,13 @@
         </mat-form-field>
       </div>
 
-      <div class="igo-input-container" *ngIf="forceNaming">
+      <div class="igo-input-container" *ngIf="forceNaming && form.value.format !== 'URL'">
         <mat-form-field>
             <input matInput formControlName="name" placeholder="{{'igo.geo.importExportForm.exportFileNamePlaceholder' | translate}}">
         </mat-form-field>
       </div>
 
-      <div class="export-options mat-typography">
+      <div class="export-options mat-typography" *ngIf="form.value.format !== 'URL'">
         <mat-slide-toggle
            formControlName="featureInMapExtent"
            [labelPosition]="'before'">
@@ -86,7 +86,7 @@
           type="button"
           [disabled]="!form.valid || (loading$ | async)"
           (click)="handleExportFormSubmit(form.value)">
-          {{'igo.geo.importExportForm.exportButton' | translate}}
+          {{form.value.format !== 'URL'  ? ('igo.geo.importExportForm.exportButton' | translate): ('igo.geo.importExportForm.exportButtonLink' | translate)}}
         </button>
         <igo-spinner [shown]="loading$ | async"></igo-spinner>
       </div>

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.html
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.html
@@ -37,8 +37,11 @@
   </mat-tab>
 
   <mat-tab [label]="'igo.geo.importExportForm.exportTabTitle' | translate">
-    <form class="igo-form" [formGroup]="form">
+    <section class="mat-typography" *ngIf="layers.length === 0">
+      <h4>{{'igo.geo.importExportForm.exportNoLayersExportable' | translate}}</h4>
+    </section>
 
+   <form class="igo-form" [formGroup]="form" *ngIf="layers.length > 0">
       <div class="igo-input-container">
         <mat-form-field>
           <mat-select

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.html
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.html
@@ -37,17 +37,17 @@
   </mat-tab>
 
   <mat-tab [label]="'igo.geo.importExportForm.exportTabTitle' | translate">
-    <section class="mat-typography" *ngIf="layers.length === 0">
+    <section class="mat-typography" *ngIf="(exportableLayers$ | async).length === 0">
       <h4>{{'igo.geo.importExportForm.exportNoLayersExportable' | translate}}</h4>
     </section>
 
-   <form class="igo-form" [formGroup]="form" *ngIf="layers.length > 0">
+   <form class="igo-form" [formGroup]="form" *ngIf="(exportableLayers$ | async).length > 0">
       <div class="igo-input-container">
         <mat-form-field>
           <mat-select
             formControlName="layer"
             placeholder="{{'igo.geo.importExportForm.exportLayerPlaceholder' | translate}}">
-            <mat-option *ngFor="let layer of layers" [value]="layer.id">
+            <mat-option *ngFor="let layer of (exportableLayers$ | async)" [value]="layer.id">
               {{layer.title}}
             </mat-option>
           </mat-select>

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.html
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.html
@@ -56,7 +56,7 @@
           <mat-select
             formControlName="format"
             placeholder="{{'igo.geo.importExportForm.exportFormatPlaceholder' | translate}}">
-            <mat-option *ngFor="let format of formats | keyvalue " [value]="format.key">
+            <mat-option *ngFor="let format of (formats$ | async) | keyvalue " [value]="format.key">
               {{format.value}}
             </mat-option>
           </mat-select>

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -101,6 +101,9 @@ export class ImportExportComponent implements OnDestroy, OnInit {
 
     this.formLayer$$ = this.form.get('layer').valueChanges.subscribe((layerId) => {
       this.computeFormats(this.map.getLayerById(layerId));
+      if (Object.keys(this.formats$.value).indexOf(this.form.value.format) === -1) {
+        this.form.patchValue({ format: undefined });
+      }
     });
 
     this.formats$$ = this.formats$

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -32,7 +32,8 @@ import { skipWhile } from 'rxjs/operators';
 })
 export class ImportExportComponent implements OnDestroy, OnInit {
   public form: FormGroup;
-  public formats;
+  public selectedFormat$ = new BehaviorSubject(undefined);
+  public formats$ = new BehaviorSubject(undefined);
   public layers: VectorLayer[];
   public inputProj: string = 'EPSG:4326';
   public loading$ = new BehaviorSubject(false);
@@ -213,9 +214,9 @@ export class ImportExportComponent implements OnDestroy, OnInit {
       const validatedListFormat = this.validateListFormat(
         this.config.getConfig('importExport.formats')
       );
-      this.formats = strEnum(validatedListFormat);
+      this.formats$.next(strEnum(validatedListFormat));
     } else {
-      this.formats = ExportFormat;
+      this.formats$.next(ExportFormat);
     }
   }
 

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -23,6 +23,7 @@ import {
 import { StyleService } from '../../layer/shared/style.service';
 import { StyleListService } from '../style-list/style-list.service';
 import { MatTabChangeEvent } from '@angular/material';
+import { skipWhile } from 'rxjs/operators';
 
 @Component({
   selector: 'igo-import-export',
@@ -82,9 +83,11 @@ export class ImportExportComponent implements OnDestroy, OnInit {
       (configFileSizeMb ? configFileSizeMb : 30) * Math.pow(1024, 2);
     this.fileSizeMb = this.clientSideFileSizeMax / Math.pow(1024, 2);
 
-    this.exportOptions$$ = this.exportOptions$.subscribe((exportOptions) => {
-      this.form.patchValue(exportOptions, {emitEvent: false} );
-    });
+    this.exportOptions$$ = this.exportOptions$
+      .pipe(skipWhile(exportOptions => !exportOptions))
+      .subscribe((exportOptions) => {
+        this.form.patchValue(exportOptions, { emitEvent: false });
+      });
 
     this.form$$ = this.form.valueChanges.subscribe(() => {
       this.exportOptionsChange.emit(this.form.value);

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -210,17 +210,17 @@ export class ImportExportComponent implements OnDestroy, OnInit {
     }
 
     if (this.config.getConfig('importExport.formats') !== undefined) {
-      const liste = this.validerListeFormat(
+      const validatedListFormat = this.validateListFormat(
         this.config.getConfig('importExport.formats')
       );
-      this.formats = strEnum(liste);
+      this.formats = strEnum(validatedListFormat);
     } else {
       this.formats = ExportFormat;
     }
   }
 
-  private validerListeFormat(liste: string[]): string[] {
-    return liste
+  private validateListFormat(formats: string[]): string[] {
+    return formats
       .filter(format => {
         if (
           format.toUpperCase() === ExportFormat.CSV.toUpperCase() ||

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -158,8 +158,10 @@ export class ImportExportComponent implements OnDestroy, OnInit {
     }
     const dSOptions: DataSourceOptions = layer.dataSource.options;
     if (data.format === ExportFormat.URL && dSOptions.download && dSOptions.download.url) {
-      window.open(dSOptions.download.url, '_blank');
-      this.loading$.next(false);
+      setTimeout(() => { // better look an feel
+        window.open(dSOptions.download.url, '_blank');
+        this.loading$.next(false);
+      }, 500);
       return;
     }
 

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -32,7 +32,6 @@ import { skipWhile } from 'rxjs/operators';
 })
 export class ImportExportComponent implements OnDestroy, OnInit {
   public form: FormGroup;
-  public selectedFormat$ = new BehaviorSubject(undefined);
   public formats$ = new BehaviorSubject(undefined);
   public layers: VectorLayer[];
   public inputProj: string = 'EPSG:4326';
@@ -92,7 +91,9 @@ export class ImportExportComponent implements OnDestroy, OnInit {
 
     this.form$$ = this.form.valueChanges.subscribe(() => {
       this.exportOptionsChange.emit(this.form.value);
-  });
+    });
+
+
   }
 
   ngOnDestroy() {
@@ -229,7 +230,8 @@ export class ImportExportComponent implements OnDestroy, OnInit {
           format.toUpperCase() === ExportFormat.GPX.toUpperCase() ||
           format.toUpperCase() === ExportFormat.GeoJSON.toUpperCase() ||
           format.toUpperCase() === ExportFormat.KML.toUpperCase() ||
-          format.toUpperCase() === ExportFormat.Shapefile.toUpperCase()
+          format.toUpperCase() === ExportFormat.Shapefile.toUpperCase() ||
+          format.toUpperCase() === ExportFormat.URL.toUpperCase()
         ) {
           return format;
         }
@@ -257,6 +259,11 @@ export class ImportExportComponent implements OnDestroy, OnInit {
         }
         if (format.toUpperCase() === ExportFormat.Shapefile.toUpperCase()) {
           format = ExportFormat.Shapefile;
+          return format;
+        }
+
+        if (format.toUpperCase() === ExportFormat.URL.toUpperCase()) {
+          format = ExportFormat.URL;
           return format;
         }
       });

--- a/packages/geo/src/lib/import-export/shared/export.type.ts
+++ b/packages/geo/src/lib/import-export/shared/export.type.ts
@@ -1,4 +1,4 @@
 import { strEnum } from '@igo2/utils';
 
-export const ExportFormat = strEnum(['GeoJSON', 'GML', 'GPX', 'KML', 'Shapefile', 'CSV']);
+export const ExportFormat = strEnum(['GeoJSON', 'GML', 'GPX', 'KML', 'Shapefile', 'CSV', 'URL']);
 export type ExportFormat = keyof typeof ExportFormat;

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -63,6 +63,7 @@
         "exportFileNamePlaceholder": "Filename",
         "exportTabTitle": "Export",
         "exportFeatureInExtent": "Export only features in map extent",
+        "exportNoLayersExportable": "There is no layer exportable in your map",
         "importButton": "Import",
         "importProjPlaceholder": "Coordinate system",
         "importTabTitle": "Import",

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -58,6 +58,7 @@
       },
       "importExportForm": {
         "exportButton": "Export",
+        "exportButtonLink": "Open the link",
         "exportFormatPlaceholder": "Format",
         "exportLayerPlaceholder": "Layer",
         "exportFileNamePlaceholder": "Filename",

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -64,7 +64,7 @@
         "exportFileNamePlaceholder": "Filename",
         "exportTabTitle": "Export",
         "exportFeatureInExtent": "Export only features in map extent",
-        "exportNoLayersExportable": "There is no layer exportable in your map",
+        "exportNoLayersExportable": "There is no exportable layer in your map",
         "importButton": "Import",
         "importProjPlaceholder": "Coordinate system",
         "importTabTitle": "Import",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -58,6 +58,7 @@
       },
       "importExportForm": {
         "exportButton": "Exporter",
+        "exportButtonLink": "Ouvrir le lien",
         "exportFormatPlaceholder": "Format",
         "exportLayerPlaceholder": "Données géospatiales",
         "exportFileNamePlaceholder": "Nom du fichier",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -63,6 +63,7 @@
         "exportFileNamePlaceholder": "Nom du fichier",
         "exportTabTitle": "Exporter",
         "exportFeatureInExtent": "Seulement les entités contenues dans la carte",
+        "exportNoLayersExportable": "Aucune couche exportable dans la carte courante",
         "importButton": "Importer",
         "importProjPlaceholder": "Système de coordonnées",
         "importTabTitle": "Importer",

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -10,7 +10,7 @@
   [queryBadge]="queryBadge">
 
   <ng-template #igoLayerItemToolbar let-layer="layer">
-    <igo-download-button [layer]="layer"></igo-download-button>
+    <!-- <igo-download-button [layer]="layer"></igo-download-button> -->
     <igo-export-button [layer]="layer" (click)="activateExport(layer.id)"></igo-export-button>
     <igo-metadata-button [layer]="layer"></igo-metadata-button>
     <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"></igo-ogc-filter-button>

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.html
@@ -11,6 +11,7 @@
 
   <ng-template #igoLayerItemToolbar let-layer="layer">
     <igo-download-button [layer]="layer"></igo-download-button>
+    <igo-export-button [layer]="layer" (click)="activateExport(layer.id)"></igo-export-button>
     <igo-metadata-button [layer]="layer"></igo-metadata-button>
     <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"></igo-ogc-filter-button>
     <igo-time-filter-button [header]="timeButton" [layer]="layer"></igo-time-filter-button>

--- a/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
+++ b/packages/integration/src/lib/map/map-details-tool/map-details-tool.component.ts
@@ -9,11 +9,13 @@ import {
   IgoMap,
   LayerListControlsOptions,
   SearchSourceService,
-  sourceCanSearch
+  sourceCanSearch,
+  ExportOptions
 } from '@igo2/geo';
 
 import { ToolState } from './../../tool/tool.state';
 import { MapState } from './../map.state';
+import { ImportExportState } from '../../import-export/import-export.state';
 
 @ToolComponent({
   name: 'mapDetails',
@@ -107,7 +109,8 @@ export class MapDetailsToolComponent implements OnInit {
     private mapState: MapState,
     private toolState: ToolState,
     private searchSourceService: SearchSourceService,
-    private cdRef: ChangeDetectorRef
+    private cdRef: ChangeDetectorRef,
+    private importExportState: ImportExportState
   ) {}
 
   ngOnInit(): void {
@@ -128,5 +131,11 @@ export class MapDetailsToolComponent implements OnInit {
 
   contextEmit() {
     this.toolState.toolbox.activateTool('contextManager');
+  }
+
+  activateExport(id: string) {
+    this.importExportState.setsExportOptions({layer: id} as ExportOptions);
+    this.importExportState.setSelectedTab(1);
+    this.toolState.toolbox.activateTool('importExport');
   }
 }

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -14,6 +14,7 @@
 
       <ng-template #igoLayerItemToolbar let-layer="layer">
         <igo-download-button [layer]="layer"></igo-download-button>
+        <igo-export-button [layer]="layer" (click)="activateExport(layer.id)"></igo-export-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"></igo-ogc-filter-button>
         <igo-time-filter-button [header]="timeButton" [layer]="layer"></igo-time-filter-button>

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.html
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.html
@@ -13,7 +13,7 @@
       [queryBadge]="queryBadge">
 
       <ng-template #igoLayerItemToolbar let-layer="layer">
-        <igo-download-button [layer]="layer"></igo-download-button>
+        <!-- <igo-download-button [layer]="layer"></igo-download-button> -->
         <igo-export-button [layer]="layer" (click)="activateExport(layer.id)"></igo-export-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"></igo-ogc-filter-button>

--- a/packages/integration/src/lib/map/map-tool/map-tool.component.ts
+++ b/packages/integration/src/lib/map/map-tool/map-tool.component.ts
@@ -1,8 +1,10 @@
 import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
 
 import { ToolComponent } from '@igo2/common';
-import { LayerListControlsEnum, LayerListControlsOptions, IgoMap } from '@igo2/geo';
+import { LayerListControlsEnum, LayerListControlsOptions, IgoMap, ExportOptions } from '@igo2/geo';
 import { MapState } from './../map.state';
+import { ImportExportState } from '../../import-export/import-export.state';
+import { ToolState } from '../../tool/tool.state';
 
 /**
  * Tool to browse a map's layers or to choose a different map
@@ -60,6 +62,15 @@ export class MapToolComponent {
     return filterSortOptions;
   }
 
-  constructor(private mapState: MapState) {}
+  constructor(
+    private mapState: MapState,
+    private toolState: ToolState,
+    private importExportState: ImportExportState) {}
+
+  activateExport(id: string) {
+    this.importExportState.setsExportOptions({ layer: id } as ExportOptions);
+    this.importExportState.setSelectedTab(1);
+    this.toolState.toolbox.activateTool('importExport');
+  }
 
 }

--- a/packages/integration/src/lib/map/map-tools/map-tools.component.html
+++ b/packages/integration/src/lib/map/map-tools/map-tools.component.html
@@ -17,7 +17,7 @@
       (appliedFilterAndSort)= onLayerListChange($event)>
 
       <ng-template #igoLayerItemToolbar let-layer="layer">
-        <igo-download-button [layer]="layer"></igo-download-button>
+        <!-- <igo-download-button [layer]="layer"></igo-download-button> -->
         <igo-export-button [layer]="layer" (click)="activateExport(layer.id)"></igo-export-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"

--- a/packages/integration/src/lib/map/map-tools/map-tools.component.html
+++ b/packages/integration/src/lib/map/map-tools/map-tools.component.html
@@ -18,6 +18,7 @@
 
       <ng-template #igoLayerItemToolbar let-layer="layer">
         <igo-download-button [layer]="layer"></igo-download-button>
+        <igo-export-button [layer]="layer" (click)="activateExport(layer.id)"></igo-export-button>
         <igo-metadata-button [layer]="layer"></igo-metadata-button>
         <igo-ogc-filter-button [header]="ogcButton" [layer]="layer"
         (click)="activateOgcFilter()"></igo-ogc-filter-button>

--- a/packages/integration/src/lib/map/map-tools/map-tools.component.ts
+++ b/packages/integration/src/lib/map/map-tools/map-tools.component.ts
@@ -14,7 +14,8 @@ import {
   IgoMap,
   SearchSourceService,
   sourceCanSearch,
-  Layer
+  Layer,
+  ExportOptions
 } from '@igo2/geo';
 
 import { LayerListToolState } from '../layer-list-tool.state';
@@ -23,6 +24,7 @@ import { ToolState } from '../../tool/tool.state';
 import { MapState } from '../map.state';
 import { BehaviorSubject, Observable, Subscription, combineLatest } from 'rxjs';
 import { map, debounceTime } from 'rxjs/operators';
+import { ImportExportState } from '../../import-export/import-export.state';
 /**
  * Tool to browse a map's layers or to choose a different map
  */
@@ -157,7 +159,8 @@ export class MapToolsComponent implements OnInit, OnDestroy {
     public layerListToolState: LayerListToolState,
     private toolState: ToolState,
     public mapState: MapState,
-    private searchSourceService: SearchSourceService
+    private searchSourceService: SearchSourceService,
+    private importExportState: ImportExportState
   ) {}
 
   ngOnInit(): void {
@@ -249,6 +252,12 @@ export class MapToolsComponent implements OnInit, OnDestroy {
       }
     }
     return true;
+  }
+
+  activateExport(id: string) {
+    this.importExportState.setsExportOptions({ layer: id } as ExportOptions);
+    this.importExportState.setSelectedTab(1);
+    this.toolState.toolbox.activateTool('importExport');
   }
 
   activateTimeFilter() {

--- a/packages/integration/src/lib/map/map.module.ts
+++ b/packages/integration/src/lib/map/map.module.ts
@@ -13,7 +13,8 @@ import {
   IgoLayerModule,
   IgoMetadataModule,
   IgoDownloadModule,
-  IgoFilterModule
+  IgoFilterModule,
+  IgoImportExportModule
 } from '@igo2/geo';
 
 import { IgoContextModule } from '@igo2/context';
@@ -33,6 +34,7 @@ import { MapLegendToolComponent } from './map-legend/map-legend-tool.component';
     IgoLayerModule,
     IgoMetadataModule,
     IgoDownloadModule,
+    IgoImportExportModule,
     IgoFilterModule,
     IgoContextModule
   ],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1- Non vector layers with download (url) property contained in sourceOptions are not exportable by the import/Export tool. 
2- Vector layer that were not initialized (visibility set to false in config) were not exportable. This cause an error :
![image](https://user-images.githubusercontent.com/7397743/83875460-1a87bd80-a705-11ea-8cb3-1f766eba24bc.png)



**What is the new behavior?**
1- These layers are now listed exportable. The associated export format is an URL and the form submit open the link. 
2- On layer selection, if the vector contain no feature, the layer visibility is set to true, the opacity = 0 and queryable = false. Then OpenLayers download the features. On the next layer selection (or on tool leave) the previous layer original visibility, opacity and queryable status are "roolbacked".



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No