### PR TITLE
feat(sharemap): keep the layer wms version on share map

### DIFF
--- a/packages/context/src/lib/share-map/shared/share-map.service.ts
+++ b/packages/context/src/lib/share-map/shared/share-map.service.ts
@@ -143,10 +143,10 @@ export class ShareMapService {
             break;
         }
         const addedLayerPosition = `${addedLayer}:igoz${layer.zIndex}`;
-        
+
         let version = '';
         if (layerVersion) {
-          let operator = linkUrl.indexOf('?') === -1 ? '?' : '&';
+          const operator = linkUrl.indexOf('?') === -1 ? '?' : '&';
           version = encodeURIComponent(`${operator}VERSION=${layerVersion}`);
         }
         linkUrl = `${linkUrl}${version}`;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When you add a layer from a catalog specifying a wms version, the shared link do not keep the version. 


**What is the new behavior?**
The share map now add the version into the share url IF the version (wms) is different than 1.3.0. 




**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
