### PR TITLE
fix(about-tool): disabled guide button when downloading

### DIFF
--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -252,7 +252,6 @@ export class CapabilitiesService {
     const timeFilter = this.getTimeFilter(layer);
     const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0;
     const legendOptions = layer.Style ? this.getStyle(layer.Style) : undefined;
-      
     const extent = layer.EX_GeographicBoundingBox ?
         olproj.transformExtent(layer.EX_GeographicBoundingBox, 'EPSG:4326', 'EPSG:3857') :
         undefined;

--- a/packages/integration/src/lib/about/about-tool/about-tool.component.html
+++ b/packages/integration/src/lib/about/about-tool/about-tool.component.html
@@ -12,7 +12,7 @@
   mat-raised-button
   tooltip-position="below"
   matTooltipShowDelay="500"
-  [disabled]="!trainingGuideURLs.length"
+  [disabled]="loading"
   [matTooltip]="'igo.integration.aboutTool.trainingGuideTooltip' | translate"
   (click)="openGuide()">
   <span>{{'igo.integration.aboutTool.trainingGuide' | translate}}</span>
@@ -24,6 +24,7 @@
   mat-raised-button
   tooltip-position="below"
   matTooltipShowDelay="500"
+  [disabled]="loading"
   [matTooltip]="'igo.integration.aboutTool.trainingGuideTooltip' | translate"
   [matMenuTriggerFor]="menu">
   <span>{{'igo.integration.aboutTool.trainingGuide' | translate}}</span>

--- a/packages/integration/src/lib/about/about-tool/about-tool.component.ts
+++ b/packages/integration/src/lib/about/about-tool/about-tool.component.ts
@@ -45,6 +45,8 @@ export class AboutToolComponent implements OnInit {
   private baseUrlProfil;
   private baseUrlGuide;
 
+  public loading = false;
+
   constructor(
     public configService: ConfigService,
     public auth: AuthService,
@@ -71,6 +73,7 @@ export class AboutToolComponent implements OnInit {
   }
 
   openGuide(guide?) {
+    this.loading = true;
     const url = guide ?
       this.baseUrlGuide + guide + '?' :
       this.baseUrlGuide + this.trainingGuideURLs[0] + '?';
@@ -79,7 +82,9 @@ export class AboutToolComponent implements OnInit {
       responseType: 'blob'
     })
     .subscribe(() => {
+      this.loading = false;
       window.open(url, '_blank');
+      this.cdRef.detectChanges();
     });
   }
 


### PR DESCRIPTION
- Disabled guide download button when call is not finished and window not opened yet

- To avoid multiple clicking from user
