### PR TITLE
refactor(catalog-service): change regex filters pattern test by an eq…

### DIFF
--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -512,7 +512,7 @@ export class CatalogService {
     if (regexes.length === 0) {
       return true;
     }
-    return regexes.find((regex: RegExp) => regex.test(layerName)) !== undefined;
+    return regexes.find((regex: RegExp) => regex.source === layerName) !== undefined;
   }
 
   private retriveLayerInfoFormat(


### PR DESCRIPTION
- Before, regex filters uses only pattern in the layer name. It creates a non-desired behavior when WMS layer's name aren't explicit (example: when layer's name are only numbers)

- Now, regex needs to be the exact layer's name to be returned and added to the catalog.
