### PR TITLE
fix(map utils): conversion to latitude longitude out of bounds

### DIFF
--- a/packages/geo/src/lib/map/shared/map.utils.ts
+++ b/packages/geo/src/lib/map/shared/map.utils.ts
@@ -320,13 +320,21 @@ export function stringToLonLat(
       };
     }
   }
-
-  return {
-    lonLat,
-    message: '',
-    radius: radius ? parseInt(radius, 10) : undefined,
-    conf: conf ? parseInt(conf, 10) : undefined
-  };
+  if (Math.abs(lonLat[0]) <= 180 && Math.abs(lonLat[1]) <= 90) {
+    return {
+      lonLat,
+      message: '',
+      radius: radius ? parseInt(radius, 10) : undefined,
+      conf: conf ? parseInt(conf, 10) : undefined
+    };
+  } else {
+    return {
+      lonLat: undefined,
+      message: 'Coordinate out of Longitude/Latitude bounds',
+      radius: undefined,
+      conf: undefined
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When 2 numeric terms are search and these are not coordinates, the app detect a coordinate type. The app convert the provided coords into longitude/latitude coords.  The app crash

https://infra-geo-ouverte.github.io/igo2/?search=000012392110001%200001320192110001



**What is the new behavior?**
If the longitude latitude coords are out of bounds, (180 to -180 and -90 to 90), the reversesearch is not triggered.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
