### PR TITLE
fix(print): graphic scale + attribution in print pdf

### DIFF
--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -118,6 +118,10 @@ export class IgoMap {
     this.buffer = new Overlay(this);
   }
 
+  setattribution(){
+    this.options.controls.attribution = true;
+  }
+
   setTarget(id: string) {
     this.ol.setTarget(id);
     if (id !== undefined) {

--- a/packages/geo/src/lib/print/shared/print.service.ts
+++ b/packages/geo/src/lib/print/shared/print.service.ts
@@ -562,6 +562,8 @@ export class PrintService {
       const commentWidth = newContext.measureText(comment).width;
       // Add height for title if defined
       height = title !== '' ? height + 30 : height;
+      // Add height for title if defined
+      height = subtitle !== '' ? height + 30 : height; 
       // Add height for projection or scale (same line) if defined
       height = projection !== false || scale !== false ? height + 30 : height;
       const positionHProjScale = height - 10;
@@ -592,9 +594,9 @@ export class PrintService {
         // Set font for subtitle
         // Adjust according to title length
         newContext.font = '26px Calibri';
-        positionHCanvas = 30;
+        positionHCanvas = 60;
         newContext.textAlign = 'center';
-        newContext.fillText(subtitle, width / 2, 20, width * 0.9);
+        newContext.fillText(subtitle, width / 2, 50, width * 0.9);
       }
       // Set font for next section
       newContext.font = '20px Calibri';


### PR DESCRIPTION
Ajout de l'échelle graphique quand imprime en pdf
Ajout des attributions quand imprime en pdf

il y avait des problèmes sur mes tests en local car la zone de carte en locale n'affiche pas l'échelle sauf si forcé dans les fichiers de config, je ne peux pas push ces fichiers de config mais car l'échelle marche sur le build normal ca devrait marcher
Aussi les attributions nécessite usecors pour les images et il y avait un problème similaire mais je pense également que ca va marcher

- toujours problème de format de texte d'attribution en bleu surligné (a changer)
- imprime pas encore en image