### PR TITLE
Entity table renderer for url and image

### DIFF
--- a/demo/src/app/common/entity-table/entity-table.component.ts
+++ b/demo/src/app/common/entity-table/entity-table.component.ts
@@ -56,6 +56,14 @@ export class AppEntityTableComponent implements OnInit, OnDestroy {
         renderer: EntityTableColumnRenderer.HTML
       },
       {
+        name: 'url',
+        title: 'Hyperlink'
+      },
+      {
+        name: 'image',
+        title: 'Image'
+      },
+      {
         name: 'action',
         title: '',
         valueAccessor: (entity: object) => {
@@ -76,7 +84,7 @@ export class AppEntityTableComponent implements OnInit, OnDestroy {
     const ids = [2, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 
     const entities = ids.map(id => {
-      return { id , name: `Name ${id}`, description: `<b>Description ${id}</b>`};
+      return { id , name: `Name ${id}`, description: `<b>Description ${id}</b>`, url: 'https://igouverte.org', image: 'http://www.igouverte.org/assets/img/Igo_logoavec.png'};
     });
     this.store.load(entities);
   }

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.html
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.html
@@ -42,23 +42,53 @@
 
       <ng-container *ngIf="getColumnRenderer(column) as columnRenderer">
         <ng-container *ngIf="columnRenderer === entityTableColumnRenderer.Default">
-            <td mat-cell *matCellDef="let record" class="mat-cell-text"
-              [ngClass]="getCellClass(record, column)">
-              {{getValue(record, column)}}
-            </td>
+            <ng-container *matCellDef="let record">
+              <td mat-cell class="mat-cell-text" *ngIf="!isUrl(getValue(record, column));else isAnUrlDefault"
+                [ngClass]="getCellClass(record, column)">
+                {{getValue(record, column)}}
+              </td>
+              <ng-template #isAnUrlDefault>
+                <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
+                  <a href="{{getValue(record, column)}}" target='_blank'>
+                    <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
+                    <ng-template #notImg><span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span></ng-template>
+                  </a>
+                </td>
+              </ng-template>
+            </ng-container>
           </ng-container>
           <ng-container *ngIf="columnRenderer === entityTableColumnRenderer.HTML">
-            <td mat-cell *matCellDef="let record" class="mat-cell-text"
-              [ngClass]="getCellClass(record, column)"
-              [innerHTML]="getValue(record, column)">
-            </td>
+            <ng-container *matCellDef="let record">
+              <td mat-cell class="mat-cell-text" *ngIf="!isUrl(getValue(record, column));else isAnUrlHTML"
+                [ngClass]="getCellClass(record, column)"
+                [innerHTML]="getValue(record, column)">
+              </td>
+              <ng-template #isAnUrlHTML>
+                <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
+                  <a href="{{getValue(record, column)}}" target='_blank'>
+                    <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
+                    <ng-template #notImg><span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span></ng-template>
+                  </a>
+                </td>
+              </ng-template>
+            </ng-container>
           </ng-container>
           <ng-container *ngIf="columnRenderer === entityTableColumnRenderer.UnsanitizedHTML">
-              <td mat-cell *matCellDef="let record" class="mat-cell-text"
+            <ng-container *matCellDef="let record">
+              <td mat-cell class="mat-cell-text" *ngIf="!isUrl(getValue(record, column));else isAnUrlUnsanitizedHTML"
                 [ngClass]="getCellClass(record, column)"
                 [innerHTML]="getValue(record, column) | sanitizeHtml">
               </td>
+              <ng-template #isAnUrlUnsanitizedHTML>
+                <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
+                  <a href="{{getValue(record, column)}}" target='_blank'>
+                    <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
+                    <ng-template #notImg><span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span></ng-template>
+                  </a>
+                </td>
+              </ng-template>
             </ng-container>
+          </ng-container>
           <ng-container *ngIf="columnRenderer === entityTableColumnRenderer.Icon">
             <td mat-cell *matCellDef="let record" class="mat-cell-text"
               [ngClass]="getCellClass(record, column)">

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.html
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.html
@@ -49,7 +49,7 @@
               </td>
               <ng-template #isAnUrlDefault>
                 <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
-                  <a href="{{getValue(record, column)}}" target='_blank'>
+                  <a href="{{getValue(record, column)}}" target='_blank' (click)="$event.stopPropagation()">
                     <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
                     <ng-template #notImg><span>{{ 'igo.common.entity-table.targetHtmlUrl' | translate }} </span></ng-template>
                   </a>
@@ -65,7 +65,7 @@
               </td>
               <ng-template #isAnUrlHTML>
                 <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
-                  <a href="{{getValue(record, column)}}" target='_blank'>
+                  <a href="{{getValue(record, column)}}" target='_blank' (click)="$event.stopPropagation()">
                     <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
                     <ng-template #notImg><span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span></ng-template>
                   </a>
@@ -81,7 +81,7 @@
               </td>
               <ng-template #isAnUrlUnsanitizedHTML>
                 <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
-                  <a href="{{getValue(record, column)}}" target='_blank'>
+                  <a href="{{getValue(record, column)}}" target='_blank' (click)="$event.stopPropagation()">
                     <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
                     <ng-template #notImg><span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span></ng-template>
                   </a>

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.html
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.html
@@ -51,7 +51,7 @@
                 <td mat-cell class="mat-cell-text" [ngClass]="getCellClass(record, column)">
                   <a href="{{getValue(record, column)}}" target='_blank'>
                     <img *ngIf="isImg(getValue(record, column));else notImg" src="{{(getValue(record, column) | secureImage) | async}}" width="50" heigth="auto">
-                    <ng-template #notImg><span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span></ng-template>
+                    <ng-template #notImg><span>{{ 'igo.common.entity-table.targetHtmlUrl' | translate }} </span></ng-template>
                   </a>
                 </td>
               </ng-template>

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -433,6 +433,28 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy  {
     return state.selected ? state.selected : false;
   }
 
+  isImg(value) {
+    if (this.isUrl(value)) {
+      return (
+        ['jpg', 'png', 'gif'].indexOf(value.split('.').pop().toLowerCase()) !== -1
+      );
+    } else {
+      return false;
+    }
+  }
+
+  isUrl(value) {
+    console.log('isUrl', value);
+    if (typeof value === 'string') {
+      return (
+        value.slice(0, 8) === 'https://' || value.slice(0, 7) === 'http://'
+      );
+    } else {
+      return false;
+    }
+  }
+
+
   /**
    * Method to access an entity's values
    * @param record Record

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -453,7 +453,6 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy  {
     }
   }
 
-
   /**
    * Method to access an entity's values
    * @param record Record

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -444,7 +444,6 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy  {
   }
 
   isUrl(value) {
-    console.log('isUrl', value);
     if (typeof value === 'string') {
       return (
         value.slice(0, 8) === 'https://' || value.slice(0, 7) === 'http://'

--- a/packages/common/src/lib/entity/entity-table/entity-table.module.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.module.ts
@@ -12,6 +12,8 @@ import { EntityTableRowDirective } from './entity-table-row.directive';
 import { EntityTableComponent } from './entity-table.component';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { IgoEntityTablePaginatorModule } from '../entity-table-paginator/entity-table-paginator.module';
+import { IgoImageModule } from '../../image/image.module';
+import { IgoLanguageModule } from '@igo2/core';
 
 /**
  * @ignore
@@ -27,7 +29,9 @@ import { IgoEntityTablePaginatorModule } from '../entity-table-paginator/entity-
     MatPaginatorModule,
     IgoStopPropagationModule,
     IgoCustomHtmlModule,
-    IgoEntityTablePaginatorModule
+    IgoEntityTablePaginatorModule,
+    IgoImageModule,
+    IgoLanguageModule
   ],
   exports: [
     EntityTableComponent

--- a/packages/common/src/locale/en.common.json
+++ b/packages/common/src/locale/en.common.json
@@ -9,6 +9,9 @@
       "table": {
         "filter": "Filter"
       },
+      "entity-table": {
+        "targetHtmlUrl": "Open the external link"
+      },
       "form": {
         "errors": {
           "required": "This field is required"

--- a/packages/common/src/locale/fr.common.json
+++ b/packages/common/src/locale/fr.common.json
@@ -9,6 +9,9 @@
       "table": {
         "filter": "Filtre"
       },
+      "entity-table": {
+        "targetHtmlUrl": "Ouvrir le lien externe"
+      },
       "form": {
         "errors": {
           "required": "Ce champ est requis"

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -348,9 +348,9 @@ export class ImportExportComponent implements OnDestroy, OnInit {
   }
 
   handlePopup(preCheck: boolean = true): boolean {
-    const p1 = window.open('', '_blank');
+    const p1 = window.open('', 'popup', 'width=1, height=1');
     p1.close();
-    const p2 = window.open('', '_blank');
+    const p2 = window.open('', 'popup', 'width=1, height=1');
     if (!p2 || p2.closed || typeof p2.closed === 'undefined' || p2 === null) {
       this.onPopupBlockedError(preCheck);
       this.popupAllowed = false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
URL were rendered as plain text.

**What is the new behavior?**
1- Allow to format an url like string (begin with http:// or https://)  
2- If it is an url and containt .png .jpg or .gif, then the image is shown, height set to 50, click on the image open the link.

![image](https://user-images.githubusercontent.com/7397743/97729063-aa5d4800-1aa8-11eb-88da-82729e617d4d.png)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
