### PR TITLE
Fix(capabilities.service): Access denied err handling

### DIFF
--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -4,7 +4,7 @@ import { EMPTY, Observable, of, zip } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { uuid, ObjectUtils } from '@igo2/utils';
-import { LanguageService, ConfigService } from '@igo2/core';
+import { LanguageService, MessageService, ConfigService } from '@igo2/core';
 import {
   CapabilitiesService,
   TypeCapabilities,
@@ -34,6 +34,7 @@ export class CatalogService {
     private http: HttpClient,
     private config: ConfigService,
     private languageService: LanguageService,
+    private messageService: MessageService,
     private capabilitiesService: CapabilitiesService
   ) {}
 
@@ -65,7 +66,7 @@ export class CatalogService {
       const catalogsFromApi$ = this.http
         .get<Catalog[]>(`${apiUrl}/catalogs`)
         .pipe(
-          map(catalogs =>
+          map((catalogs) =>
             catalogs.map((c: any) => Object.assign(c, c.options))
           ),
           catchError((_response: HttpErrorResponse) => EMPTY)
@@ -78,7 +79,7 @@ export class CatalogService {
       observables$.push(
         of(catalogsFromConfig).pipe(
           map((catalogs: Catalog[]) =>
-            catalogs.map(c => {
+            catalogs.map((c) => {
               if (!c.id) {
                 c.id = uuid();
               }
@@ -153,7 +154,7 @@ export class CatalogService {
     return this.getCatalogCapabilities(catalog).pipe(
       map((capabilities: any) => {
         return this.getArcGISRESTItems(catalog, capabilities);
-        })
+      })
     );
   }
 
@@ -187,7 +188,7 @@ export class CatalogService {
     }
 
     if (
-      Object.keys(compositeCatalog).find(k => compositeCatalog[k].groupImpose)
+      Object.keys(compositeCatalog).find((k) => compositeCatalog[k].groupImpose)
     ) {
       const pushImposeGroup = (item, index) => {
         const c = catalogsFromInstance[index];
@@ -198,7 +199,7 @@ export class CatalogService {
 
         const flatLayer = flatDeepLayer(item);
         flatLayer.map(
-          v => (v.address = `${outGroupImpose.address}.${outGroupImpose.id}`)
+          (v) => (v.address = `${outGroupImpose.address}.${outGroupImpose.id}`)
         );
         outGroupImpose.items = flatLayer;
 
@@ -207,7 +208,7 @@ export class CatalogService {
 
       request2$ = request1$.map((obs, idx) =>
         obs.pipe(
-          map(items =>
+          map((items) =>
             compositeCatalog[idx].groupImpose
               ? pushImposeGroup(items, idx)
               : items
@@ -229,7 +230,7 @@ export class CatalogService {
     const groupByGroupId = (data, keyFn) =>
       data.reduce((acc, group) => {
         const groupId = keyFn(group);
-        const ind = acc.find(x => x.id === groupId);
+        const ind = acc.find((x) => x.id === groupId);
 
         if (!ind) {
           acc[acc.length] = group;
@@ -266,12 +267,12 @@ export class CatalogService {
           }); // $& i !== idx
 
           if (diffAddress.length > 0) {
-            const nPosition = indicesMatchTitle.findIndex(x => x === idx) + 1;
+            const nPosition = indicesMatchTitle.findIndex((x) => x === idx) + 1;
             outItem.title = `${item.title} (${nPosition})`; // source: ${item.address.split('.')[0]}
           }
 
           const exist = acc.find(
-            x => x.title === outItem.title && x.type === CatalogItemType.Layer
+            (x) => x.title === outItem.title && x.type === CatalogItemType.Layer
           );
           if (!exist) {
             acc[acc.length] = outItem;
@@ -279,7 +280,7 @@ export class CatalogService {
         } else if (item.type === CatalogItemType.Group) {
           outItem.items = recursiveGroupByLayerAddress(
             item.items,
-            layer => layer.title
+            (layer) => layer.title
           );
           acc[acc.length] = outItem;
         }
@@ -288,9 +289,9 @@ export class CatalogService {
       }, []);
 
     const request4$ = request3$.pipe(
-      map(output => groupByGroupId(output, group => group.id)),
-      map(output => [].concat(...output)),
-      map(data => recursiveGroupByLayerAddress(data, layer => layer.title))
+      map((output) => groupByGroupId(output, (group) => group.id)),
+      map((output) => [].concat(...output)),
+      map((data) => recursiveGroupByLayerAddress(data, (layer) => layer.title))
     );
 
     return request4$;
@@ -298,11 +299,22 @@ export class CatalogService {
 
   private getCatalogCapabilities(catalog: Catalog): Observable<any> {
     const sType: string = TypeCatalog[catalog.type as string];
-    return this.capabilitiesService.getCapabilities(
-      TypeCapabilities[sType],
-      catalog.url,
-      catalog.version
-    );
+    return this.capabilitiesService
+      .getCapabilities(TypeCapabilities[sType], catalog.url, catalog.version)
+      .pipe(
+        catchError((e) => {
+          const title = this.languageService.translate.instant(
+            'igo.geo.catalog.unavailableTitle'
+          );
+          const message = this.languageService.translate.instant(
+            'igo.geo.catalog.unavailable',
+            { value: catalog.title }
+          );
+
+          this.messageService.error(message, title);
+          throw e;
+        })
+      );
   }
 
   private prepareCatalogItemLayer(layer, idParent, layersQueryFormat, catalog) {
@@ -394,9 +406,7 @@ export class CatalogService {
             return items;
           }
 
-          const layerItem: CatalogItemLayer<
-            ImageLayerOptions
-          > = this.prepareCatalogItemLayer(
+          const layerItem: CatalogItemLayer<ImageLayerOptions> = this.prepareCatalogItemLayer(
             layer,
             idGroup,
             layersQueryFormat,
@@ -573,9 +583,9 @@ export class CatalogService {
     layersQueryFormat: { layer: string; queryFormat: QueryFormat }[]
   ): QueryFormat {
     const currentLayerInfoFormat = layersQueryFormat.find(
-      f => f.layer === layerNameFromCatalog
+      (f) => f.layer === layerNameFromCatalog
     );
-    const baseInfoFormat = layersQueryFormat.find(f => f.layer === '*');
+    const baseInfoFormat = layersQueryFormat.find((f) => f.layer === '*');
     let queryFormat: QueryFormat;
     if (currentLayerInfoFormat) {
       queryFormat = currentLayerInfoFormat.queryFormat;
@@ -592,11 +602,11 @@ export class CatalogService {
     if (!catalog.queryFormat) {
       return layersQueryFormat;
     }
-    Object.keys(catalog.queryFormat).forEach(configuredInfoFormat => {
+    Object.keys(catalog.queryFormat).forEach((configuredInfoFormat) => {
       if (catalog.queryFormat[configuredInfoFormat] instanceof Array) {
-        catalog.queryFormat[configuredInfoFormat].forEach(layerName => {
+        catalog.queryFormat[configuredInfoFormat].forEach((layerName) => {
           if (
-            !layersQueryFormat.find(specific => specific.layer === layerName)
+            !layersQueryFormat.find((specific) => specific.layer === layerName)
           ) {
             layersQueryFormat.push({
               layer: layerName,
@@ -607,7 +617,7 @@ export class CatalogService {
       } else {
         if (
           !layersQueryFormat.find(
-            specific =>
+            (specific) =>
               specific.layer === catalog.queryFormat[configuredInfoFormat]
           )
         ) {

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -172,9 +172,11 @@ export class CapabilitiesService {
             return res;
           }
           if (String(res).includes('ServiceException') && String(res).includes('Access denied')) {
-            throw new HttpErrorResponse(
-              {error: {message: 'service error getCapabilities: Access is denied', caught: false}, status: 403 }
-            );
+            throw {
+              error: {
+                message: 'Service error getCapabilities: Access is denied'
+              }
+            };
           } else {
             return this.parsers[service].read(res);
           }

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpParams,
+  HttpErrorResponse
+} from '@angular/common/http';
 import { Observable, forkJoin, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { Cacheable } from 'ngx-cacheable';
@@ -112,7 +116,7 @@ export class CapabilitiesService {
     const arcgisOptions = this.http.get(baseUrl);
     const legend = this.http.get(legendUrl).pipe(
       map((res: any) => res),
-      catchError(err => {
+      catchError((err) => {
         console.log('No legend associated with this Feature Service');
         return of(err);
       })
@@ -167,25 +171,27 @@ export class CapabilitiesService {
     }
 
     return request.pipe(
-      map(res => {
-          if ((service as any) === 'esriJSON') {
-            return res;
-          }
-          if (String(res).toLowerCase().includes('serviceexception') && String(res).toLowerCase().includes('access denied')) {
-            throw {
-              error: {
-                message: 'Service error getCapabilities: Access is denied'
-              }
-            };
-          } else {
-            return this.parsers[service].read(res);
-          }
+      map((res) => {
+        if ((service as any) === 'esriJSON') {
+          return res;
+        }
+        if (
+          String(res).toLowerCase().includes('serviceexception') &&
+          String(res).toLowerCase().includes('access denied')
+        ) {
+          throw {
+            error: {
+              message: 'Service error getCapabilities: Access is denied'
+            }
+          };
+        } else {
+          return this.parsers[service].read(res);
+        }
       }),
-      catchError(e => {
-        // ** comment to show user service error message when a service have bad adress
-        // if (typeof(e.error) !== 'undefined') {
-        //   e.error.caught = true;
-        // }
+      catchError((e) => {
+        if (typeof e.error !== 'undefined') {
+          e.error.caught = true;
+        }
         throw e;
       })
     );
@@ -233,7 +239,7 @@ export class CapabilitiesService {
         ) !== -1
       ) {
         const keyEnum = Object.keys(QueryFormatMimeType).find(
-          key => QueryFormatMimeType[key] === mimeType
+          (key) => QueryFormatMimeType[key] === mimeType
         );
         queryFormat = QueryFormat[keyEnum];
         break;
@@ -269,16 +275,19 @@ export class CapabilitiesService {
     baseOptions: WMTSDataSourceOptions,
     capabilities: any
   ): WMTSDataSourceOptions {
-
     // Put Title source in _layerOptionsFromSource. (For source & catalog in _layerOptionsFromSource, if not already on config)
-    const layer = capabilities.Contents.Layer.find(el => el.Identifier === baseOptions.layer);
+    const layer = capabilities.Contents.Layer.find(
+      (el) => el.Identifier === baseOptions.layer
+    );
 
     const options = optionsFromCapabilities(capabilities, baseOptions);
 
     const ouputOptions = Object.assign(options, baseOptions);
     const sourceOptions = ObjectUtils.removeUndefined({
       _layerOptionsFromSource: {
-        title: layer.Title}});
+        title: layer.Title
+      }
+    });
 
     return ObjectUtils.mergeDeep(sourceOptions, ouputOptions);
   }
@@ -289,7 +298,7 @@ export class CapabilitiesService {
   ): CartoDataSourceOptions {
     const layers = [];
     const params = cartoOptions.layers[1].options.layer_definition;
-    params.layers.forEach(element => {
+    params.layers.forEach((element) => {
       layers.push({
         type: element.type.toLowerCase(),
         options: element.options,
@@ -399,7 +408,7 @@ export class CapabilitiesService {
   private findDataSourceInCapabilities(layerArray, name): any {
     if (Array.isArray(layerArray)) {
       let layer;
-      layerArray.find(value => {
+      layerArray.find((value) => {
         layer = this.findDataSourceInCapabilities(value, name);
         return layer !== undefined;
       }, this);
@@ -437,7 +446,7 @@ export class CapabilitiesService {
   }
 
   getStyle(Style): LegendOptions {
-    const styleOptions: ItemStyleOptions[] = Style.map(style => {
+    const styleOptions: ItemStyleOptions[] = Style.map((style) => {
       return {
         name: style.Name,
         title: style.Title

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -171,7 +171,7 @@ export class CapabilitiesService {
           if ((service as any) === 'esriJSON') {
             return res;
           }
-          if (String(res).includes('ServiceException') && String(res).includes('Access denied')) {
+          if (String(res).toLowerCase().includes('serviceexception') && String(res).toLowerCase().includes('access denied')) {
             throw {
               error: {
                 message: 'Service error getCapabilities: Access is denied'

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -225,7 +225,7 @@ export class VectorLayer extends Layer {
    * @param interceptor the interceptor of the data
    * @param extent the extent of the requested data
    * @param resolution the current resolution
-   * @param projection the projection to retrieve the data 
+   * @param projection the projection to retrieve the data
    */
   private customLoader(vectorSource, url, interceptor, extent, resolution, projection) {
     const xhr = new XMLHttpRequest();

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -8,7 +8,9 @@
         "layer.removeFromMapOutRange": "Remove from map. The layer is not visible at the current scale. Please zoom in/out",
         "group.addToMap": "Add all layers from this group to map",
         "group.removeFromMap": "Remove all layers from this group to map",
-        "baseLayers": "Baselayers"
+        "baseLayers": "Baselayers",
+        "unavailableTitle": "Catalog unavailable",
+        "unavailable": "The catalog '{{value}}' is unavailable at the moment or you don't have the required permissions."
       },
       "clickOnMap": {
         "clickedFeature": "Clicked Feature"

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -8,7 +8,9 @@
         "layer.removeFromMapOutRange": "Retirer de la carte. La donnée est non visible à l'échelle active. Veuillez zoomer +/- si vous voulez l'apercevoir à la carte.",
         "group.addToMap": "Ajouter toutes les couches de ce groupe à la carte",
         "group.removeFromMap": "Retirer toutes les couches de ce groupe de la carte",
-        "baseLayers": "Fonds de carte"
+        "baseLayers": "Fonds de carte",
+        "unavailableTitle": "Catalogue indisponible",
+        "unavailable": "Le catalogue '{{value}}' est indisponible pour le moment ou vous n'avez pas les permissions requises."
       },
       "clickOnMap": {
         "clickedFeature": "Entités cliquées"


### PR DESCRIPTION

What is the current behavior? (You can also link to an open issue here)
In catalog when service getCapabilities return Acces Denied, the app throw an error: cannot read property 'layer' of undefined

What is the new behavior?
In that case, the app trow now a Error with message:
Service error getCapabilities: Access is denied

No message to user only in console


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No


