### PR TITLE
fix(storedQueries): params property was not initilized properly

### DIFF
--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -180,11 +180,8 @@ export class StoredQueriesSearchSource extends SearchSource
       options || {},
       storedqueriesParams
     );
-    if (this.options.params === null) {
-      this.options.params = { page : '1'};
-    } else {
-      this.options.params.page = options.page !== null ? String(options.page) : '1';
-    }
+    this.options.params = this.options.params ? this.options.params : {};
+    this.options.params.page = !options.page ? String(options.page) : '1';
 
     if (
       new RegExp('.*?gml.*?', 'i').test(this.storedQueriesOptions.outputformat)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Due to the migration to eslint, an error was inserted, then the params property was not initilized properly.


**What is the new behavior?**
Fix it. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
