### PR TITLE
fix(imagearcgisrest/layer-legend): release 1.7 various fix

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
@@ -29,11 +29,7 @@ export class ImageArcGISRestDataSource extends DataSource {
   }
 
   protected createOlSource(): ImageArcGISRest {
-    console.log(this.options);
-    const params = !this.options.layer ? this.options.params : Object.assign(
-      {LAYERS: `show:${this.options.layer}`},
-      this.options.params
-    );
+    const params = this.options.layer !== undefined ? {LAYERS: `show:${this.options.layer}`} : this.options.params;
 
     if (typeof params.renderingRule === 'object') {
       params.renderingRule = JSON.stringify(params.renderingRule);

--- a/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
@@ -29,7 +29,7 @@ export class ImageArcGISRestDataSource extends DataSource {
   }
 
   protected createOlSource(): ImageArcGISRest {
-
+    console.log(this.options);
     const params = !this.options.layer ? this.options.params : Object.assign(
       {LAYERS: `show:${this.options.layer}`},
       this.options.params
@@ -47,9 +47,9 @@ export class ImageArcGISRestDataSource extends DataSource {
   }
 
   getLegend(): Legend[] {
-    const legendInfo = this.options.options.legendInfo;
+    const legendInfo = this.options.options?.legendInfo || this.params?.legendInfo;
     const legend = super.getLegend();
-    if (legendInfo === undefined || !this.options.layer || legend.length > 0) {
+    if (legendInfo === undefined || this.options.layer === undefined || legend.length > 0) {
       return legend;
     }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
@@ -29,7 +29,10 @@ export class ImageArcGISRestDataSource extends DataSource {
   }
 
   protected createOlSource(): ImageArcGISRest {
-    const params = this.options.layer !== undefined ? {LAYERS: `show:${this.options.layer}`} : this.options.params;
+    const params = this.options.layer === undefined ? this.options.params : Object.assign(
+      {LAYERS: `show:${this.options.layer}`},
+      this.options.params
+    );
 
     if (typeof params.renderingRule === 'object') {
       params.renderingRule = JSON.stringify(params.renderingRule);

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -135,10 +135,12 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
     const secureIMG = new SecureImagePipe(this.http);
     secureIMG.transform(item.url).pipe(
       catchError((err) => {
-        err.error.caught = true;
-        this.getLegend = false;
-        this.cdRef.detectChanges();
-        return err;
+        if (err.error) {
+          err.error.caught = true;
+          this.getLegend = false;
+          this.cdRef.detectChanges();
+          return err;
+        }
       })
     ).subscribe((legend: string) => {
       this.legendGraphic = legend;


### PR DESCRIPTION
- Fix imagearcgisrest datasource params options if layer is not defined

- GetLegendGraphic catchError only if error is error type (browser console error could appeared if not)
