### PR TITLE
fix(GoogleMapsLink): fix line and polygon google maps link

### DIFF
--- a/demo/src/app/geo/search/search.component.ts
+++ b/demo/src/app/geo/search/search.component.ts
@@ -223,7 +223,7 @@ export class AppSearchComponent implements OnInit, OnDestroy {
   }
 
   onOpenGoogleMaps() {
-    window.open(GoogleLinks.getGoogleMapsLink(this.lonlat[0], this.lonlat[1]));
+    window.open(GoogleLinks.getGoogleMapsCoordLink(this.lonlat[0], this.lonlat[1]));
   }
 
   onOpenGoogleStreetView() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3708,6 +3708,126 @@
         "@turf/meta": "6.x"
       }
     },
+    "@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/invariant": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        }
+      }
+    },
+    "@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/bbox": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+          "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/meta": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        }
+      }
+    },
+    "@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        }
+      }
+    },
+    "@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/invariant": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        }
+      }
+    },
+    "@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/meta": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        }
+      }
+    },
     "@turf/helpers": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
@@ -3749,6 +3869,51 @@
       "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
       "requires": {
         "@turf/helpers": "6.x"
+      }
+    },
+    "@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/meta": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        }
+      }
+    },
+    "@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        }
       }
     },
     "@types/chokidar": {
@@ -4106,7 +4271,7 @@
     },
     "acorn-globals": {
       "version": "1.0.9",
-      "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "requires": {
         "acorn": "^2.1.0"
@@ -4272,7 +4437,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -4415,7 +4580,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "archy": {
       "version": "1.0.0",
@@ -4465,7 +4630,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-map": {
       "version": "2.0.2",
@@ -4495,7 +4660,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
@@ -4981,7 +5146,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -5181,7 +5346,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -5515,7 +5680,7 @@
     "buffer-indexof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
       "dev": true
     },
     "buffer-xor": {
@@ -5570,7 +5735,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -5771,7 +5936,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6186,7 +6351,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "conventional-changelog": {
@@ -6954,7 +7119,7 @@
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "requires": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -8221,7 +8386,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -9459,7 +9624,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gauge": {
@@ -10048,7 +10213,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -11350,7 +11515,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -11861,7 +12026,7 @@
     },
     "jsdom": {
       "version": "8.5.0",
-      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-8.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.5.0.tgz",
       "integrity": "sha1-1Nj12/J2hjW2KmKCO5R89wcevJg=",
       "requires": {
         "abab": "^1.0.0",
@@ -13029,7 +13194,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -13090,7 +13255,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -13831,7 +13996,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -14225,7 +14390,7 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
     "p-try": {
@@ -14568,7 +14733,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -14578,7 +14743,7 @@
     "pbf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
-      "integrity": "sha1-9wAEutyygXYeq7HnbJLxefCBiek=",
+      "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "requires": {
         "ieee754": "^1.1.6",
         "resolve-protobuf-schema": "^2.0.0"
@@ -15059,7 +15224,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -15848,7 +16013,7 @@
     "replacestream": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
-      "integrity": "sha1-PuV5gJK+Nksc2xSEMISSyz3/LzY=",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.3",
@@ -16782,7 +16947,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -16828,7 +16993,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
       },
@@ -18873,7 +19038,7 @@
     "vlq": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@ngx-translate/core": "^10.0.1",
     "@turf/helpers": "^6.1.4",
     "@turf/line-intersect": "^6.0.2",
+    "@turf/point-on-feature": "^5.1.5",
     "angular2-notifications": "^2.0.0",
     "bowser": "^2.9.0",
     "classlist.js": "^1.1.20150312",

--- a/packages/geo/ng-package.json
+++ b/packages/geo/ng-package.json
@@ -53,6 +53,7 @@
       "ol/geom/LineString" : "OlLineString",
       "@turf/line-intersect" : "lineIntersect",
       "@turf/helpers" : "helpers",
+      "@turf/point-on-feature" : "pointOnFeature",
       "ol/interaction/Modify" : "OlModify",
       "ol/interaction/Translate" : "OlTranslate",
       "ol/interaction/Draw" : "OlDraw",
@@ -87,6 +88,7 @@
     "ngx-cacheable",
     "ts-md5",
     "@turf/helpers",
-    "@turf/line-intersect"
+    "@turf/line-intersect",
+    "@turf/point-on-feature"
   ]
 }

--- a/packages/geo/ng-package.prod.json
+++ b/packages/geo/ng-package.prod.json
@@ -52,6 +52,7 @@
       "ol/geom/LineString" : "OlLineString",
       "@turf/line-intersect" : "lineIntersect",
       "@turf/helpers" : "helpers",
+      "@turf/point-on-feature" : "pointOnFeature",
       "ol/interaction/Modify" : "OlModify",
       "ol/interaction/Translate" : "OlTranslate",
       "ol/interaction/Draw" : "OlDraw",
@@ -86,6 +87,7 @@
     "ngx-cacheable",
     "ts-md5",
     "@turf/helpers",
-    "@turf/line-intersect"
+    "@turf/line-intersect",
+    "@turf/point-on-feature"
   ]
 }

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -17,7 +17,8 @@
     "ngx-cacheable": "^1.0.9",
     "ts-md5": "^1.2.0",
     "@turf/helpers": "^6.1.4",
-    "@turf/line-intersect": "^6.0.2"
+    "@turf/line-intersect": "^6.1.2",
+    "@turf/point-on-feature": "^5.1.5"
   },
   "peerDependencies": {
     "@angular/animations": "^7.2.6",

--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.html
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.html
@@ -1,6 +1,6 @@
 <table class="igo-striped mat-typography" *ngIf="feature && isObject(feature.properties) && feature.properties.target !== 'iframe'">
   <tbody>
-    <tr *ngFor="let property of filterFeatureProperties(feature) | keyvalue">
+    <tr *ngFor="let property of filterFeatureProperties(feature)">
 
       <td *ngIf="feature.properties.target === '_blank' && property.key === 'url'">
         <mat-icon mat-list-avatar svgIcon="{{icon}}"></mat-icon>
@@ -17,7 +17,12 @@
       <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && !isUrl(property.value)" [innerHTML]=property.value>
       </td>
 
-      <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value)">
+      <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value) && property.key === 'GoogleMaps'">
+        <a href="{{property.value}}" target='_blank'>{{ 'igo.geo.searchByCoord' | translate }} </a> <br />
+        <a href="{{feature.properties.GoogleMapsNom}}" target='_blank'>{{ 'igo.geo.searchByName' | translate }} </a>
+      </td>
+
+      <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value) && property.key !== 'GoogleMaps'">
         <a href="{{property.value}}" target='_blank'>{{ 'igo.geo.targetHtmlUrl' | translate }} </a>
       </td>
 

--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.html
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.html
@@ -1,6 +1,6 @@
 <table class="igo-striped mat-typography" *ngIf="feature && isObject(feature.properties) && feature.properties.target !== 'iframe'">
   <tbody>
-    <tr *ngFor="let property of filterFeatureProperties(feature)">
+    <tr *ngFor="let property of filterFeatureProperties(feature) | keyvalue">
 
       <td *ngIf="feature.properties.target === '_blank' && property.key === 'url'">
         <mat-icon mat-list-avatar svgIcon="{{icon}}"></mat-icon>
@@ -17,12 +17,7 @@
       <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && !isUrl(property.value)" [innerHTML]=property.value>
       </td>
 
-      <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value) && property.key === 'GoogleMaps'">
-        <a href="{{property.value}}" target='_blank'>{{ 'igo.geo.searchByCoord' | translate }} </a> <br />
-        <a href="{{feature.properties.GoogleMapsNom}}" target='_blank'>{{ 'igo.geo.searchByName' | translate }} </a>
-      </td>
-
-      <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value) && property.key !== 'GoogleMaps'">
+      <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value)">
         <a href="{{property.value}}" target='_blank'>{{ 'igo.geo.targetHtmlUrl' | translate }} </a>
       </td>
 

--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.ts
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.ts
@@ -138,6 +138,8 @@ export class FeatureDetailsComponent {
         });
       }
     }
-    return feature.properties;
+
+    const propertiesArray = Object.keys(feature.properties).map(key => ({key, value: feature.properties[key]}));
+    return propertiesArray.filter(property => property.key !== 'GoogleMapsNom');
   }
 }

--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.ts
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.ts
@@ -139,7 +139,6 @@ export class FeatureDetailsComponent {
       }
     }
 
-    const propertiesArray = Object.keys(feature.properties).map(key => ({key, value: feature.properties[key]}));
-    return propertiesArray.filter(property => property.key !== 'GoogleMapsNom');
+    return feature.properties;
   }
 }

--- a/packages/geo/src/lib/search/shared/sources/coordinates.ts
+++ b/packages/geo/src/lib/search/shared/sources/coordinates.ts
@@ -105,7 +105,7 @@ export class CoordinatesReverseSearchSource extends SearchSource
           coordLonLat,
           coords,
           {
-            GoogleMaps: GoogleLinks.getGoogleMapsLink(data[0], data[1]),
+            GoogleMaps: GoogleLinks.getGoogleMapsCoordLink(data[0], data[1]),
             GoogleStreetView: GoogleLinks.getGoogleStreetViewLink(
               data[0],
               data[1]

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -417,24 +417,34 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
 
     const googleLinksProperties: {
       GoogleMaps: string;
-      GoogleMapsNom: string;
       GoogleStreetView?: string;
     } = {
-      GoogleMaps: '',
-      GoogleMapsNom: ''
+      GoogleMaps: ''
     };
 
+    let googleMaps;
     if (data.geometry.type === 'Point') {
-      googleLinksProperties.GoogleMaps = GoogleLinks.getGoogleMapsCoordLink(
+      googleMaps = GoogleLinks.getGoogleMapsCoordLink(
         data.geometry.coordinates[0],
         data.geometry.coordinates[1]
       );
     } else {
       const point = pointOnFeature(data.geometry);
-      googleLinksProperties.GoogleMaps = GoogleLinks.getGoogleMapsCoordLink(point.geometry.coordinates[0], point.geometry.coordinates[1]);
+      googleMaps = GoogleLinks.getGoogleMapsCoordLink(point.geometry.coordinates[0], point.geometry.coordinates[1]);
     }
 
-    googleLinksProperties.GoogleMapsNom = GoogleLinks.getGoogleMapsNameLink(data.properties.nom || data.highlight.title);
+    let googleMapsNom;
+    if (data.index === 'routes') {
+      googleMapsNom = GoogleLinks.getGoogleMapsNameLink(data.properties.nom + ', ' + data.properties.municipalite);
+    } else if (data.index === 'municipalites') {
+      googleMapsNom = GoogleLinks.getGoogleMapsNameLink(data.properties.nom + ', ' + data.properties.regAdmin);
+    } else {
+      googleMapsNom = GoogleLinks.getGoogleMapsNameLink(data.properties.nom || data.highlight.title);
+    }
+
+    googleLinksProperties.GoogleMaps = '<a href=' + googleMaps + ' target="_blank">' +
+      this.languageService.translate.instant('igo.geo.searchByCoord') + '</a> <br /> <a href=' + googleMapsNom +
+        ' target="_blank">' + this.languageService.translate.instant('igo.geo.searchByName') + '</a>';
 
     if (data.geometry.type === 'Point') {
       googleLinksProperties.GoogleStreetView = GoogleLinks.getGoogleStreetViewLink(

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -417,10 +417,11 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
       GoogleMaps: string;
       GoogleStreetView?: string;
     } = {
-      GoogleMaps: GoogleLinks.getGoogleMapsLink(
+      GoogleMaps: data.geometry.type === 'Point' ? GoogleLinks.getGoogleMapsLink(
         data.geometry.coordinates[0],
         data.geometry.coordinates[1]
-      )
+      ) :
+      GoogleLinks.getGoogleMapsNameLink(data.properties.nom || data.highlight.title)
     };
     if (data.geometry.type === 'Point') {
       googleLinksProperties.GoogleStreetView = GoogleLinks.getGoogleStreetViewLink(

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -8,6 +8,8 @@ import { AuthService } from '@igo2/auth';
 import { LanguageService } from '@igo2/core';
 import { ObjectUtils } from '@igo2/utils';
 
+import pointOnFeature from '@turf/point-on-feature';
+
 import { FEATURE, Feature } from '../../../feature';
 import { GoogleLinks } from './../../../utils/googleLinks';
 
@@ -415,14 +417,25 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
 
     const googleLinksProperties: {
       GoogleMaps: string;
+      GoogleMapsNom: string;
       GoogleStreetView?: string;
     } = {
-      GoogleMaps: data.geometry.type === 'Point' ? GoogleLinks.getGoogleMapsLink(
+      GoogleMaps: '',
+      GoogleMapsNom: ''
+    };
+
+    if (data.geometry.type === 'Point') {
+      googleLinksProperties.GoogleMaps = GoogleLinks.getGoogleMapsCoordLink(
         data.geometry.coordinates[0],
         data.geometry.coordinates[1]
-      ) :
-      GoogleLinks.getGoogleMapsNameLink(data.properties.nom || data.highlight.title)
-    };
+      );
+    } else {
+      const point = pointOnFeature(data.geometry);
+      googleLinksProperties.GoogleMaps = GoogleLinks.getGoogleMapsCoordLink(point.geometry.coordinates[0], point.geometry.coordinates[1]);
+    }
+
+    googleLinksProperties.GoogleMapsNom = GoogleLinks.getGoogleMapsNameLink(data.properties.nom || data.highlight.title);
+
     if (data.geometry.type === 'Point') {
       googleLinksProperties.GoogleStreetView = GoogleLinks.getGoogleStreetViewLink(
         data.geometry.coordinates[0],

--- a/packages/geo/src/lib/utils/googleLinks.ts
+++ b/packages/geo/src/lib/utils/googleLinks.ts
@@ -6,4 +6,8 @@ export class GoogleLinks {
   static getGoogleStreetViewLink(lon, lat) {
     return 'https://www.google.com/maps?q=&layer=c&cbll=' + lat + ',' + lon;
   }
+
+  static getGoogleMapsNameLink(name) {
+    return 'https://www.google.com/maps?q=' + name;
+  }
 }

--- a/packages/geo/src/lib/utils/googleLinks.ts
+++ b/packages/geo/src/lib/utils/googleLinks.ts
@@ -8,6 +8,7 @@ export class GoogleLinks {
   }
 
   static getGoogleMapsNameLink(name) {
-    return 'https://www.google.com/maps?q=' + name;
+    const encodedName = encodeURI(name);
+    return 'https://www.google.com/maps?q=' + encodedName;
   }
 }

--- a/packages/geo/src/lib/utils/googleLinks.ts
+++ b/packages/geo/src/lib/utils/googleLinks.ts
@@ -1,5 +1,5 @@
 export class GoogleLinks {
-  static getGoogleMapsLink(lon, lat) {
+  static getGoogleMapsCoordLink(lon, lat) {
     return 'https://www.google.com/maps?q=' + lat + ',' + lon;
   }
 

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -369,6 +369,8 @@
         "polygon": "Polygon"
       },
       "targetHtmlUrl": "Open the external link",
+      "searchByCoord": "Search by coordinates",
+      "searchByName": "Search by name",
       "timeFilter": {
         "date": "Date",
         "endDate": "End Date",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -370,6 +370,8 @@
         "polygon": "Surface"
       },
       "targetHtmlUrl": "Ouvrir le lien externe",
+      "searchByCoord": "Rechercher par coordonnées",
+      "searchByName": "Rechercher par nom",
       "timeFilter": {
         "date": "Date",
         "endDate": "Date de fin",


### PR DESCRIPTION
- Before : Point, Line and Polygon were all treated the same. Coordinates (lon/lat) were used to open google maps link and cause problems with long geometry.

- Now : If search-result is a Point, use the coordinates and if not, use the name or the title of the result. 
