### PR TITLE
feat(options-api) extend the capacities to arcgis services

### DIFF
--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -158,7 +158,13 @@ export class CapabilitiesService {
     const baseUrl = baseOptions.url + '/' + baseOptions.layer + '?f=json';
     const legendUrl = baseOptions.url + '/legend?f=json';
     const arcgisOptions = this.http.get(baseUrl);
-    const legendInfo = this.http.get(legendUrl);
+    const legendInfo = this.http.get(legendUrl).pipe(
+      map((res: any) => res),
+      catchError((err) => {
+        console.log('No legend associated with this Tile Service');
+        return of(err);
+      })
+    );
 
     return forkJoin([arcgisOptions, legendInfo]).pipe(
       map((res: any) =>

--- a/packages/geo/src/lib/datasource/shared/datasource.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasource.service.ts
@@ -89,8 +89,8 @@ export class DataSourceService {
         dataSource = this.createXYZDataSource(context as XYZDataSourceOptions);
         break;
       case 'tiledebug':
-          dataSource = this.createTileDebugDataSource(context as TileDebugDataSource);
-          break;
+        dataSource = this.createTileDebugDataSource(context as TileDebugDataSource);
+        break;
       case 'carto':
         dataSource = this.createCartoDataSource(
           context as CartoDataSourceOptions
@@ -98,14 +98,14 @@ export class DataSourceService {
         break;
       case 'arcgisrest':
         dataSource = this.createArcGISRestDataSource(
-          context as ArcGISRestDataSourceOptions
+          context as ArcGISRestDataSourceOptions, detailedContextUri
         );
         break;
-        case 'imagearcgisrest':
-          dataSource = this.createArcGISRestImageDataSource(
-            context as ArcGISRestImageDataSourceOptions
-          );
-          break;
+      case 'imagearcgisrest':
+        dataSource = this.createArcGISRestImageDataSource(
+          context as ArcGISRestImageDataSourceOptions, detailedContextUri
+        );
+        break;
       case 'websocket':
         dataSource = this.createWebSocketDataSource(
           context as FeatureDataSourceOptions
@@ -116,7 +116,7 @@ export class DataSourceService {
         break;
       case 'tilearcgisrest':
         dataSource = this.createTileArcGISRestDataSource(
-          context as TileArcGISRestDataSourceOptions
+          context as TileArcGISRestDataSourceOptions, detailedContextUri
         );
         break;
       case 'cluster':
@@ -265,41 +265,133 @@ export class DataSourceService {
   }
 
   private createArcGISRestDataSource(
-    context: ArcGISRestDataSourceOptions
+    context: ArcGISRestDataSourceOptions,
+    detailedContextUri?: string
   ): Observable<ArcGISRestDataSource> {
-    return this.capabilitiesService
+    const observables = [];
+    observables.push(this.capabilitiesService
       .getArcgisOptions(context)
       .pipe(
         map(
           (options: ArcGISRestDataSourceOptions) =>
             new ArcGISRestDataSource(options)
         )
+      ));
+    if (this.optionsService && context.optionsFromApi === true) {
+      observables.push(
+        this.optionsService.getArcgisRestOptions(context, detailedContextUri).pipe(
+          catchError(e => {
+            e.error.toDisplay = true;
+            e.error.title = this.languageService.translate.instant(
+              'igo.geo.dataSource.unavailableTitle'
+            );
+            e.error.message = this.languageService.translate.instant(
+              'igo.geo.dataSource.optionsApiUnavailable'
+            );
+            return of({});
+          })
+        )
       );
+    }
+    observables.push(of(context));
+    return forkJoin(observables).pipe(
+      map((options: ArcGISRestDataSource[]) => {
+        const optionsMerged = options.reduce((a, b) =>
+          ObjectUtils.mergeDeep(a, b)
+        );
+        return new ArcGISRestDataSource(optionsMerged);
+      }),
+      catchError(() => {
+        return of(undefined);
+      })
+    );
   }
+
   private createArcGISRestImageDataSource(
-    context: ArcGISRestImageDataSourceOptions
-  ): Observable<ImageArcGISRestDataSource> {
-    return this.capabilitiesService
+    context: ArcGISRestImageDataSourceOptions,
+    detailedContextUri?: string
+  ): Observable<ArcGISRestImageDataSourceOptions> {
+    const observables = [];
+
+    observables.push(this.capabilitiesService
       .getImageArcgisOptions(context)
       .pipe(
         map(
           (options: ArcGISRestImageDataSourceOptions) =>
             new ImageArcGISRestDataSource(options)
         )
+      ));
+    if (this.optionsService && context.optionsFromApi === true) {
+      observables.push(
+        this.optionsService.getArcgisRestOptions(context, detailedContextUri).pipe(
+          catchError(e => {
+            e.error.toDisplay = true;
+            e.error.title = this.languageService.translate.instant(
+              'igo.geo.dataSource.unavailableTitle'
+            );
+            e.error.message = this.languageService.translate.instant(
+              'igo.geo.dataSource.optionsApiUnavailable'
+            );
+            return of({});
+          })
+        )
       );
+    }
+    observables.push(of(context));
+    return forkJoin(observables).pipe(
+      map((options: ImageArcGISRestDataSource[]) => {
+        const optionsMerged = options.reduce((a, b) =>
+          ObjectUtils.mergeDeep(a, b)
+        );
+        return new ImageArcGISRestDataSource(optionsMerged);
+      }),
+      catchError(() => {
+        return of(undefined);
+      })
+    );
   }
 
   private createTileArcGISRestDataSource(
-    context: TileArcGISRestDataSourceOptions
+    context: TileArcGISRestDataSourceOptions,
+    detailedContextUri?: string
   ): Observable<TileArcGISRestDataSource> {
-    return this.capabilitiesService
+    const observables = [];
+    observables.push(this.capabilitiesService
       .getTileArcgisOptions(context)
       .pipe(
         map(
           (options: TileArcGISRestDataSourceOptions) =>
             new TileArcGISRestDataSource(options)
         )
+      ));
+    if (this.optionsService && context.optionsFromApi === true) {
+      observables.push(
+        this.optionsService.getArcgisRestOptions(context, detailedContextUri).pipe(
+          catchError(e => {
+            e.error.toDisplay = true;
+            e.error.title = this.languageService.translate.instant(
+              'igo.geo.dataSource.unavailableTitle'
+            );
+            e.error.message = this.languageService.translate.instant(
+              'igo.geo.dataSource.optionsApiUnavailable'
+            );
+            return of({});
+          })
+        )
       );
+    }
+    observables.push(of(context));
+    return forkJoin(observables).pipe(
+      map((options: TileArcGISRestDataSource[]) => {
+        const optionsMerged = options.reduce((a, b) =>
+          ObjectUtils.mergeDeep(a, b)
+        );
+        return new TileArcGISRestDataSource(optionsMerged);
+      }),
+      catchError(() => {
+        return of(undefined);
+      })
+    );
   }
 
   private createMVTDataSource(

--- a/packages/geo/src/lib/datasource/shared/options/options-api.service.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options-api.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { WMSDataSourceOptions } from '../datasources';
+import { ArcGISRestDataSourceOptions, ArcGISRestImageDataSourceOptions, TileArcGISRestDataSourceOptions, WMSDataSourceOptions } from '../datasources';
 import { OptionsService } from './options.service';
 import { OptionsApiOptions } from './options-api.interface';
 
@@ -54,6 +54,46 @@ export class OptionsApiService extends OptionsService {
         }) => {
           if (!res || !res.sourceOptions) {
             return {} as WMSDataSourceOptions;
+          }
+          res.sourceOptions._layerOptionsFromSource = res.layerOptions;
+          return res.sourceOptions;
+        }
+      )
+    );
+  }
+
+
+  getArcgisRestOptions(
+    baseOptions: ArcGISRestDataSourceOptions | ArcGISRestImageDataSourceOptions | TileArcGISRestDataSourceOptions,
+    detailedContextUri?: string
+  ): Observable<ArcGISRestDataSourceOptions | ArcGISRestImageDataSourceOptions | TileArcGISRestDataSourceOptions> {
+    if (!this.urlApi) {
+      return of({} as ArcGISRestImageDataSourceOptions);
+    }
+    let params = new HttpParams({
+      fromObject: {
+        type: baseOptions.type,
+        url: baseOptions.url,
+        layers: baseOptions.layer
+      }
+    });
+
+    if (detailedContextUri && this.provideContextUri) {
+      params = params.append('context', detailedContextUri);
+    }
+
+    const request = this.http.get(this.urlApi, {
+      params
+    });
+
+    return request.pipe(
+      map(
+        (res: {
+          sourceOptions: ArcGISRestDataSourceOptions | ArcGISRestImageDataSourceOptions | TileArcGISRestDataSourceOptions;
+          layerOptions: { [keys: string]: string };
+        }) => {
+          if (!res || !res.sourceOptions) {
+            return {} as ArcGISRestDataSourceOptions | ArcGISRestImageDataSourceOptions | TileArcGISRestDataSourceOptions;
           }
           res.sourceOptions._layerOptionsFromSource = res.layerOptions;
           return res.sourceOptions;

--- a/packages/geo/src/lib/datasource/shared/options/options.service.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options.service.ts
@@ -1,10 +1,14 @@
 import { Observable } from 'rxjs';
 
-import { WMSDataSourceOptions } from '../datasources';
+import { ArcGISRestDataSourceOptions, ArcGISRestImageDataSourceOptions, TileArcGISRestDataSourceOptions, WMSDataSourceOptions } from '../datasources';
 
 export abstract class OptionsService {
   abstract getWMSOptions(
     _baseOptions: WMSDataSourceOptions,
     detailedContextUri?: string
   ): Observable<WMSDataSourceOptions>;
+  abstract getArcgisRestOptions(
+    _baseOptions: ArcGISRestDataSourceOptions | ArcGISRestImageDataSourceOptions | TileArcGISRestDataSourceOptions,
+    detailedContextUri?: string
+  ): Observable<ArcGISRestImageDataSourceOptions>;
 }

--- a/packages/geo/src/lib/search/shared/sources/ilayer.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.ts
@@ -277,9 +277,8 @@ export class ILayerSearchSource extends SearchSource implements TextSearch {
         url,
         queryFormat: queryParams.queryFormat,
         queryHtmlTarget: queryParams.queryHtmlTarget,
-        params: {
-          LAYERS: data.properties.name
-        },
+        params: data.properties.format === 'wms' ? {LAYERS: data.properties.name} : undefined,
+        layer: data.properties.format === 'wms' ? undefined : data.properties.name,
         optionsFromCapabilities: true,
         crossOrigin: 'anonymous'
       },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Only wms layer can retrieve the options from the options api


**What is the new behavior?**
Provide to the arcgis datasource, a method to retrieve their options from options api.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
