### PR TITLE
feat(interactive-tour)add config + handling error no configtourFile

### DIFF
--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -34,7 +34,8 @@ export const environment: Environment = {
       prefix: './locale/'
     },
     interactiveTour: {
-      tourInMobile: true
+      tourInMobile: true,
+      activateInteractiveTour: true
     },
     importExport: {
       url: '/apis/ogre',

--- a/packages/common/src/lib/interactive-tour/interactive-tour.loader.ts
+++ b/packages/common/src/lib/interactive-tour/interactive-tour.loader.ts
@@ -12,10 +12,19 @@ export class InteractiveTourLoader {
 
   constructor(private http: HttpClient, private configService: ConfigService) {
     this.jsonURL = this.getPathToConfigFile();
-    this.allToursOptions = this.getJSON().subscribe((data) => {
-      this.allToursOptions = data;
-    });
   }
+
+   public loadConfigTour() {
+      this.getJSON()
+        .subscribe(
+          (data) => {
+            this.allToursOptions = data;
+          },
+          (err) => {
+            throw new Error('Problem with Interactive tour configuration file: interactiveTour.json not find. Check if the file and is path is set correctly.');
+          }
+        );
+   }
 
   public getPathToConfigFile(): string {
     return (

--- a/packages/common/src/lib/interactive-tour/interactive-tour.service.ts
+++ b/packages/common/src/lib/interactive-tour/interactive-tour.service.ts
@@ -21,7 +21,20 @@ export class InteractiveTourService {
     private languageService: LanguageService,
     private interactiveTourLoader: InteractiveTourLoader,
     private shepherdService: ShepherdService
-  ) {}
+  ) {
+    if (this.isAppHaveTour()) {
+      this.interactiveTourLoader.loadConfigTour();
+    }
+  }
+
+  public isAppHaveTour() {
+    const haveTour = this.configService.getConfig('interactiveTour.activateInteractiveTour')
+    if (haveTour === undefined) {
+      return true;
+    } else {
+      return haveTour;
+    }
+  }
 
   public isToolHaveTourConfig(toolName: string): boolean {
     const checkTourActiveOptions = this.interactiveTourLoader.getTourOptionData(


### PR DESCRIPTION
add new config  : 
"activateInteractiveTour": true

- no error went is false and  no interactiveTour config file 
- Better handling error went param is true and no interactiveTour config file are detect

