### PR TITLE
(feat): display adjustments on CatalogItemGroup

### DIFF
--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.html
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.html
@@ -10,6 +10,22 @@
   </mat-icon>
 
   <h4 class="igo-catalog-group-title" id="catalog-group-title" mat-line matTooltipShowDelay="500" [matTooltip]="title" (click)="onTitleClick()">{{title}}</h4>
+
+  <button *ngIf="group.externalProvider"
+    disabled="true"
+    mat-icon-button>
+    <mat-icon
+      class="igo-cataloggroup-external-icon"
+      *ngIf="group.externalProvider"
+      tooltip-position="below"
+      matTooltipShowDelay="500"
+      [matTooltip]="'igo.geo.catalog.externalProvider.group' | translate"
+      color="primary"
+      (click)="$event.stopPropagation()"
+      svgIcon="earth-arrow-right">
+    </mat-icon>
+  </button>
+
   <ng-container *ngIf="(added$ | async) && !(preview$ | async); else notadded">
     <button
       mat-icon-button

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.scss
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.scss
@@ -6,3 +6,7 @@
 #catalog-group-title {
   font-weight: bold;
 }
+
+.igo-cataloggroup-external-icon  {
+    cursor: help;
+  }

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.ts
@@ -114,11 +114,11 @@ export class CatalogBrowserGroupComponent implements OnInit, OnDestroy {
     this.store.load(this.group.items);
     this.evaluateAdded();
     this.evaluateDisabled(this.collapsed);
-    if (this.catalog && this.catalog.sortDirection !== undefined) {
+    if (this.group.sortDirection !== undefined) {
       this.store.view.sort({
-        direction: this.catalog.sortDirection,
+        direction: this.group.sortDirection,
         valueAccessor: (item: CatalogItem) => item.title
-      });
+        });
     }
   }
 

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.html
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.html
@@ -7,6 +7,7 @@
         [state]="store.state"
         [resolution]="resolution$ | async"
         [catalogAllowLegend]="catalogAllowLegend"
+        [collapsed]="(store.count === 1) ? false : true"
         [toggleCollapsed]="toggleCollapsedGroup"
         (addedChange)="onGroupAddedChange($event)"
         (layerAddedChange)="onLayerAddedChange($event)">

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
@@ -225,12 +225,12 @@ export class CatalogBrowserComponent implements OnInit, OnDestroy {
       const added = this.store.state.get(item).added || false;
       return this.isLayer(item) && added === false;
     });
-    if (this.catalog && this.catalog.sortDirection !== undefined) {
-      layers = this.sortCatalogItemsByTitle(layers, this.catalog.sortDirection);
-  }
+    if (group.sortDirection !== undefined) {
+        layers = this.sortCatalogItemsByTitle(layers, group.sortDirection);
+    }
     this.addLayersToMap(layers.reverse() as CatalogItemLayer[]);
   }
-
+  
   /**
    * Remove all the layers of a group from map
    * @param group Catalog group

--- a/packages/geo/src/lib/catalog/shared/catalog.interface.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.interface.ts
@@ -19,7 +19,7 @@ export interface ICatalog {
   forcedProperties?: any[];
   requestEncoding?: string;
   regFilters?: string[];
-  groupImpose?: CatalogItemGroup; // only use by ICompositeCatalog object (id and title)
+  groupImpose?: CatalogItemGroup; // only use by ICompositeCatalog object (id, title, sortDirection?)
   groupSeparator?: string;
   queryFormat?: QueryFormat;
   queryParams?: { [key: string]: string };
@@ -49,6 +49,7 @@ export interface CatalogItemLayer<L = MetadataLayerOptions>
 
 export interface CatalogItemGroup extends CatalogItem {
   items?: CatalogItem[];
+  sortDirection?: 'asc' | 'desc';  // use with groupImpose and ICompositeCatalog
 }
 
 export interface CatalogItemState extends EntityState {

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -117,6 +117,7 @@ export class CatalogService {
           {
             id: 'catalog.group.baselayers',
             type: CatalogItemType.Group,
+            externalProvider: catalog.externalProvider,
             title: catalog.title,
             items
           }
@@ -189,10 +190,12 @@ export class CatalogService {
     const compositeCatalog = (catalog as CompositeCatalog).composite;
 
     const catalogsFromInstance = [] as Catalog[];
-    compositeCatalog.map((component: Catalog) =>
+    compositeCatalog.map((component: Catalog) => {
+      component.sortDirection = catalog.sortDirection;  // propagate sortDirection with parent value
       catalogsFromInstance.push(
         CatalogFactory.createInstanceCatalog(component, this)
-      )
+    );
+  }
     );
 
     // get CatalogItems for each original Catalog-----------------------------------------------------
@@ -222,6 +225,10 @@ export class CatalogService {
         const outGroupImpose = Object.assign({}, c.groupImpose);
         outGroupImpose.address = c.id;
         outGroupImpose.type = CatalogItemType.Group;
+        outGroupImpose.externalProvider = c.externalProvider;
+        if (outGroupImpose.sortDirection === undefined) {
+          outGroupImpose.sortDirection = c.sortDirection;
+        }
         outGroupImpose.items = [];
 
         const flatLayer = flatDeepLayer(item);
@@ -433,6 +440,8 @@ export class CatalogService {
       type: CatalogItemType.Group,
       title: itemListIn.Title,
       address: catalog.id,
+      externalProvider: catalog.externalProvider || false,
+      sortDirection: catalog.sortDirection,  // propagate sortDirection
       items: itemListIn.Layer.reduce((items: CatalogItem[], layer: any) => {
         if (layer.Layer !== undefined) {
           // recursive, check next level

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -13,6 +13,7 @@
         "unavailable": "The catalog '{{value}}' is unavailable at the moment or you don't have the required permissions.",
         "externalProvider": {
            "catalog": "This catalog comes from an external organization.",
+           "group": "This layers comes from an external organization.",
            "layer": "This layer comes from an external organization.",
            "unavailableWithEmail": "The catalog '{{value}}' is unavailable at the moment. To add an external service to the predefined list, please contact us at {{emailAddress}}. Delays can apply if problems occurs with the provider."
         },

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -13,6 +13,7 @@
         "unavailable": "Le catalogue '{{value}}' est indisponible pour le moment ou vous n'avez pas les permissions requises.",
         "externalProvider": {
           "catalog": "Ce catalogue provient d'une organisation externe.",
+          "group": "Ces couches proviennent d'une organisation externe.",
           "layer": "Cette couche provient d'une organisation externe.",
           "unavailableWithEmail": "Le catalogue '{{value}}' est indisponible pour le moment. Pour ajouter un service externe à la liste prédéfinie, veuillez contacter {{email}}. Des délais peuvent s'appliquer si problème il y a avec le fournisseur externe."
         },


### PR DESCRIPTION
(feat): add icon externalProvider on CatalogItemGroup
(feat): add sortDirection possibility on groupImpose in CompositeCatalog (practice for recent years first on a specific group)
(feat): display by default all layers of a group if there is only group in the catalog

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1. the groups in catalogue have no externalProvider icon
2. the groupImpose is only sorted like its parent catalog
3. a group only don't show their layers
What is the new behavior?


**What is the new behavior?**
1. the groups in catalogue show a externalProvider icon when the parent catalog is taged externalProvider
2. the groupImpose can have a diffetent sortDirection than its parent catalog
3. a group only in catalog show their layers


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
