### PR TITLE
Catalog force name

### DIFF
--- a/packages/geo/src/lib/catalog/shared/catalog.abstract.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.abstract.ts
@@ -14,7 +14,7 @@ export abstract class Catalog implements ICatalog {
     id: string;
     title: string;
     url: string;
-    alias?: string[];
+    forcedProperties?: any[];
     items?: CatalogItem[];
     type?: TypeCatalogStrings;
     version?: string;

--- a/packages/geo/src/lib/catalog/shared/catalog.abstract.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.abstract.ts
@@ -14,6 +14,7 @@ export abstract class Catalog implements ICatalog {
     id: string;
     title: string;
     url: string;
+    alias?: string[];
     items?: CatalogItem[];
     type?: TypeCatalogStrings;
     version?: string;

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -318,6 +318,8 @@ export class CatalogService {
   }
 
   private prepareCatalogItemLayer(layer, idParent, layersQueryFormat, catalog) {
+    console.log('prepareCatalogItemLayer');
+    console.log(layer);
     const configuredQueryFormat = this.retriveLayerInfoFormat(
       layer.Name,
       layersQueryFormat
@@ -354,6 +356,17 @@ export class CatalogService {
       { params }
     ) as WMSDataSourceOptions;
 
+    const regexes = (catalog.regFilters || []).map(
+      (pattern: string) => new RegExp(pattern)
+    ) as string[];
+    console.log(regexes);
+    for (let regex of regexes) {
+      console.log(regex);
+      regex = regex.toString().replace('/', '').replace('^', '').replace('$', '');
+    }
+    console.log(regexes);
+    const index = regexes.findIndex(reg => reg === layer.name);
+    console.log(index);
     const layerPrepare = {
       id: generateIdFromSourceOptions(sourceOptions),
       type: CatalogItemType.Layer,
@@ -483,6 +496,7 @@ export class CatalogService {
     catalog: Catalog,
     capabilities: { [key: string]: any }
   ): CatalogItemLayer[] {
+    console.log('WMTS');
     const layers = capabilities.Contents.Layer;
     const regexes = (catalog.regFilters || []).map(
       (pattern: string) => new RegExp(pattern)
@@ -490,6 +504,7 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
+        const index = layers.findIndex(lay => lay.id === layer.id);
         if (this.testLayerRegexes(layer.Identifier, regexes) === false) {
           return undefined;
         }
@@ -518,7 +533,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: layer.Title,
+          title: catalog.alias ? catalog.alias[index] : layer.Title,
           address: catalog.id,
           options: {
             sourceOptions
@@ -539,6 +554,7 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
+        const index = layers.findIndex(lay => lay.id === layer.id);
         if (this.testLayerRegexes(layer.id, regexes) === false) {
           return undefined;
         }
@@ -562,7 +578,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: layer.name,
+          title: catalog.alias ? catalog.alias[index] : layer.name,
           address: catalog.id,
           options: {
             sourceOptions

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -318,7 +318,6 @@ export class CatalogService {
   }
 
   private prepareCatalogItemLayer(layer, idParent, layersQueryFormat, catalog) {
-    console.log(layer);
     const configuredQueryFormat = this.retriveLayerInfoFormat(
       layer.Name,
       layersQueryFormat
@@ -355,18 +354,14 @@ export class CatalogService {
       { params }
     ) as WMSDataSourceOptions;
 
-    const regexes = (catalog.regFilters || []).map(
-      (pattern: string) => new RegExp(pattern)
-    ) as string[];
-
     let layerTitle;
-        if (catalog.forcedProperties) {
-          for (const property of catalog.forcedProperties) {
-            if (layer.Name === property.layerName && property.title) {
-              layerTitle = property.title;
-            }
-          }
+    if (catalog.forcedProperties) {
+      for (const property of catalog.forcedProperties) {
+        if (layer.Name === property.layerName && property.title) {
+          layerTitle = property.title;
         }
+      }
+    }
 
     const layerPrepare = {
       id: generateIdFromSourceOptions(sourceOptions),
@@ -504,15 +499,13 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
-        let layerTitle;
+        let forcedTitle;
         if (catalog.forcedProperties) {
-          layers.forEach(layer => {
-            for (const property of catalog.forcedProperties) {
-              if (layer.name === property.layerName && property.title) {
-                layerTitle = property.Title
-              }
+          for (const property of catalog.forcedProperties) {
+            if (layer.Title === property.layerName && property.title) {
+              forcedTitle = property.title;
             }
-          });
+          }
         }
         if (this.testLayerRegexes(layer.Identifier, regexes) === false) {
           return undefined;
@@ -542,7 +535,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: layerTitle !== undefined ? layerTitle : layer.Title,
+          title: forcedTitle !== undefined ? forcedTitle : layer.Title,
           address: catalog.id,
           options: {
             sourceOptions
@@ -563,15 +556,13 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
-        let layerTitle;
+        let forcedTitle;
         if (catalog.forcedProperties) {
-          layers.forEach(layer => {
-            for (const property of catalog.forcedProperties) {
-              if (layer.name === property.layerName && property.title) {
-                layerTitle = property.title
-              }
+          for (const property of catalog.forcedProperties) {
+            if (layer.name === property.layerName && property.title) {
+              forcedTitle = property.title;
             }
-          });
+          }
         }
         if (this.testLayerRegexes(layer.id, regexes) === false) {
           return undefined;
@@ -596,7 +587,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: layerTitle !== undefined ? layerTitle : layer.name,
+          title: forcedTitle !== undefined ? forcedTitle : layer.name,
           address: catalog.id,
           options: {
             sourceOptions

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -364,7 +364,7 @@ export class CatalogService {
         regex = regex.toString().split('/').join('');
         regex = regex.toString().split('^').join('');
         regex = regex.toString().split('$').join('');
-        if (regex === layer.Name) {
+        if (regex === layer.Name && catalog.alias[index]) {
           layerIndex = index;
         }
       });
@@ -546,7 +546,7 @@ export class CatalogService {
   }
 
   private getArcGISRESTItems(
-    catalog: Catalog,
+    catalog,
     capabilities
   ): CatalogItemLayer[] {
     const layers = capabilities.layers;
@@ -556,7 +556,17 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
-        const index = layers.findIndex(lay => lay.id === layer.id);
+        let layerIndex;
+        if (catalog.alias) {
+          regexes.forEach((regex, index) => {
+            regex = regex.toString().split('/').join('');
+            regex = regex.toString().split('^').join('');
+            regex = regex.toString().split('$').join('');
+            if (regex === layer.id.toString() && catalog.alias[index]) {
+              layerIndex = index;
+            }
+          });
+        }
         if (this.testLayerRegexes(layer.id, regexes) === false) {
           return undefined;
         }
@@ -580,7 +590,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: catalog.alias ? catalog.alias[index] : layer.name,
+          title: layerIndex !== undefined ? catalog.alias[layerIndex] : layer.name,
           address: catalog.id,
           options: {
             sourceOptions

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -496,7 +496,7 @@ export class CatalogService {
   }
 
   private getWMTSItems(
-    catalog: Catalog,
+    catalog,
     capabilities: { [key: string]: any }
   ): CatalogItemLayer[] {
     const layers = capabilities.Contents.Layer;
@@ -506,7 +506,17 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
-        const index = layers.findIndex(lay => lay.id === layer.id);
+        let layerIndex;
+        if (catalog.alias) {
+          regexes.forEach((regex, index) => {
+            regex = regex.toString().split('/').join('');
+            regex = regex.toString().split('^').join('');
+            regex = regex.toString().split('$').join('');
+            if (regex === layer.Title && catalog.alias[index]) {
+              layerIndex = index;
+            }
+          });
+        }
         if (this.testLayerRegexes(layer.Identifier, regexes) === false) {
           return undefined;
         }
@@ -535,7 +545,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: catalog.alias ? catalog.alias[index] : layer.Title,
+          title: layerIndex !== undefined ? catalog.alias[layerIndex] : layer.Title,
           address: catalog.id,
           options: {
             sourceOptions

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -318,6 +318,7 @@ export class CatalogService {
   }
 
   private prepareCatalogItemLayer(layer, idParent, layersQueryFormat, catalog) {
+    console.log(layer);
     const configuredQueryFormat = this.retriveLayerInfoFormat(
       layer.Name,
       layersQueryFormat
@@ -358,22 +359,19 @@ export class CatalogService {
       (pattern: string) => new RegExp(pattern)
     ) as string[];
 
-    let layerIndex;
-    if (catalog.alias) {
-      regexes.forEach((regex, index) => {
-        regex = regex.toString().split('/').join('');
-        regex = regex.toString().split('^').join('');
-        regex = regex.toString().split('$').join('');
-        if (regex === layer.Name && catalog.alias[index]) {
-          layerIndex = index;
+    let layerTitle;
+        if (catalog.forcedProperties) {
+          for (const property of catalog.forcedProperties) {
+            if (layer.Name === property.layerName && property.title) {
+              layerTitle = property.title;
+            }
+          }
         }
-      });
-    }
 
     const layerPrepare = {
       id: generateIdFromSourceOptions(sourceOptions),
       type: CatalogItemType.Layer,
-      title: layerIndex !== undefined ? catalog.alias[layerIndex] : layer.Title,
+      title: layerTitle !== undefined ? layerTitle : layer.Title,
       address: idParent,
       options: {
         maxResolution: getResolutionFromScale(layer.MaxScaleDenominator),
@@ -506,14 +504,13 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
-        let layerIndex;
-        if (catalog.alias) {
-          regexes.forEach((regex, index) => {
-            regex = regex.toString().split('/').join('');
-            regex = regex.toString().split('^').join('');
-            regex = regex.toString().split('$').join('');
-            if (regex === layer.Title && catalog.alias[index]) {
-              layerIndex = index;
+        let layerTitle;
+        if (catalog.forcedProperties) {
+          layers.forEach(layer => {
+            for (const property of catalog.forcedProperties) {
+              if (layer.name === property.layerName && property.title) {
+                layerTitle = property.Title
+              }
             }
           });
         }
@@ -545,7 +542,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: layerIndex !== undefined ? catalog.alias[layerIndex] : layer.Title,
+          title: layerTitle !== undefined ? layerTitle : layer.Title,
           address: catalog.id,
           options: {
             sourceOptions
@@ -566,14 +563,13 @@ export class CatalogService {
 
     return layers
       .map((layer: any) => {
-        let layerIndex;
-        if (catalog.alias) {
-          regexes.forEach((regex, index) => {
-            regex = regex.toString().split('/').join('');
-            regex = regex.toString().split('^').join('');
-            regex = regex.toString().split('$').join('');
-            if (regex === layer.id.toString() && catalog.alias[index]) {
-              layerIndex = index;
+        let layerTitle;
+        if (catalog.forcedProperties) {
+          layers.forEach(layer => {
+            for (const property of catalog.forcedProperties) {
+              if (layer.name === property.layerName && property.title) {
+                layerTitle = property.title
+              }
             }
           });
         }
@@ -600,7 +596,7 @@ export class CatalogService {
         return ObjectUtils.removeUndefined({
           id: generateIdFromSourceOptions(sourceOptions),
           type: CatalogItemType.Layer,
-          title: layerIndex !== undefined ? catalog.alias[layerIndex] : layer.name,
+          title: layerTitle !== undefined ? layerTitle : layer.name,
           address: catalog.id,
           options: {
             sourceOptions

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -318,8 +318,6 @@ export class CatalogService {
   }
 
   private prepareCatalogItemLayer(layer, idParent, layersQueryFormat, catalog) {
-    console.log('prepareCatalogItemLayer');
-    console.log(layer);
     const configuredQueryFormat = this.retriveLayerInfoFormat(
       layer.Name,
       layersQueryFormat
@@ -359,18 +357,23 @@ export class CatalogService {
     const regexes = (catalog.regFilters || []).map(
       (pattern: string) => new RegExp(pattern)
     ) as string[];
-    console.log(regexes);
-    for (let regex of regexes) {
-      console.log(regex);
-      regex = regex.toString().replace('/', '').replace('^', '').replace('$', '');
+
+    let layerIndex;
+    if (catalog.alias) {
+      regexes.forEach((regex, index) => {
+        regex = regex.toString().split('/').join('');
+        regex = regex.toString().split('^').join('');
+        regex = regex.toString().split('$').join('');
+        if (regex === layer.Name) {
+          layerIndex = index;
+        }
+      });
     }
-    console.log(regexes);
-    const index = regexes.findIndex(reg => reg === layer.name);
-    console.log(index);
+
     const layerPrepare = {
       id: generateIdFromSourceOptions(sourceOptions),
       type: CatalogItemType.Layer,
-      title: layer.Title,
+      title: layerIndex !== undefined ? catalog.alias[layerIndex] : layer.Title,
       address: idParent,
       options: {
         maxResolution: getResolutionFromScale(layer.MaxScaleDenominator),
@@ -496,7 +499,6 @@ export class CatalogService {
     catalog: Catalog,
     capabilities: { [key: string]: any }
   ): CatalogItemLayer[] {
-    console.log('WMTS');
     const layers = capabilities.Contents.Layer;
     const regexes = (catalog.regFilters || []).map(
       (pattern: string) => new RegExp(pattern)


### PR DESCRIPTION
- Allow to add alias to WMS, WMTS or ArcGIS REST catalog's layer (for composite catalog for example)

- regFilters must be used to match the indexes. 

For example, if catalog's config is : 
        {
            "id": "2",
            "url": "https://geoappext.nrcan.gc.ca/arcgis/services/GSCA/basin_f/MapServer/WMSServer?",
            "groupImpose": {"id": "geo", "title": "Géologie"},
            "regFilters": ["^3$", "^6$"],
            "alias": ["Analyse - 1", "Analyse - 2"]
          }
Then it would mean that the layer whose name is 3 going to be rename as "Analyse - 1" and the layer whose name is 6 is going to be rename as "Analyse - 2".

Note that if alias is not mandatory, if none are provided, the service's title is going to be used (like it was before).

Issue https://github.com/infra-geo-ouverte/igo2/issues/515 in igo2 (assemblage)
JIRA : http://jira.msp.gouv.qc.ca:8080/browse/MIGO2-232 