### PR TITLE
feat(query-directive*) New query behavior for workspace and wms wfs combine

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
@@ -21,4 +21,5 @@ export interface WFSDataSourceOptionsParams {
   outputFormatDownload?: string;
   srsName?: string;
   xmlFilter?: string;
+  combineLayerWFSMapQuerySameAsWms?: boolean;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -89,6 +89,19 @@ export class WFSDataSource extends DataSource {
       this.ogcFilters$.next(this.ogcFilters);
     }
   }
+  getParamsWFSFeatureTypes() {
+    if (this.options.paramsWFS && this.options.paramsWFS.featureTypes) {
+      return this.options.paramsWFS.featureTypes;
+    }
+    else return null;
+  }
+
+  getCombineLayerWFSMapQuerySameAsWms() {
+    if (this.options.paramsWFS && this.options.paramsWFS.combineLayerWFSMapQuerySameAsWms) {
+      return this.options.paramsWFS.combineLayerWFSMapQuerySameAsWms;
+    }
+    else return null;
+  }
 
   public onUnwatch() { }
 }

--- a/packages/geo/src/lib/feature/shared/feature.utils.ts
+++ b/packages/geo/src/lib/feature/shared/feature.utils.ts
@@ -414,6 +414,10 @@ export function tryBindStoreLayer(store: FeatureStore, layer?: VectorLayer) {
     store.map.addLayer(store.layer);
   }
 }
+export function getFeatureLayerId(feature: Feature): string {
+  let featureStore = feature.ol.get('_featureStore');
+  return featureStore.layer.id;
+}
 
 /**
  * Compute a diff between a source array of Ol features and a target array

--- a/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
@@ -40,6 +40,8 @@ export interface GeoWorkspaceOptions {
   minResolution?: number;
   maxResolution?: number;
   enabled?: boolean;
+  noQueryOnClickInTab?: boolean;
+  noMapQueryOnOpenTab?: boolean;
 }
 
 export interface LayersLink {

--- a/packages/geo/src/lib/query/shared/query.directive.ts
+++ b/packages/geo/src/lib/query/shared/query.directive.ts
@@ -160,7 +160,7 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
     const resolution = this.map.ol.getView().getResolution();
 
     this.setQueryableForCombineWMS_WFS(this.map.layers);
-    this.setQueryableForWorkspaceOpen(this.map.layers)
+    this.setQueryableForWorkspaceOpen(this.map.layers);
 
     const queryLayers = this.map.layers.filter(layerIsQueryable);
     queries$.push(
@@ -207,9 +207,9 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
           const layer = this.map.getLayerById(layerOL.values_._layer.id);
           // check no query param workspace
           if (layer.options.workspace && layer.options.workspace.noMapQueryOnOpenTab) {
-            if(this.queryService.workspace && 
-              this.queryService.workspace.id === getShortLayerId(layer) && 
-              this.queryService.workspace.active && 
+            if(this.queryService.workspace &&
+              this.queryService.workspace.id === getShortLayerId(layer) &&
+              this.queryService.workspace.active &&
               this.queryService.workspace.getInResolutionRange() &&
               this.queryService.workspaceIsOpen) {
                 return;
@@ -351,9 +351,9 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
   private setQueryableForWorkspaceOpen(layers: AnyLayer[]) {
     for (let layer of layers) {
       if (layer.options.workspace && layer.options.workspace.noMapQueryOnOpenTab) {
-        if (this.queryService.workspace && 
-          this.queryService.workspace.id === getShortLayerId(layer) && 
-          this.queryService.workspace.active && 
+        if (this.queryService.workspace &&
+          this.queryService.workspace.id === getShortLayerId(layer) &&
+          this.queryService.workspace.active &&
           this.queryService.workspace.getInResolutionRange() &&
           this.queryService.workspaceIsOpen) {
             setLayerQueryable(layer, false);

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -42,6 +42,8 @@ import { MapExtent } from '../../map/shared/map.interface';
 })
 export class QueryService {
   public queryEnabled = true;
+  public workspace;
+  public workspaceIsOpen = false;
 
   constructor(private http: HttpClient) {}
 

--- a/packages/geo/src/lib/query/shared/query.utils.ts
+++ b/packages/geo/src/lib/query/shared/query.utils.ts
@@ -13,7 +13,36 @@ export function layerIsQueryable(layer: AnyLayer): boolean {
   const dataSource = layer.dataSource as QueryableDataSource;
   return dataSource.options.queryable === true;
 }
+export function setLayerQueryable(layer: AnyLayer, queryable: boolean) {
+  let dataSource = layer.dataSource as QueryableDataSource;
+  dataSource.options.queryable = queryable;
+}
+export function setLayerQueryFormat(layer: AnyLayer, format) {
+  let dataSource = layer.dataSource as QueryableDataSource;
+  dataSource.options.queryFormat = format;
+}
 
+export function getShortLayerId(layer: AnyLayer): string {
+  return layer.id.toString().split('.')[0];
+}
+
+export function getIdsSameLayer(layers: AnyLayer[]): string[] {
+  // check if same id many times
+  let sameIdFind = [];
+  for (let i = 0; i < layers.length ; i++ ) {
+    let layId = getShortLayerId(layers[i]) ;
+    if (layId === 'searchPointerSummaryId') {
+      continue;
+    }
+    for (let j = i + 1 ; j < layers.length ; j++ ) {
+      let layId2 = getShortLayerId(layers[j]) ;
+      if (layId === layId2) {
+        sameIdFind.push(layId);
+      }
+    }
+  }
+  return sameIdFind;
+}
 /**
  * Whether an OL layer is queryable
  * @param layer Layer

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -47,13 +47,19 @@ export class FeatureWorkspaceService {
     if (layer.options.workspace?.enabled === false) {
       return;
     }
-    layer.options.workspace = Object.assign({}, layer.options.workspace, {enabled: true});
+    let wksConfig;
+    if (layer.options.workspace) {
+      wksConfig = layer.options.workspace;
+    } else {
+      wksConfig = {};
+    }
+    wksConfig.srcId = layer.id;
+    wksConfig.workspaceId = layer.id;
+    wksConfig.enabled = true;
 
     layer.options.workspace = Object.assign({}, layer.options.workspace,
       {
-        enabled: true,
-        srcId: layer.id,
-        workspaceId: layer.id
+        wksConfig
       } as GeoWorkspaceOptions);
 
 

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.ts
@@ -30,4 +30,7 @@ export class FeatureWorkspace extends Workspace {
       }
     });
   }
+  private getInResolutionRange(): boolean {
+    return this.inResolutionRange$.value;
+  }
 }

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -51,7 +51,6 @@ export class WfsWorkspaceService {
     } else {
       wksConfig = {};
     }
-    
     wksConfig.srcId = layer.id;
     wksConfig.workspaceId = layer.id;
     wksConfig.enabled = true;

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -45,12 +45,19 @@ export class WfsWorkspaceService {
     if (layer.options.workspace?.enabled === false) {
       return;
     }
-
+    let wksConfig;
+    if (layer.options.workspace) {
+      wksConfig = layer.options.workspace;
+    } else {
+      wksConfig = {};
+    }
+    
+    wksConfig.srcId = layer.id;
+    wksConfig.workspaceId = layer.id;
+    wksConfig.enabled = true;
     layer.options.workspace = Object.assign({}, layer.options.workspace,
       {
-        enabled: true,
-        srcId: layer.id,
-        workspaceId: layer.id
+        wksConfig
       } as GeoWorkspaceOptions);
 
     const wks = new WfsWorkspace({
@@ -66,7 +73,6 @@ export class WfsWorkspaceService {
     });
     this.createTableTemplate(wks, layer);
     return wks;
-
   }
 
   private createFeatureStore(layer: VectorLayer, map: IgoMap): FeatureStore {

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.ts
@@ -30,4 +30,8 @@ export class WfsWorkspace extends Workspace {
       }
     });
   }
+
+  private getInResolutionRange(): boolean {
+    return this.inResolutionRange$.value;
+  }
 }

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -82,7 +82,7 @@ export class WmsWorkspaceService {
     layer.options.linkedLayers.linkId = layer.options.linkedLayers.linkId ? layer.options.linkedLayers.linkId : wmsLinkId,
       layer.options.linkedLayers.links = clonedLinks;
     interface WFSoptions extends WFSDataSourceOptions, OgcFilterableDataSourceOptions { }
-    
+
     let wksConfig;
     if (layer.options.workspace) {
       wksConfig = layer.options.workspace;
@@ -92,7 +92,6 @@ export class WmsWorkspaceService {
     wksConfig.srcId = layer.id;
     wksConfig.workspaceId = undefined;
     wksConfig.enabled = false;
-    
     let wks;
     this.layerService
       .createAsyncLayer({

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -82,6 +82,17 @@ export class WmsWorkspaceService {
     layer.options.linkedLayers.linkId = layer.options.linkedLayers.linkId ? layer.options.linkedLayers.linkId : wmsLinkId,
       layer.options.linkedLayers.links = clonedLinks;
     interface WFSoptions extends WFSDataSourceOptions, OgcFilterableDataSourceOptions { }
+    
+    let wksConfig;
+    if (layer.options.workspace) {
+      wksConfig = layer.options.workspace;
+    } else {
+      wksConfig = {};
+    }
+    wksConfig.srcId = layer.id;
+    wksConfig.workspaceId = undefined;
+    wksConfig.enabled = false;
+    
     let wks;
     this.layerService
       .createAsyncLayer({
@@ -89,11 +100,7 @@ export class WmsWorkspaceService {
         linkedLayers: {
           linkId: wfsLinkId
         },
-        workspace: {
-          srcId: layer.id,
-          workspaceId: undefined,
-          enabled: false,
-        },
+        workspace: wksConfig,
         showInLayerList: false,
         opacity: 0,
         title: layer.title,

--- a/packages/integration/src/lib/workspace/workspace.state.ts
+++ b/packages/integration/src/lib/workspace/workspace.state.ts
@@ -62,7 +62,7 @@ export class WorkspaceState implements OnDestroy {
     this.initWorkspaces();
     this.workspacePanelExpanded$.subscribe(isOpen => {
       this.queryService.workspaceIsOpen = isOpen;
-    })
+    });
   }
 
   /**
@@ -74,7 +74,7 @@ export class WorkspaceState implements OnDestroy {
     this.workspace$.subscribe(val => {
       debugger;
       this.queryService.workspace = val;
-    })
+    });
     this._store = new WorkspaceStore([]);
     this._store.stateView
       .firstBy$((record: EntityRecord<Workspace>) => record.state.active === true)

--- a/packages/integration/src/lib/workspace/workspace.state.ts
+++ b/packages/integration/src/lib/workspace/workspace.state.ts
@@ -72,7 +72,6 @@ export class WorkspaceState implements OnDestroy {
    */
   private initWorkspaces() {
     this.workspace$.subscribe(val => {
-      debugger;
       this.queryService.workspace = val;
     });
     this._store = new WorkspaceStore([]);

--- a/packages/integration/src/lib/workspace/workspace.state.ts
+++ b/packages/integration/src/lib/workspace/workspace.state.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import {
   EntityRecord,Workspace, WorkspaceStore, Widget,
   EntityStoreFilterCustomFuncStrategy, EntityStoreFilterSelectionStrategy } from '@igo2/common';
-import { WfsWorkspace, FeatureWorkspace } from '@igo2/geo';
+import { WfsWorkspace, FeatureWorkspace, QueryService } from '@igo2/geo';
 import { FeatureActionsService } from './shared/feature-actions.service';
 import { WfsActionsService } from './shared/wfs-actions.service';
 import { StorageService } from '@igo2/core';
@@ -19,6 +19,7 @@ import { StorageService } from '@igo2/core';
 export class WorkspaceState implements OnDestroy {
 
   public workspacePanelExpanded: boolean = false;
+  public workspacePanelExpanded$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   readonly workspaceEnabled$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   readonly rowsInMapExtentCheckCondition$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
@@ -55,9 +56,13 @@ export class WorkspaceState implements OnDestroy {
   constructor(
     private featureActionsService: FeatureActionsService,
     private wfsActionsService: WfsActionsService,
-    private storageService: StorageService
+    private storageService: StorageService,
+    public queryService: QueryService
   ) {
     this.initWorkspaces();
+    this.workspacePanelExpanded$.subscribe(isOpen => {
+      this.queryService.workspaceIsOpen = isOpen;
+    })
   }
 
   /**
@@ -66,6 +71,10 @@ export class WorkspaceState implements OnDestroy {
    * to make sure only one widget is active at a time.
    */
   private initWorkspaces() {
+    this.workspace$.subscribe(val => {
+      debugger;
+      this.queryService.workspace = val;
+    })
     this._store = new WorkspaceStore([]);
     this._store.stateView
       .firstBy$((record: EntityRecord<Workspace>) => record.state.active === true)


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
workspace:
- click in workspace table =­­ query open
- click on feature when workspace is open = query open

combineWMS-WFS layer - paramWFS
- click on feature when in resolution wfs = query in GML open (not in html or htmlgml2)
[igo2-634](https://github.com/infra-geo-ouverte/igo2/issues/634)


**What is the new behavior?**
3 new param to change query behavior

workspace:
            "noQueryOnClickInTab": true,
            "noMapQueryOnOpenTab": true

paramWFS:
             "combineLayerWFSMapQuerySameAsWms": true


*** link to PR IGO2 to work
exemple in workspace context


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

