### PR TITLE
fix(ogcFilters): various fix for release 1.7

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -51,6 +51,16 @@ export class WFSDataSource extends DataSource {
       this.wfsService.getSourceFieldsFromWFS(this.options);
     }
 
+    if (ogcFilters.pushButtons){
+      ogcFilters.pushButtons.selectorType = 'pushButton';
+    }
+    if (ogcFilters.checkboxes){
+      ogcFilters.checkboxes.selectorType = 'checkbox';
+    }
+    if (ogcFilters.radioButtons){
+      ogcFilters.radioButtons.selectorType = 'radioButton';
+    }
+
     this.setOgcFilters((this.options as OgcFilterableDataSourceOptions).ogcFilters, true);
   }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -116,6 +116,15 @@ export class WMSDataSource extends DataSource {
       initOgcFilters.advancedOgcFilters = (initOgcFilters.pushButtons || initOgcFilters.checkboxes || initOgcFilters.radioButtons)
         ? false
         : true;
+      if (initOgcFilters.pushButtons){
+        initOgcFilters.pushButtons.selectorType = 'pushButton';
+      }
+      if (initOgcFilters.checkboxes){
+        initOgcFilters.checkboxes.selectorType = 'checkbox';
+      }
+      if (initOgcFilters.radioButtons){
+        initOgcFilters.radioButtons.selectorType = 'radioButton';
+      }
     }
 
     if (

--- a/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.html
@@ -35,10 +35,10 @@
       <ng-container *ngFor="let bundle of currentCheckboxesGroup.computedSelectors">
         <h4>{{bundle.title}}</h4>
         <div class="checkboxes mat-typography" appearance="legacy" multiple="true">
-          <mat-checkbox [checked]="ogcCheckbox.enabled" formControlName="checkboxes"
+          <mat-checkbox [checked]="ogcCheckbox.enabled"
             (change)="onSelectionChange(ogcCheckbox)" tooltip-position="below" matTooltipShowDelay="500"
             [matTooltip]="getToolTip(ogcCheckbox)" matTooltipClass="material-tooltip"
-            *ngFor="let ogcCheckbox of getCurrentCheckboxesSelectors(bundle)" [value]="ogcCheckbox">{{ogcCheckbox.title}}
+            *ngFor="let ogcCheckbox of bundle.selectors; let i = index" [value]="ogcCheckbox">{{ogcCheckbox.title}}
           </mat-checkbox>
         </div>
         <p *ngIf="isLessResults(bundle, 'checkbox') || isMoreResults(bundle, 'checkbox')">
@@ -68,7 +68,7 @@
           <mat-radio-button
             (change)="onSelectionChange(ogcRadioButton)" tooltip-position="below" matTooltipShowDelay="500"
             [matTooltip]="getToolTip(ogcRadioButton)" matTooltipClass="material-tooltip"
-            *ngFor="let ogcRadioButton of getCurrentRadioButtonsSelectors(bundle)" [value]="ogcRadioButton">{{ogcRadioButton.title}}
+            *ngFor="let ogcRadioButton of bundle.selectors" [value]="ogcRadioButton">{{ogcRadioButton.title}}
           </mat-radio-button>
           <p *ngIf="isLessResults(bundle, 'radio') || isMoreResults(bundle, 'radio')">
             <u *ngIf="isLessResults(bundle, 'radio')" class="lessResults mat-typography" (click)="displayLessResults('radio')">

--- a/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.ts
@@ -99,30 +99,6 @@ export class OgcFilterSelectionComponent implements OnInit {
     this.form.patchValue({ radioButtonsGroup: value });
   }
 
-  getCurrentCheckboxesSelectors(bundle) {
-    const current = [];
-    if (bundle?.selectors.length) {
-      for (let i = 0; i < this.checkboxesIndex; i++) {
-        if (bundle.selectors[i]) {
-          current.push(bundle.selectors[i]);
-        }
-      }
-    }
-    return current;
-  }
-
-  getCurrentRadioButtonsSelectors(bundle) {
-    const current = [];
-    if (bundle?.selectors.length) {
-      for (let i = 0; i < this.radioButtonsIndex; i++) {
-        if (bundle.selectors[i]) {
-          current.push(bundle.selectors[i]);
-        }
-      }
-    }
-    return current;
-  }
-
   constructor(
     private ogcFilterService: OGCFilterService,
     private formBuilder: FormBuilder
@@ -134,7 +110,6 @@ export class OgcFilterSelectionComponent implements OnInit {
   private buildForm() {
     this.form = this.formBuilder.group({
       pushButtons: ['', [Validators.required]],
-      checkboxes: ['', [Validators.required]],
       radioButtons: ['', [Validators.required]],
       pushButtonsGroup: ['', [Validators.required]],
       checkboxesGroup: ['', [Validators.required]],
@@ -214,13 +189,6 @@ export class OgcFilterSelectionComponent implements OnInit {
         this.applyFilters();
       });
     this.form
-      .get('checkboxes')
-      .valueChanges
-      .pipe(debounceTime(750))
-      .subscribe(() => {
-        this.applyFilters();
-      });
-    this.form
       .get('radioButtons')
       .valueChanges
       .pipe(debounceTime(750))
@@ -290,6 +258,9 @@ export class OgcFilterSelectionComponent implements OnInit {
     if (currentOgcSelection) {
       currentOgcSelection.enabled = !currentOgcSelection.enabled;
     }
+    setTimeout(() => {
+      this.applyFilters();
+    }, 750);
   }
 
   private applyFilters() {

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -714,7 +714,7 @@ export class OgcFilterWriter {
     if (!ogcFilters) {
       return;
     }
-    let conditions = [];
+    const conditions = [];
     let filterQueryStringSelector = '';
     let filterQueryStringAdvancedFilters = '';
     if (ogcFilters.enabled && (ogcFilters.pushButtons || ogcFilters.checkboxes || ogcFilters.radioButtons)) {

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -714,24 +714,44 @@ export class OgcFilterWriter {
     if (!ogcFilters) {
       return;
     }
-    const filterQueryStringSelector = '';
+    let conditions = [];
+    let filterQueryStringSelector = '';
     let filterQueryStringAdvancedFilters = '';
     if (ogcFilters.enabled && (ogcFilters.pushButtons || ogcFilters.checkboxes || ogcFilters.radioButtons)) {
       let selectors;
       if (ogcFilters.pushButtons) {
         selectors = ogcFilters.pushButtons;
-        this.formatGroupAndFilter(ogcFilters, selectors, filterQueryStringSelector, extent, proj);
+        const pushConditions = this.formatGroupAndFilter(ogcFilters, selectors);
+        for (const condition of pushConditions) {
+          conditions.push(condition);
+        }
       }
       if (ogcFilters.checkboxes) {
         selectors = ogcFilters.checkboxes;
-        this.formatGroupAndFilter(ogcFilters, selectors, filterQueryStringSelector, extent, proj);
+        const checkboxConditions = this.formatGroupAndFilter(ogcFilters, selectors);
+        for (const condition of checkboxConditions) {
+          conditions.push(condition);
+        }
       }
       if (ogcFilters.radioButtons) {
         selectors = ogcFilters.radioButtons;
-        this.formatGroupAndFilter(ogcFilters, selectors, filterQueryStringSelector, extent, proj);
+        const radioConditions = this.formatGroupAndFilter(ogcFilters, selectors);
+        for (const condition of radioConditions) {
+          conditions.push(condition);
+        }
+      }
+
+      if (conditions.length >= 1) {
+        filterQueryStringSelector = this.buildFilter(
+          conditions.length === 1
+            ? conditions[0]
+            : { logical: 'And', filters: conditions },
+          extent,
+          proj,
+          ogcFilters.geometryName
+        );
       }
     }
-
     if (ogcFilters.enabled && ogcFilters.filters) {
       ogcFilters.geometryName = ogcFilters.geometryName || fieldNameGeometry;
       const igoFilters = ogcFilters.filters;
@@ -763,7 +783,7 @@ export class OgcFilterWriter {
     return filterQueryString;
   }
 
-  public formatGroupAndFilter(ogcFilters: OgcFiltersOptions, selectors, filterQueryStringSelector = '', extent, proj) {
+  public formatGroupAndFilter(ogcFilters: OgcFiltersOptions, selectors) {
     selectors = this.computeIgoSelector(
       selectors
     );
@@ -789,16 +809,6 @@ export class OgcFilterWriter {
         });
       }
     });
-    if (conditions.length >= 1) {
-      filterQueryStringSelector = this.buildFilter(
-        conditions.length === 1
-          ? conditions[0]
-          : { logical: 'And', filters: conditions },
-        extent,
-        proj,
-        ogcFilters.geometryName
-      );
-    }
 
     if (selectors.selectorType === 'pushButton') {
       ogcFilters.pushButtons = selectors;
@@ -807,6 +817,7 @@ export class OgcFilterWriter {
     } else if (selectors.selectorType === 'radioButton') {
       ogcFilters.radioButtons = selectors;
     }
+    return conditions;
   }
 
   public formatProcessedOgcFilter(


### PR DESCRIPTION
- Auto detection of selector type (@pelord )

- Fix apply filters at map initialization when selector is enabled

- Fix checkbox enabled condition :
    - There was a problem with checkbox enabled condition because they were all linked to the same formControl


It'll be needed to discuss what to do with radioButtons enabled initial attribute. There can only be one radio buttons selected at the same time, so it can cause problem when multiple buttons are set to true. 