### PR TITLE
fix(layer-list-tool) alphaSort icon name+ tooltip

### DIFF
--- a/packages/geo/src/lib/layer/layer-list-tool/layer-list-tool.component.html
+++ b/packages/geo/src/lib/layer/layer-list-tool/layer-list-tool.component.html
@@ -21,10 +21,10 @@
       </mat-form-field>
 
       <div [matTooltip]="sortAlpha ?
-      ('igo.geo.layer.sortAlphabetically' | translate) :
-      ('igo.geo.layer.sortMapOrder' | translate)" matTooltipShowDelay="500">
+      ('igo.geo.layer.sortMapOrder' | translate) :
+      ('igo.geo.layer.sortAlphabetically' | translate)" matTooltipShowDelay="500">
         <button [color]="sortAlpha ? 'warn' : 'primary'" mat-icon-button (click)="toggleSortAlpha()">
-          <mat-icon [svgIcon]="sortAlpha ? 'sort-variant-remove' : 'sort-alphabetical'"></mat-icon>
+          <mat-icon [svgIcon]="sortAlpha ? 'sort-variant-remove' : 'sort-alphabetical-variant'"></mat-icon>
         </button>
       </div>
 


### PR DESCRIPTION

The icon doesn't appear and the tooltip was invert for alpha sort 

I change the icon name 'sort-alphabetical' -> for -> 'sort-alphabetical-variant'
I invert the tooltip whe alpha sort is active or not (IGO2 issus 461)
https://github.com/infra-geo-ouverte/igo2/issues/461


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

**Other information**:
