### PR TITLE
Fix(layerContextDirective.computeLayerVisibilityFromUrl) share link bug with layer id numeric

### DIFF
--- a/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
+++ b/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
@@ -172,14 +172,14 @@ export class LayerContextDirective implements OnInit, OnDestroy {
       // After, managing named layer by id (context.json OR id from datasource)
       visiblelayers = visibleOnLayersParams.split(',');
       invisiblelayers = visibleOffLayersParams.split(',');
-      if (visiblelayers.indexOf(currentLayerid) > -1) {
+      if (visiblelayers.indexOf(currentLayerid) > -1  || visiblelayers.indexOf(currentLayerid.toString()) > -1) {
         visible = true;
       }
-      if (invisiblelayers.indexOf(currentLayerid) > -1) {
+      if (invisiblelayers.indexOf(currentLayerid) > -1 || invisiblelayers.indexOf(currentLayerid.toString()) > -1) {
         visible = false;
       }
     }
-
+    
     return visible;
   }
 }

--- a/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
+++ b/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
@@ -179,7 +179,7 @@ export class LayerContextDirective implements OnInit, OnDestroy {
         visible = false;
       }
     }
-    
+
     return visible;
   }
 }


### PR DESCRIPTION

- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Share link problem with a layer id numeric set in context


**What is the new behavior?**
ShareLink is ok 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


