### PR TITLE
fix(capabilities): fix bad geographical extent

### DIFF
--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -253,7 +253,21 @@ export class CapabilitiesService {
     const timeFilter = this.getTimeFilter(layer);
     const timeFilterable = timeFilter && Object.keys(timeFilter).length > 0;
     const legendOptions = layer.Style ? this.getStyle(layer.Style) : undefined;
-    const extent = layer.EX_GeographicBoundingBox ?
+    let isExtentInGeographic = true;
+    if (layer.EX_GeographicBoundingBox) {
+      layer.EX_GeographicBoundingBox.forEach((coord, index) => {
+        if (index < 2 && (coord > 180 || coord < -180)) {
+          isExtentInGeographic = false;
+        }
+        if (index >= 2 && (coord > 90 || coord < -90)) {
+          isExtentInGeographic = false;
+        }
+      });
+    } else {
+      isExtentInGeographic = false;
+    }
+
+    const extent = isExtentInGeographic ?
         olproj.transformExtent(layer.EX_GeographicBoundingBox, 'EPSG:4326', this.mapService.getMap().projection) :
         undefined;
 


### PR DESCRIPTION
- Fix non geographical wms layer extent


- It was causing the extent to be out of bounds for 3857 (results in NaN), so the layer would not be displayed.
