### PR TITLE
WFS call optimization

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasource.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasource.service.ts
@@ -35,6 +35,7 @@ import {
 import { ObjectUtils } from '@igo2/utils';
 import { LanguageService, MessageService } from '@igo2/core';
 import { ProjectionService } from '../../map/shared/projection.service';
+import { AuthInterceptor } from '@igo2/auth';
 
 @Injectable({
   providedIn: 'root'
@@ -48,7 +49,8 @@ export class DataSourceService {
     private wfsDataSourceService: WFSService,
     private languageService: LanguageService,
     private messageService: MessageService,
-    private projectionService: ProjectionService
+    private projectionService: ProjectionService,
+    private authInterceptor?: AuthInterceptor
   ) {}
 
   createAsyncDataSource(context: AnyDataSourceOptions): Observable<DataSource> {
@@ -142,7 +144,7 @@ export class DataSourceService {
     context: WFSDataSourceOptions
   ): Observable<WFSDataSource> {
     return new Observable(d =>
-      d.next(new WFSDataSource(context, this.wfsDataSourceService))
+      d.next(new WFSDataSource(context, this.wfsDataSourceService, this.authInterceptor))
     );
   }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -12,7 +12,8 @@ import {
   formatWFSQueryString,
   defaultFieldNameGeometry,
   checkWfsParams,
-  getFormatFromOptions, defaultMaxFeatures
+  getFormatFromOptions,
+  defaultMaxFeatures
 } from './wms-wfs.utils';
 import { AuthInterceptor } from '@igo2/auth';
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -12,15 +12,17 @@ import {
   formatWFSQueryString,
   defaultFieldNameGeometry,
   checkWfsParams,
-  getFormatFromOptions
+  getFormatFromOptions, defaultMaxFeatures
 } from './wms-wfs.utils';
+import { AuthInterceptor } from '@igo2/auth';
 
 export class WFSDataSource extends DataSource {
   public ol: olSourceVector;
 
   constructor(
     public options: WFSDataSourceOptions,
-    protected wfsService: WFSService
+    protected wfsService: WFSService,
+    private authInterceptor?: AuthInterceptor
   ) {
     super(checkWfsParams(options, 'wfs'));
 
@@ -39,18 +41,62 @@ export class WFSDataSource extends DataSource {
 
   protected createOlSource(): olSourceVector {
 
-    return new olSourceVector({
+    const vectorSource = new olSourceVector({
       format: getFormatFromOptions(this.options),
-      overlaps: false,
-      url: (extent, resolution, proj: olProjection) => {
+      loader: (extent, resolution, proj: olProjection) => {
         this.options.paramsWFS.srsName = this.options.paramsWFS.srsName || proj.getCode();
-        return this.buildUrl(
+        const url = this.buildUrl(
           extent,
           proj,
           (this.options as OgcFilterableDataSourceOptions).ogcFilters);
+        let startIndex = 0;
+        if (
+          this.options.paramsWFS.version === '2.0.0' &&
+          this.options.paramsWFS.maxFeatures > defaultMaxFeatures) {
+          const nbOfFeature = 1000;
+          while (startIndex < this.options.paramsWFS.maxFeatures) {
+            let alteredUrl = url.replace('count=' + this.options.paramsWFS.maxFeatures, 'count=' + nbOfFeature);
+            alteredUrl = alteredUrl.replace('startIndex=0', '0');
+            alteredUrl += '&startIndex=' + startIndex;
+            alteredUrl.replace(/&&/g, '&');
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', alteredUrl);
+            this.authInterceptor.interceptXhr(xhr, alteredUrl);
+            const onError = () => vectorSource.removeLoadedExtent(extent);
+            xhr.onerror = onError;
+            xhr.onload = () => {
+              if (xhr.status === 200) {
+                vectorSource.addFeatures(
+                  vectorSource.getFormat().readFeatures(xhr.responseText));
+              } else {
+                onError();
+              }
+            };
+            xhr.send();
+            startIndex += nbOfFeature;
+          }
+        } else {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', url);
+          this.authInterceptor.interceptXhr(xhr, url);
+          const onError = () => vectorSource.removeLoadedExtent(extent);
+          xhr.onerror = onError;
+          xhr.onload = () => {
+            if (xhr.status === 200) {
+              vectorSource.addFeatures(
+                vectorSource.getFormat().readFeatures(xhr.responseText));
+            } else {
+              onError();
+            }
+          };
+          xhr.send();
+        }
+
+
       },
       strategy: OlLoadingStrategy.bbox
     });
+    return vectorSource;
   }
 
   private buildUrl(extent, proj: olProjection, ogcFilters: OgcFiltersOptions): string {
@@ -78,5 +124,5 @@ export class WFSDataSource extends DataSource {
     return baseUrl.replace(/&&/g, '&');
   }
 
-  public onUnwatch() {}
+  public onUnwatch() { }
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -58,11 +58,11 @@ export class WFSDataSource extends DataSource {
             alteredUrl = alteredUrl.replace('startIndex=0', '0');
             alteredUrl += '&startIndex=' + startIndex;
             alteredUrl.replace(/&&/g, '&');
-            this.getFeatures(vectorSource, extent, alteredUrl);
+            this.getFeatures(vectorSource, extent, alteredUrl, nbOfFeature);
             startIndex += nbOfFeature;
           }
         } else {
-          this.getFeatures(vectorSource, extent, url);
+          this.getFeatures(vectorSource, extent, url, this.options.paramsWFS.maxFeatures);
         }
 
 
@@ -72,7 +72,7 @@ export class WFSDataSource extends DataSource {
     return vectorSource;
   }
 
-  private getFeatures(vectorSource: olSourceVector, extent, url: string) {
+  private getFeatures(vectorSource: olSourceVector, extent, url: string, threshold: number) {
     const xhr = new XMLHttpRequest();
     xhr.open('GET', url);
     this.authInterceptor.interceptXhr(xhr, url);
@@ -80,8 +80,12 @@ export class WFSDataSource extends DataSource {
     xhr.onerror = onError;
     xhr.onload = () => {
       if (xhr.status === 200) {
-        vectorSource.addFeatures(
-          vectorSource.getFormat().readFeatures(xhr.responseText));
+        const features = vectorSource.getFormat().readFeatures(xhr.responseText);
+        // TODO Manage "More feature"
+        /*if (features.length === 0 || features.length < threshold ) {
+          console.log('No more data to download at this resolution');
+        }*/
+        vectorSource.addFeatures(features);
       } else {
         onError();
       }

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs.service.ts
@@ -106,8 +106,8 @@ export class WFSService extends DataService {
               fieldListWoGeomStr = fieldListWoGeom.join(',');
               const processingArray = [];
               let startIndex = 0;
-              // If the service do not allow gml return, dice the
-              // call in multiple calls by increment of chunkSize with the original outputFormat
+              // If the service do not allow gml return, dice the call in multiple
+              // calls by increment of chunkSize with the original outputFormat
               if (
                 !allowGml && dataSourceOptions.paramsWFS.version === '2.0.0' &&
                 dataSourceOptions.paramsWFS.maxFeatures > defaultMaxFeatures) {

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { combineLatest, Observable, of } from 'rxjs';
 import olFeature from 'ol/Feature';
-import * as olformat from 'ol/format';
 import { WFSDataSourceOptions } from './wfs-datasource.interface';
 import { WMSDataSourceOptions } from './wms-datasource.interface';
 import { DataService } from './data.service';
@@ -11,7 +10,8 @@ import { formatWFSQueryString,
           defaultEpsg,
           defaultMaxFeatures,
           getFormatFromOptions} from './wms-wfs.utils';
-
+import { concatMap } from 'rxjs/operators';
+import { WFS } from 'ol/format';
 @Injectable({
   providedIn: 'root'
 })
@@ -50,12 +50,14 @@ export class WFSService extends DataService {
     dataSourceOptions: WFSDataSourceOptions | WMSDataSourceOptions,
     nb: number = defaultMaxFeatures,
     epsgCode: string = defaultEpsg,
-    propertyName?: string
+    propertyName?: string,
+    startIndex: number = 0,
+    forceDefaultOutputFormat: boolean = false
   ): Observable<any> {
-    const queryStringValues = formatWFSQueryString(dataSourceOptions, nb, epsgCode, propertyName);
+    const queryStringValues = formatWFSQueryString(dataSourceOptions, nb, epsgCode, propertyName, startIndex, forceDefaultOutputFormat );
     const baseUrl = queryStringValues.find(f => f.name === 'getfeature').value;
     const outputFormat = dataSourceOptions.paramsWFS.outputFormat;
-    if (gmlRegex.test(outputFormat) || !outputFormat) {
+    if (forceDefaultOutputFormat || gmlRegex.test(outputFormat) || !outputFormat) {
       return this.http.get(baseUrl, { responseType: 'text' });
     } else {
       return this.http.get(baseUrl);
@@ -71,37 +73,87 @@ export class WFSService extends DataService {
       let fieldListWoGeom;
       let fieldListWoGeomStr;
       let olFormats;
+      let effectiveOlFormats;
 
       olFormats = getFormatFromOptions(dataSourceOptions);
+      const gmlDataSourceOptions: WFSDataSourceOptions | WMSDataSourceOptions = JSON.parse(
+        JSON.stringify(dataSourceOptions)
+      );
+      delete gmlDataSourceOptions.paramsWFS.outputFormat;
+      delete (gmlDataSourceOptions as WFSDataSourceOptions).formatOptions;
 
-      this.wfsGetFeature(dataSourceOptions, 1).subscribe(oneFeature => {
-        const features = olFormats.readFeatures(oneFeature);
-        fieldList = features[0].getKeys();
-        fieldListWoGeom = fieldList.filter(
-          field =>
-            field !== features[0].getGeometryName() &&
-            !field.match(/boundedby/gi)
-        );
-        fieldListWoGeomStr = fieldListWoGeom.join(',');
-        this.wfsGetFeature(
-          dataSourceOptions,
-          dataSourceOptions.paramsWFS.maxFeatures || defaultMaxFeatures,
-          dataSourceOptions.paramsWFS.srsName,
-          fieldListWoGeomStr
-        ).subscribe(manyFeatures => {
-          const mfeatures = olFormats.readFeatures(manyFeatures);
+      effectiveOlFormats = getFormatFromOptions(gmlDataSourceOptions);
+      let sourceFieldsToRetrieveValues = dataSourceOptions.sourceFields?.filter(f => !f.values).map(f => f.name);
+
+      // Validate if the service manage no outputformat (wfs 1.0.0 and GML is the default return)
+      this.wfsGetFeature(dataSourceOptions, 1, undefined, undefined, 0, true).pipe(
+        concatMap(res => String(res).toLowerCase().includes('exception') ? of(false) : of(true)),
+        concatMap(allowGml => {
+          // If the service return GML (return no exception)
+          return this.wfsGetFeature(dataSourceOptions, 1).pipe(
+            concatMap(firstFeature => {
+              const features = olFormats.readFeatures(firstFeature);
+              fieldList = features[0].getKeys();
+              if (dataSourceOptions.sourceFields || dataSourceOptions.sourceFields.length === 0) {
+                sourceFieldsToRetrieveValues = fieldList;
+              }
+              fieldListWoGeom = fieldList.filter(
+                field =>
+                  sourceFieldsToRetrieveValues.includes(field) &&
+                  field !== features[0].getGeometryName() &&
+                  !field.match(/boundedby/gi)
+              );
+              fieldListWoGeomStr = fieldListWoGeom.join(',');
+              const processingArray = [];
+              let startIndex = 0;
+              // If the service do not allow gml return, dice the
+              // call in multiple calls by increment of chunkSize with the original outputFormat
+              if (
+                !allowGml && dataSourceOptions.paramsWFS.version === '2.0.0' &&
+                dataSourceOptions.paramsWFS.maxFeatures > defaultMaxFeatures) {
+                const chunkSize = 1000;
+                while (startIndex < dataSourceOptions.paramsWFS.maxFeatures) {
+                  processingArray.push(this.wfsGetFeature(
+                    dataSourceOptions,
+                    chunkSize,
+                    dataSourceOptions.paramsWFS.srsName,
+                    fieldListWoGeomStr,
+                    startIndex
+                  ));
+                  startIndex += chunkSize;
+                }
+                effectiveOlFormats = olFormats;
+              } else {
+                processingArray.push(this.wfsGetFeature(
+                  dataSourceOptions,
+                  dataSourceOptions.paramsWFS.maxFeatures || defaultMaxFeatures,
+                  dataSourceOptions.paramsWFS.srsName,
+                  fieldListWoGeomStr,
+                  0, true
+                ));
+              }
+              return combineLatest(processingArray);
+            })
+          );
+        })).subscribe((results) => {
+          let mfeatures: olFeature[] = [];
+          results.map((result) => {
+            const loopFeatures = effectiveOlFormats.readFeatures(result);
+            mfeatures = mfeatures.concat(loopFeatures);
+          });
           this.built_properties_value(mfeatures).forEach(element => {
             sourceFields.push(element);
           });
           d.next(sourceFields);
           d.complete();
         });
-      });
-
     });
   }
 
   private built_properties_value(features: olFeature[]): string[] {
+    if (features.length === 0) {
+      return [];
+    }
     const kv = Object.assign({}, features[0].getProperties());
     delete kv[features[0].getGeometryName()];
     delete kv.boundedBy;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1-When retrieving values from fields, sometime, the call take very long time to get the results...
2- Openlayers always call only once the service to retrieve the data.

**What is the new behavior?**
1- try to make a gml call without the geometry to accelerate the retrieval of the values from a field.
2- Dice the wfs getfeature call for wfs 2.0.0 & outputformat different from gml, where the count is superior to defaultMaxFeatures (5000). Then call the service by 1000 chunks. 

@mbarbeau 
https://github.com/infra-geo-ouverte/igo2-lib/commit/03a257f73f2e9048615083bd8553acdfda65f423
and 
https://github.com/infra-geo-ouverte/igo2-lib/pull/732/commits/2c18db81569f6ec769c01f8bd2e905907ea8c562
 Check if these commits are more efficient on pg based services.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
