### PR TITLE
fix(arcgisrest datasource): Fix id generator for arcgis rest catalog …

### DIFF
--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -74,6 +74,19 @@ export const environment: Environment = {
           tooltipType: 'abstract' // or title
         },
         {
+          id: 'arcgisrestcompletecatalog',
+          title: 'ArcGIS Rest complete catalog',
+          url: 'https://gisp.dfo-mpo.gc.ca/arcgis/rest/services/FGP/CSAS_Corals_Sponges_2010_FR/MapServer',
+          type: 'arcgisrest'
+        },
+        {
+          id: 'arcgisrestcatalog',
+          title: 'ArcGIS Rest focus catalog',
+          url: 'https://gisp.dfo-mpo.gc.ca/arcgis/rest/services/FGP/CSAS_Corals_Sponges_2010_FR/MapServer',
+          type: 'arcgisrest',
+          regFilters: ['^10$']
+        },
+        {
           id: 'fusion_catalog',
           title: '(composite catalog) fusion catalog',
           composite: [

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -152,7 +152,7 @@ export class CatalogService {
   loadCatalogArcGISRestItems(catalog: Catalog): Observable<CatalogItem[]> {
     return this.getCatalogCapabilities(catalog).pipe(
       map((capabilities: any) => {
-        return this.getArcGISRESTItems(catalog, capabilities)
+        return this.getArcGISRESTItems(catalog, capabilities);
         })
     );
   }

--- a/packages/geo/src/lib/utils/id-generator.ts
+++ b/packages/geo/src/lib/utils/id-generator.ts
@@ -1,3 +1,4 @@
+import { ArcGISRestDataSourceOptions } from './../datasource/shared/datasources/arcgisrest-datasource.interface';
 import { Md5 } from 'ts-md5';
 
 import { uuid } from '@igo2/utils';
@@ -18,6 +19,7 @@ export function generateIdFromSourceOptions(options: DataSourceOptions): string 
     wmts: generateWMTSIdFromSourceOptions,
     xyz: generateXYZIdFromSourceOptions,
     feature: generateFeatureIdFromSourceOptions,
+    arcgisrest: generateArcgisRestIdFromSourceOptions,
     osm: (_options: AnyDataSourceOptions) => 'OSM'
   };
   const generator = generators[options.type] || generateId;
@@ -65,6 +67,18 @@ export function generateXYZIdFromSourceOptions(options: WMTSDataSourceOptions) {
 export function generateFeatureIdFromSourceOptions(options: WMTSDataSourceOptions) {
   if (! options.url) { return generateId(options); }
   const chain = 'feature' + options.url;
+  return Md5.hashStr(chain) as string;
+}
+
+/**
+ * Generate a id from ArcGIS Rest data source options
+ * @param options ArcGIS Rest data source options
+ * @returns A md5 hash of the url and layers
+ */
+export function generateArcgisRestIdFromSourceOptions(options: ArcGISRestDataSourceOptions) {
+  const layers = options.layer;
+  const url = options.url.charAt(0) === '/' ? window.location.origin + options.url : options.url;
+  const chain = 'arcgis' + url + layers;
   return Md5.hashStr(chain) as string;
 }
 


### PR DESCRIPTION
- Add an id generator for arcgis rest datasource options. A conflict existed because two random id (from uuid function) were generated for the same layer.

- Add arcgis rest catalog example in demo
