### PR TITLE
feat(add-catalog-dialog): add info message if catalog isn't in the pr…

### DIFF
--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.html
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.html
@@ -39,7 +39,7 @@
     <p class="error">{{languageService.translate.instant('igo.geo.catalog.externalProvider.unavailableWithEmail', { value: addedCatalog.url, email: emailAddress })}}</p>
   </span>
   <span *ngIf="error && addedCatalog && !emailAddress">
-    <p class="error">{{languageService.translate.instant('igo.geo.catalog.unavailable')}}</p>
+    <p class="error">{{languageService.translate.instant('igo.geo.catalog.unavailable', { value: addedCatalog.url })}}</p>
   </span>
 </div>
 <div mat-dialog-actions style="justify-content: center">

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.html
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.html
@@ -35,7 +35,12 @@
       </mat-form-field>
     </div>
   </form>
-
+  <span *ngIf="error && addedCatalog && emailAddress">
+    <p class="error">{{languageService.translate.instant('igo.geo.catalog.externalProvider.unavailableWithEmail', { value: addedCatalog.url, email: emailAddress })}}</p>
+  </span>
+  <span *ngIf="error && addedCatalog && !emailAddress">
+    <p class="error">{{languageService.translate.instant('igo.geo.catalog.unavailable')}}</p>
+  </span>
 </div>
 <div mat-dialog-actions style="justify-content: center">
   <div class="igo-form-button-group add-catalog-button-top-padding">

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.scss
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.scss
@@ -23,3 +23,7 @@ button#addCatalogBtnDialog[disabled=true] {
   background-color: rgba(0,0,0,.12);
   color: rgba(0,0,0,.26);
 }
+
+.error {
+   color: red;
+}

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
@@ -67,7 +67,7 @@ export class AddCatalogDialogComponent implements OnInit, OnDestroy {
       .all$()
       .subscribe(() => this.computePredefinedCatalogList());
 
-    this.emailAddress = this.configService.getConfig('catalog.emailAddress');
+    this.emailAddress = this.configService.getConfig('emailAddress');
   }
 
   ngOnDestroy() {

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
@@ -1,3 +1,4 @@
+import { LanguageService, ConfigService } from '@igo2/core';
 import { Component, OnInit, OnDestroy, Optional, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -20,17 +21,24 @@ export class AddCatalogDialogComponent implements OnInit, OnDestroy {
   typeCapabilities: string[];
   predefinedCatalogs: Catalog[] = [];
   store: EntityStore<Catalog>;
+  error = false;
+  addedCatalog: Catalog;
+  emailAddress: string;
   private storeViewAll$$: Subscription;
 
   constructor(
     private formBuilder: FormBuilder,
+    public languageService: LanguageService,
+    private configService: ConfigService,
     public dialogRef: MatDialogRef<AddCatalogDialogComponent>,
     @Optional()
     @Inject(MAT_DIALOG_DATA)
-    public data: { predefinedCatalogs: Catalog[]; store: EntityStore<Catalog> }
+    public data: { predefinedCatalogs: Catalog[]; store: EntityStore<Catalog>; error: boolean; addedCatalog: Catalog }
   ) {
     this.store = data.store;
     this.predefinedCatalogs = data.predefinedCatalogs;
+    this.error = data.error;
+    this.addedCatalog = data.addedCatalog;
     this.form = this.formBuilder.group({
       id: ['', []],
       title: ['', []],
@@ -58,6 +66,8 @@ export class AddCatalogDialogComponent implements OnInit, OnDestroy {
     this.storeViewAll$$ = this.store.view
       .all$()
       .subscribe(() => this.computePredefinedCatalogList());
+
+    this.emailAddress = this.configService.getConfig('catalog.emailAddress');
   }
 
   ngOnDestroy() {
@@ -67,6 +77,7 @@ export class AddCatalogDialogComponent implements OnInit, OnDestroy {
 
   changeUrl(catalog: Catalog) {
     this.form.patchValue(catalog);
+    this.error = false;
     this.computePredefinedCatalogList();
   }
 
@@ -77,10 +88,12 @@ export class AddCatalogDialogComponent implements OnInit, OnDestroy {
   }
 
   addCatalog(addedCatalog: Catalog) {
+    this.error = false;
     this.dialogRef.close(addedCatalog);
   }
 
   cancel() {
+    this.error = false;
     this.dialogRef.close();
   }
 }

--- a/packages/geo/src/lib/catalog/catalog-library/catalog-library.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/catalog-library.component.ts
@@ -152,6 +152,11 @@ export class CatalogLibaryComponent implements OnInit, OnDestroy {
           const title = this.languageService.translate.instant(
             'igo.geo.catalog.unavailableTitle'
           );
+          if (e.error) {
+            this.addCatalogDialog(true, addedCatalog);
+            e.error.caught = true;
+            return e;
+          }
           const message = this.languageService.translate.instant(
             'igo.geo.catalog.unavailable',
             { value: addedCatalog.url }
@@ -208,12 +213,14 @@ export class CatalogLibaryComponent implements OnInit, OnDestroy {
       .filter((c) => c.id !== catalog.id);
   }
 
-  addCatalogDialog() {
+  addCatalogDialog(error?, addedCatalog?: Catalog) {
     const dialogRef = this.dialog.open(AddCatalogDialogComponent, {
       width: '700px',
       data: {
         predefinedCatalogs: this.predefinedCatalogs,
-        store: this.store
+        store: this.store,
+        error,
+        addedCatalog
       }
     });
 

--- a/packages/geo/src/lib/catalog/shared/catalog.interface.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.interface.ts
@@ -59,4 +59,5 @@ export interface CatalogServiceOptions {
   baseLayers?: boolean;
   sources?: (ICatalog | ICompositeCatalog)[];
   sourcesUrl?: string;
+  emailAddress?: string;
 }

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -13,7 +13,8 @@
         "unavailable": "The catalog '{{value}}' is unavailable at the moment or you don't have the required permissions.",
         "externalProvider": {
            "catalog": "This catalog comes from an external organization.",
-           "layer": "This layer comes from an external organization."
+           "layer": "This layer comes from an external organization.",
+           "unavailableWithEmail": "The catalog '{{value}}' is unavailable at the moment. To add an external service to the predefined list, please contact us at {{emailAddress}}. Delays can apply if problems occurs with the provider."
         },
         "library.add": "Add this catalog to the list",
         "library.cancel": "Cancel",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -13,7 +13,8 @@
         "unavailable": "Le catalogue '{{value}}' est indisponible pour le moment ou vous n'avez pas les permissions requises.",
         "externalProvider": {
           "catalog": "Ce catalogue provient d'une organisation externe.",
-          "layer": "Cette couche provient d'une organisation externe."
+          "layer": "Cette couche provient d'une organisation externe.",
+          "unavailableWithEmail": "Le catalogue '{{value}}' est indisponible pour le moment. Pour ajouter un service externe à la liste prédéfinie, veuillez contacter {{email}}. Des délais peuvent s'appliquer si problème il y a avec le fournisseur externe."
         },
         "library.add": "Ajouter ce catalogue",
         "library.cancel": "Annuler",


### PR DESCRIPTION
- Before, an error message only displayed to tell the user that the catalog was unavailable

- Now, the add-catalog-dialog stay on the page and tell the user to contact the specify email address in the catalog tool config

- If none email address is provided, the same message as before is displayed in the add-catalog-dialog
   
