### PR TITLE
Monitor the load/end of url based vector sources. Related to the spinner

### DIFF
--- a/packages/geo/src/lib/layer/utils/vector-watcher.ts
+++ b/packages/geo/src/lib/layer/utils/vector-watcher.ts
@@ -39,27 +39,11 @@ export class VectorWatcher extends Watcher {
   }
 
   private handleLoadStart(event: any) {
-  /*  if (!event.__watchers__) {
-      event.__watchers__ = [];
-    }
-    event.__watchers__.push(this.id);*/
-
     this.loading += 1;
     this.status = SubjectStatus.Working;
   }
 
   private handleLoadEnd(event) {
-  /*  if (!event.__watchers__) {
-      return;
-    }
-
-    const watcherIndex = event.__watchers__.indexOf(this.id);
-    if (watcherIndex < 0) {
-      return;
-    }
-
-    event.__watchers__.splice(watcherIndex, 1);*/
-
     this.loaded += 1;
 
     const loading = this.loading;

--- a/packages/geo/src/lib/layer/utils/vector-watcher.ts
+++ b/packages/geo/src/lib/layer/utils/vector-watcher.ts
@@ -1,7 +1,7 @@
-import olSourceVector from 'ol/source/Vector';
 import { uuid, Watcher, SubjectStatus } from '@igo2/utils';
 
 import { VectorLayer } from '../shared/layers/vector-layer';
+import { ClusterDataSource } from '../../datasource/shared/datasources/cluster-datasource';
 
 export class VectorWatcher extends Watcher {
   private id: string;
@@ -17,9 +17,57 @@ export class VectorWatcher extends Watcher {
   }
 
   protected watch() {
+    let olSource = this.layer.options.source.ol;
+    if (this.layer.dataSource instanceof ClusterDataSource) {
+      olSource = (this.layer.options.source.options as any).source;
+     }
+
+    olSource.on(`vectorloading`, e => this.handleLoadStart(e));
+    olSource.on(`vectorloaded`, e => this.handleLoadEnd(e));
+    olSource.on(`vectorloaderror`, e => this.handleLoadEnd(e));
+
   }
 
   protected unwatch() {
-    this.layer.onUnwatch();
+    let olSource = this.layer.options.source.ol;
+    if (this.layer.dataSource instanceof ClusterDataSource) {
+      olSource = (this.layer.options.source.options as any).source;
+     }
+    olSource.un(`vectorloading`, e => this.handleLoadStart(e));
+    olSource.un(`vectorloaded`, e => this.handleLoadEnd(e));
+    olSource.un(`vectorloaderror`, e => this.handleLoadEnd(e));
+  }
+
+  private handleLoadStart(event: any) {
+  /*  if (!event.__watchers__) {
+      event.__watchers__ = [];
+    }
+    event.__watchers__.push(this.id);*/
+
+    this.loading += 1;
+    this.status = SubjectStatus.Working;
+  }
+
+  private handleLoadEnd(event) {
+  /*  if (!event.__watchers__) {
+      return;
+    }
+
+    const watcherIndex = event.__watchers__.indexOf(this.id);
+    if (watcherIndex < 0) {
+      return;
+    }
+
+    event.__watchers__.splice(watcherIndex, 1);*/
+
+    this.loaded += 1;
+
+    const loading = this.loading;
+    if (this.loaded >= loading) {
+      if (loading === this.loading) {
+        this.status = SubjectStatus.Done;
+        this.loaded = this.loading = 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
…elated to the spinner (activity-service)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
url based vector sources do not trigger the activity service.


**What is the new behavior?**
Monitor the load/end of url based vector sources. Now trigger the loading spinner
@drekss - Reviewer or comment after the merge...


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
