### PR TITLE
feat-fix(StoredQueriesSearchSource) fix excep when no title. Param limit is now functional

### DIFF
--- a/demo/src/app/geo/search/search.module.ts
+++ b/demo/src/app/geo/search/search.module.ts
@@ -23,7 +23,9 @@ import {
   provideNominatimSearchSource,
   provideIChercheReverseSearchSource,
   provideCoordinatesReverseSearchSource,
-  provideCadastreSearchSource
+  provideCadastreSearchSource,
+  provideStoredQueriesSearchSource,
+  provideStoredQueriesReverseSearchSource
 } from '@igo2/geo';
 
 import { IgoAppSearchModule } from '@igo2/integration';
@@ -56,7 +58,9 @@ import { AppSearchRoutingModule } from './search-routing.module';
     provideIChercheSearchSource(),
     provideILayerSearchSource(),
     provideNominatimSearchSource(),
-    provideIChercheReverseSearchSource()
+    provideIChercheReverseSearchSource(),
+    provideStoredQueriesSearchSource(),
+    provideStoredQueriesReverseSearchSource()
   ]
 })
 export class AppSearchModule {}

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -167,11 +167,11 @@ export const environment: Environment = {
     searchSources: {
       storedqueries: {
         available: true,
-        title: "Feuillets SNRC",
-        searchUrl: "/ws/mffpecofor.fcgi",
-        storedquery_id: "sq250et20kFeuillet",
-        fields: {name: "no_feuillet","defaultValue": "0"},
-        resultTitle: "feuillet",
+        title: 'Feuillets SNRC',
+        searchUrl: '/ws/mffpecofor.fcgi',
+        storedquery_id: 'sq250et20kFeuillet',
+        fields: {name: 'no_feuillet','defaultValue': '0'},
+        resultTitle: 'feuillet',
         params: {
           limit: '8'
         }

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -171,7 +171,10 @@ export const environment: Environment = {
         searchUrl: "/ws/mffpecofor.fcgi",
         storedquery_id: "sq250et20kFeuillet",
         fields: {name: "no_feuillet","defaultValue": "0"},
-        resultTitle: "feuillet"
+        resultTitle: "feuillet",
+        params: {
+          limit: '8'
+        }
     },
       nominatim: {
         enabled: false
@@ -194,7 +197,7 @@ export const environment: Environment = {
         enabled: true
       },
       ilayer: {
-        searchUrl: '/apis/layers/search',
+        searchUrl: '/apis/icherche/layers',
         order: 4,
         enabled: true,
         params: {

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -170,7 +170,7 @@ export const environment: Environment = {
         title: 'Feuillets SNRC',
         searchUrl: '/ws/mffpecofor.fcgi',
         storedquery_id: 'sq250et20kFeuillet',
-        fields: {name: 'no_feuillet','defaultValue': '0'},
+        fields: { name: 'no_feuillet', defaultValue: '0'},
         resultTitle: 'feuillet',
         params: {
           limit: '8'

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -165,6 +165,14 @@ export const environment: Environment = {
       ]
     },
     searchSources: {
+      storedqueries: {
+        available: true,
+        title: "Feuillets SNRC",
+        searchUrl: "/ws/mffpecofor.fcgi",
+        storedquery_id: "sq250et20kFeuillet",
+        fields: {name: "no_feuillet","defaultValue": "0"},
+        resultTitle: "feuillet"
+    },
       nominatim: {
         enabled: false
       },

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -198,9 +198,9 @@ export class StoredQueriesSearchSource extends SearchSource
               const resultTotLenght = resultArray.length;
               resultArray = resultArray.slice(0, idxEnd);
               if (idxEnd < resultTotLenght) {
-                resultArray[resultArray.length- 1 ].meta.nextPage = true;
+                resultArray[resultArray.length - 1 ].meta.nextPage = true;
               } else {
-                resultArray[resultArray.length- 1 ].meta.nextPage = false;
+                resultArray[resultArray.length - 1 ].meta.nextPage = false;
               }
             }
             return resultArray;

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -183,8 +183,9 @@ export class StoredQueriesSearchSource extends SearchSource
         .get(this.searchUrl, { params, responseType: 'text' })
         .pipe(
           map(response => {
-            let resultArray = this.extractResults(this.extractWFSData(response), term);
-            resultArray.sort((a,b) => (a.meta.score > b.meta.score) ? 1: (a.meta.score === b.meta.score) ? ((a.meta.titleHtml < b.meta.titleHtml) ? 1: -1) : -1);
+            const resultArray = this.extractResults(this.extractWFSData(response), term);
+            resultArray.sort((a,b) => 
+              (a.meta.score > b.meta.score) ? 1 : (a.meta.score === b.meta.score) ? ((a.meta.titleHtml < b.meta.titleHtml) ? 1 : -1) : -1);
             resultArray.reverse();
             return resultArray;
             // return this.extractResults(this.extractWFSData(response), term);
@@ -297,7 +298,6 @@ export class StoredQueriesSearchSource extends SearchSource
     const title = data.properties[this.storedQueriesOptions.resultTitle]
       ? this.storedQueriesOptions.resultTitle
       : this.resultTitle;
-      debugger;
     return {
       source: this,
       data: {
@@ -317,7 +317,9 @@ export class StoredQueriesSearchSource extends SearchSource
         title: data.properties.title,
         titleHtml: data.properties[title],
         icon: 'map-marker',
-        score: (data.properties.title) ? computeTermSimilarity(term.trim(), data.properties.title) : computeTermSimilarity(term.trim(), data.properties[title]),
+        score: (data.properties.title) ?
+        computeTermSimilarity(term.trim(), data.properties.title) :
+        computeTermSimilarity(term.trim(), data.properties[title]),
         // score: computeTermSimilarity(term.trim(), data.properties.title)
       }
     };

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -183,7 +183,11 @@ export class StoredQueriesSearchSource extends SearchSource
         .get(this.searchUrl, { params, responseType: 'text' })
         .pipe(
           map(response => {
-            return this.extractResults(this.extractWFSData(response), term);
+            let resultArray = this.extractResults(this.extractWFSData(response), term);
+            resultArray.sort((a,b) => (a.meta.score > b.meta.score) ? 1: (a.meta.score === b.meta.score) ? ((a.meta.titleHtml < b.meta.titleHtml) ? 1: -1) : -1);
+            resultArray.reverse();
+            return resultArray;
+            // return this.extractResults(this.extractWFSData(response), term);
           })
         );
     } else {
@@ -293,6 +297,7 @@ export class StoredQueriesSearchSource extends SearchSource
     const title = data.properties[this.storedQueriesOptions.resultTitle]
       ? this.storedQueriesOptions.resultTitle
       : this.resultTitle;
+      debugger;
     return {
       source: this,
       data: {
@@ -312,7 +317,8 @@ export class StoredQueriesSearchSource extends SearchSource
         title: data.properties.title,
         titleHtml: data.properties[title],
         icon: 'map-marker',
-        score: computeTermSimilarity(term.trim(), data.properties.title)
+        score: (data.properties.title) ? computeTermSimilarity(term.trim(), data.properties.title) : computeTermSimilarity(term.trim(), data.properties[title]),
+        // score: computeTermSimilarity(term.trim(), data.properties.title)
       }
     };
   }

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -175,6 +175,11 @@ export class StoredQueriesSearchSource extends SearchSource
       options || {},
       storedqueriesParams
     );
+    if (this.options.params == null) {
+      this.options.params = { page : '1'};
+    } else {
+      this.options.params.page = options.page != null ? String(options.page) : '1';
+    }
 
     if (
       new RegExp('.*?gml.*?', 'i').test(this.storedQueriesOptions.outputformat)
@@ -183,12 +188,22 @@ export class StoredQueriesSearchSource extends SearchSource
         .get(this.searchUrl, { params, responseType: 'text' })
         .pipe(
           map(response => {
-            const resultArray = this.extractResults(this.extractWFSData(response), term);
-            resultArray.sort((a,b) => 
-              (a.meta.score > b.meta.score) ? 1 : (a.meta.score === b.meta.score) ? ((a.meta.titleHtml < b.meta.titleHtml) ? 1 : -1) : -1);
+            let resultArray = this.extractResults(this.extractWFSData(response), term);
+            resultArray.sort((a, b) =>
+              (a.meta.score > b.meta.score) ? 1 : 
+              (a.meta.score === b.meta.score) ? ((a.meta.titleHtml < b.meta.titleHtml) ? 1 : -1) : -1);
             resultArray.reverse();
+            if (resultArray.length > Number(this.options.params.limit)) {
+              let idxEnd = Number(this.options.params.limit) * Number(this.options.params.page); 
+              let resultTotLenght = resultArray.length;
+              resultArray = resultArray.slice(0, idxEnd);
+              if (idxEnd < resultTotLenght) {
+                resultArray[resultArray.length-1].meta.nextPage= true;
+              } else {
+                resultArray[resultArray.length-1].meta.nextPage= false;
+              }
+            }
             return resultArray;
-            // return this.extractResults(this.extractWFSData(response), term);
           })
         );
     } else {
@@ -320,7 +335,7 @@ export class StoredQueriesSearchSource extends SearchSource
         score: (data.properties.title) ?
         computeTermSimilarity(term.trim(), data.properties.title) :
         computeTermSimilarity(term.trim(), data.properties[title]),
-        // score: computeTermSimilarity(term.trim(), data.properties.title)
+
       }
     };
   }

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -190,17 +190,17 @@ export class StoredQueriesSearchSource extends SearchSource
           map(response => {
             let resultArray = this.extractResults(this.extractWFSData(response), term);
             resultArray.sort((a, b) =>
-              (a.meta.score > b.meta.score) ? 1 : 
+              (a.meta.score > b.meta.score) ? 1 :
               (a.meta.score === b.meta.score) ? ((a.meta.titleHtml < b.meta.titleHtml) ? 1 : -1) : -1);
             resultArray.reverse();
             if (resultArray.length > Number(this.options.params.limit)) {
-              let idxEnd = Number(this.options.params.limit) * Number(this.options.params.page); 
-              let resultTotLenght = resultArray.length;
+              const idxEnd = Number(this.options.params.limit) * Number(this.options.params.page);
+              const resultTotLenght = resultArray.length;
               resultArray = resultArray.slice(0, idxEnd);
               if (idxEnd < resultTotLenght) {
-                resultArray[resultArray.length-1].meta.nextPage= true;
+                resultArray[resultArray.length- 1 ].meta.nextPage = true;
               } else {
-                resultArray[resultArray.length-1].meta.nextPage= false;
+                resultArray[resultArray.length- 1 ].meta.nextPage = false;
               }
             }
             return resultArray;


### PR DESCRIPTION

- fix bug [852](https://github.com/infra-geo-ouverte/igo2-lib/issues/852)

- param limit is now functional with a storedQuery search

Exemple of config is working now :
   "storedqueries": {
      "available": true,
      "title": "Feuillets SNRC",
      "searchUrl": "/ws/mffpecofor.fcgi",
      "storedquery_id": "sq250et20kFeuillet",
      "fields": [
            {"name": "no_feuillet","defaultValue": "0"}
      ],
      "resultTitle": "feuillet",
      "params": {
          "limit": 10
      }
    }
  },

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

**Other information**:
