### PR TITLE
feat(context-service)on context change remove mesage from other context

### DIFF
--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -600,6 +600,10 @@ export class ContextService {
     if (this.contextMessage) {
       this.messageService.remove(this.contextMessage.id);
     }
+    if (this.context$.value && context.uri && this.context$.value.uri !== context.uri) {
+      this.messageService.remove();
+    }
+
     context.messages = context.messages ? context.messages : [];
     context.messages.push(context.message);
     context.messages.map(message => {

--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -601,7 +601,7 @@ export class ContextService {
       this.messageService.remove(this.contextMessage.id);
     }
     if (this.context$.value && context.uri && this.context$.value.uri !== context.uri) {
-      this.messageService.remove();
+      this.messageService.removeAllAreNotError();
     }
 
     context.messages = context.messages ? context.messages : [];

--- a/packages/core/src/lib/message/shared/message.interface.ts
+++ b/packages/core/src/lib/message/shared/message.interface.ts
@@ -16,4 +16,5 @@ export interface MessageOptions extends Notification {
   template?: string;
   from?: Date | string;
   to?: Date | string;
+  id?: string;
 }

--- a/packages/core/src/lib/message/shared/message.service.ts
+++ b/packages/core/src/lib/message/shared/message.service.ts
@@ -128,11 +128,10 @@ export class MessageService {
   }
 
   removeAllAreNotError() {
-    debugger;
-    for (let mess of this.messages$.value) {
+    for (const mess of this.messages$.value) {
       if (mess.type !== 'error') { 
-        this.remove(mess.options.id)
-      }
+        this.remove(mess.options.id);
+      };
     }
   }
 

--- a/packages/core/src/lib/message/shared/message.service.ts
+++ b/packages/core/src/lib/message/shared/message.service.ts
@@ -129,9 +129,9 @@ export class MessageService {
 
   removeAllAreNotError() {
     for (const mess of this.messages$.value) {
-      if (mess.type !== 'error') { 
+      if (mess.type !== 'error') {
         this.remove(mess.options.id);
-      };
+      }
     }
   }
 

--- a/packages/core/src/lib/message/shared/message.service.ts
+++ b/packages/core/src/lib/message/shared/message.service.ts
@@ -77,7 +77,7 @@ export class MessageService {
       if (message.icon !== undefined) {
         this.addIcon(notification, message.icon);
       }
-
+      message.options.id = notification.id;
       return notification;
     }
     return;
@@ -125,6 +125,15 @@ export class MessageService {
 
   remove(id?: string) {
     this.notificationService.remove(id);
+  }
+
+  removeAllAreNotError() {
+    debugger;
+    for (let mess of this.messages$.value) {
+      if (mess.type !== 'error') { 
+        this.remove(mess.options.id)
+      }
+    }
   }
 
   private addIcon(notification: Notification, icon: string) {


### PR DESCRIPTION
**What is the current behavior?** 
[demande 507](https://github.com/infra-geo-ouverte/igo2/issues/507)

**What is the new behavior?**
messages is remove when context change.
* error message is keep



**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**
no

**Other information**:
Branche create from branche messageHandling
