### PR TITLE
feat(options-api) provide a context name for layer options retrieval

### DIFF
--- a/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
+++ b/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
@@ -84,7 +84,7 @@ export class LayerContextDirective implements OnInit, OnDestroy {
 
     const layersAndIndex$ = merge(
       ...context.layers.map((layerOptions: LayerOptions, index: number) => {
-        return this.layerService.createAsyncLayer(layerOptions);
+        return this.layerService.createAsyncLayer(layerOptions, context.uri);
       })
     );
 

--- a/packages/geo/src/lib/datasource/shared/datasource.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasource.service.ts
@@ -55,7 +55,7 @@ export class DataSourceService {
     private authInterceptor?: AuthInterceptor
   ) {}
 
-  createAsyncDataSource(context: AnyDataSourceOptions): Observable<DataSource> {
+  createAsyncDataSource(context: AnyDataSourceOptions, detailedContextUri?: string): Observable<DataSource> {
     if (!context.type) {
       console.error(context);
       throw new Error('Datasource needs a type');
@@ -76,7 +76,7 @@ export class DataSourceService {
       case 'wms':
         const wmsContext = context as WMSDataSourceOptions;
         ObjectUtils.removeDuplicateCaseInsensitive(wmsContext.params);
-        dataSource = this.createWMSDataSource(wmsContext);
+        dataSource = this.createWMSDataSource(wmsContext, detailedContextUri);
         break;
       case 'wmts':
         dataSource = this.createWMTSDataSource(
@@ -153,7 +153,7 @@ export class DataSourceService {
     );
   }
 
-  private createWMSDataSource(context: WMSDataSourceOptions): Observable<any> {
+  private createWMSDataSource(context: WMSDataSourceOptions, detailedContextUri?: string): Observable<any> {
     const observables = [];
     if (context.optionsFromCapabilities) {
       observables.push(
@@ -176,7 +176,7 @@ export class DataSourceService {
 
     if (this.optionsService && context.optionsFromApi === true) {
       observables.push(
-        this.optionsService.getWMSOptions(context).pipe(
+        this.optionsService.getWMSOptions(context, detailedContextUri).pipe(
           catchError(e => {
             e.error.toDisplay = true;
             e.error.title = this.languageService.translate.instant(

--- a/packages/geo/src/lib/datasource/shared/options/options-api.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options-api.interface.ts
@@ -1,3 +1,4 @@
 export interface OptionsApiOptions {
   url?: string;
+  provideContextUri?: boolean;
 }

--- a/packages/geo/src/lib/datasource/shared/options/options-api.service.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options-api.service.ts
@@ -12,6 +12,7 @@ import { OptionsApiOptions } from './options-api.interface';
 })
 export class OptionsApiService extends OptionsService {
   private urlApi: string;
+  private provideContextUri: boolean;
 
   constructor(
     private http: HttpClient,
@@ -19,21 +20,27 @@ export class OptionsApiService extends OptionsService {
   ) {
     super();
     this.urlApi = options.url || this.urlApi;
+    this.provideContextUri = options.provideContextUri || this.provideContextUri;
   }
 
   getWMSOptions(
-    baseOptions: WMSDataSourceOptions
+    baseOptions: WMSDataSourceOptions,
+    detailedContextUri?: string
   ): Observable<WMSDataSourceOptions> {
     if (!this.urlApi) {
       return of({} as WMSDataSourceOptions);
     }
-    const params = new HttpParams({
+    let params = new HttpParams({
       fromObject: {
         type: baseOptions.type,
         url: baseOptions.url,
         layers: baseOptions.params.LAYERS
       }
     });
+
+    if (detailedContextUri && this.provideContextUri) {
+      params = params.append('context', detailedContextUri);
+    }
 
     const request = this.http.get(this.urlApi, {
       params

--- a/packages/geo/src/lib/datasource/shared/options/options.service.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options.service.ts
@@ -4,6 +4,7 @@ import { WMSDataSourceOptions } from '../datasources';
 
 export abstract class OptionsService {
   abstract getWMSOptions(
-    _baseOptions: WMSDataSourceOptions
+    _baseOptions: WMSDataSourceOptions,
+    detailedContextUri?: string
   ): Observable<WMSDataSourceOptions>;
 }

--- a/packages/geo/src/lib/layer/shared/layer.service.ts
+++ b/packages/geo/src/lib/layer/shared/layer.service.ts
@@ -97,13 +97,13 @@ export class LayerService {
     return layer;
   }
 
-  createAsyncLayer(layerOptions: AnyLayerOptions): Observable<Layer> {
+  createAsyncLayer(layerOptions: AnyLayerOptions, detailedContextUri?: string): Observable<Layer> {
     if (layerOptions.source) {
       return new Observable(d => d.next(this.createLayer(layerOptions)));
     }
 
     return this.dataSourceService
-      .createAsyncDataSource(layerOptions.sourceOptions)
+      .createAsyncDataSource(layerOptions.sourceOptions, detailedContextUri)
       .pipe(
         map(source => {
           if (source === undefined) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Provide the context uri from where the layer is added. Allow the optionsApi to retrieve the correct layerOptions depending of the context. 
Controlled by a config: 
```
provideContextUri?: boolean;
```

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
