### PR TITLE
Mapserver errors

### DIFF
--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -252,7 +252,6 @@ export class CapabilitiesService {
     const timeFilter = this.getTimeFilter(layer);
     const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0;
     const legendOptions = layer.Style ? this.getStyle(layer.Style) : undefined;
-      
     const extent = layer.EX_GeographicBoundingBox ?
         olproj.transformExtent(layer.EX_GeographicBoundingBox, 'EPSG:4326', 'EPSG:3857') :
         undefined;

--- a/packages/geo/src/lib/layer/shared/layer.service.ts
+++ b/packages/geo/src/lib/layer/shared/layer.service.ts
@@ -39,6 +39,7 @@ import {
 } from './layers';
 
 import { StyleService } from './style.service';
+import { LanguageService, MessageService } from '@igo2/core';
 
 @Injectable({
   providedIn: 'root'
@@ -48,6 +49,8 @@ export class LayerService {
     private http: HttpClient,
     private styleService: StyleService,
     private dataSourceService: DataSourceService,
+    private messageService: MessageService,
+    private languageService: LanguageService,
     @Optional() private authInterceptor: AuthInterceptor
   ) {}
 
@@ -117,7 +120,7 @@ export class LayerService {
   }
 
   private createImageLayer(layerOptions: ImageLayerOptions): ImageLayer {
-    return new ImageLayer(layerOptions, this.authInterceptor);
+    return new ImageLayer(layerOptions, this.http, this.messageService, this.languageService, this.authInterceptor);
   }
 
   private createTileLayer(layerOptions: TileLayerOptions): TileLayer {

--- a/packages/geo/src/lib/layer/shared/layer.service.ts
+++ b/packages/geo/src/lib/layer/shared/layer.service.ts
@@ -120,7 +120,7 @@ export class LayerService {
   }
 
   private createImageLayer(layerOptions: ImageLayerOptions): ImageLayer {
-    return new ImageLayer(layerOptions, this.http, this.messageService, this.languageService, this.authInterceptor);
+    return new ImageLayer(layerOptions, this.messageService, this.languageService, this.authInterceptor);
   }
 
   private createTileLayer(layerOptions: TileLayerOptions): TileLayer {

--- a/packages/geo/src/lib/layer/shared/layers/image-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/image-layer.ts
@@ -11,6 +11,8 @@ import { WMSDataSource } from '../../../datasource/shared/datasources/wms-dataso
 import { Layer } from './layer';
 import { ImageLayerOptions } from './image-layer.interface';
 import { ImageArcGISRestDataSource } from '../../../datasource/shared/datasources/imagearcgisrest-datasource';
+import { HttpClient } from '@angular/common/http';
+import { LanguageService, MessageService } from '@igo2/core';
 
 export class ImageLayer extends Layer {
   public dataSource: WMSDataSource | ImageArcGISRestDataSource;
@@ -21,6 +23,9 @@ export class ImageLayer extends Layer {
 
   constructor(
     options: ImageLayerOptions,
+    private http: HttpClient,
+    private messageService: MessageService,
+    private languageService: LanguageService,
     public authInterceptor?: AuthInterceptor
   ) {
     super(options, authInterceptor);
@@ -62,6 +67,19 @@ export class ImageLayer extends Layer {
       tile.getImage().src = src;
       return;
     }
+
+    this.http.get(src, {
+      responseType: 'text'
+    }).subscribe((value) => {
+      if (value.includes('ServiceExceptionReport')) {
+        this.messageService.error(this.languageService.translate.instant(
+          'igo.geo.dataSource.optionsApiUnavailable'
+        ),
+        this.languageService.translate.instant(
+          'igo.geo.dataSource.unavailableTitle'
+        ))
+      }
+    })
 
     xhr.responseType = 'arraybuffer';
 


### PR DESCRIPTION
Allow IGO to catch mapserver service exception report (error) that has a status code 200.

Mapserver error on getMap calls returns status code 200 very often. It makes impossible for IGO to catch those errors. 

Solution here is to convert the arrayBuffer response to text and verify if it contains ServiceExceptionReport tag. 
