### PR TITLE
fix(query): wms query in geojson format now use source fields as alias

### DIFF
--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -243,7 +243,7 @@ export class QueryService {
       case QueryFormat.JSON:
       case QueryFormat.GEOJSON:
       case QueryFormat.GEOJSON2:
-        features = this.extractGeoJSONData(res);
+        features = this.extractGeoJSONData(res, layer.zIndex, allowedFieldsAndAlias);
         break;
       case QueryFormat.ESRIJSON:
         features = this.extractEsriJSONData(res, layer.zIndex, allowedFieldsAndAlias);
@@ -413,13 +413,18 @@ export class QueryService {
     );
   }
 
-  private extractGeoJSONData(res) {
+  private extractGeoJSONData(res, zIndex, allowedFieldsAndAlias?) {
     let features = [];
     try {
       features = JSON.parse(res).features;
     } catch (e) {
       console.warn('query.service: Unable to parse geojson', '\n', res);
     }
+    features.map(feature => feature.meta = {
+      id: uuid(),
+      order: 1000 - zIndex,
+      alias: allowedFieldsAndAlias
+    });
     return features;
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
wms query in geojson format do not use source fields as alias

**What is the new behavior?**
wms query in geojson format now use source fields as alias

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
