### PR TITLE
Fix(share-map.service) shareMap problem with bad layer name (#710)

### DIFF
--- a/packages/context/src/lib/share-map/shared/share-map.service.ts
+++ b/packages/context/src/lib/share-map/shared/share-map.service.ts
@@ -86,7 +86,9 @@ export class ShareMapService {
     const contextLayersID = [];
     const contextLayers = this.contextService.context$.value.layers;
     for (const contextLayer of contextLayers) {
-      contextLayersID.push(contextLayer.id || contextLayer.source.id);
+      if ( typeof contextLayer.id !== 'undefined'  ||  typeof contextLayer.source !== 'undefined' ) {
+        contextLayersID.push(contextLayer.id || contextLayer.source.id);
+      }
     }
 
     const addedLayersQueryParamsWms = this.makeLayersByService(layers, contextLayersID, 'wms');


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
 [710](https://github.com/infra-geo-ouverte/igo2-lib/issues/710)
problem with shareMap when a layer have badName in context


**What is the new behavior?**
check if contextLayer id is undefined, don't push it


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
-  [x] No

