### PR TITLE
Pointer enhancement

### DIFF
--- a/packages/geo/src/lib/search/shared/search-pointer-summary.directive.ts
+++ b/packages/geo/src/lib/search/shared/search-pointer-summary.directive.ts
@@ -176,10 +176,12 @@ export class SearchPointerSummaryDirective implements OnInit, OnDestroy, AfterCo
         if (closestResultByType.hasOwnProperty(result.data.properties.type)) {
           const prevDistance = closestResultByType[result.data.properties.type].distance;
           if (result.data.properties.distance < prevDistance) {
-            closestResultByType[result.data.properties.type] = { distance: result.data.properties.distance, title: result.meta.title };
+            const title = result.meta.pointerSummaryTitle || result.meta.title;
+            closestResultByType[result.data.properties.type] = { distance: result.data.properties.distance, title };
           }
         } else {
-          closestResultByType[result.data.properties.type] = { distance: result.data.properties.distance, title: result.meta.title };
+          const title = result.meta.pointerSummaryTitle || result.meta.title;
+          closestResultByType[result.data.properties.type] = { distance: result.data.properties.distance, title };
         }
       }
     });
@@ -204,7 +206,7 @@ export class SearchPointerSummaryDirective implements OnInit, OnDestroy, AfterCo
         processedSummarizedClosestType.push(result.data.properties.type);
       } else {
         if (processedSummarizedClosestType.indexOf(result.data.properties.type) === -1) {
-          summary.push(result.meta.title);
+          summary.push(result.meta.pointerSummaryTitle || result.meta.title);
         }
       }
     });

--- a/packages/geo/src/lib/search/shared/search-pointer-summary.directive.ts
+++ b/packages/geo/src/lib/search/shared/search-pointer-summary.directive.ts
@@ -272,6 +272,15 @@ export class SearchPointerSummaryDirective implements OnInit, OnDestroy, AfterCo
     }, this.igoSearchPointerSummaryDelay);
   }
 
+    /**
+   * Sort the results by display order.
+   * @param r1 First result
+   * @param r2 Second result
+   */
+     private sortByOrder(r1: SearchResult, r2: SearchResult) {
+      return r1.source.displayOrder - r2.source.displayOrder;
+    }
+
   private onSearchCoordinate() {
     this.pointerSearchStore.clear();
     const results = this.searchService.reverseSearch(this.lonLat, { params: { geometry: 'false', icon: 'false' } }, true);
@@ -291,7 +300,7 @@ export class SearchPointerSummaryDirective implements OnInit, OnDestroy, AfterCo
     const newResults = this.pointerSearchStore.all()
       .filter((result: SearchResult) => result.source !== event.research.source)
       .concat(results);
-    this.pointerSearchStore.load(newResults);
+    this.pointerSearchStore.load(newResults.sort(this.sortByOrder));
   }
 
   /**

--- a/packages/geo/src/lib/search/shared/search.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/search.interfaces.ts
@@ -17,6 +17,7 @@ export interface SearchResult<T = { [key: string]: any }> {
     id: string;
     title: string;
     titleHtml?: string;
+    pointerSummaryTitle?: string;
     icon: string;
     score?: number;
     nextPage?: boolean;

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -864,7 +864,8 @@ export class IChercheReverseSearchSource extends SearchSource
         id,
         title: data.properties.nom,
         titleHtml: titleHtml + subtitleHtml,
-        icon: data.icon || 'map-marker'
+        icon: data.icon || 'map-marker',
+        pointerSummaryTitle: this.getSubtitle(data)+ ': ' + data.properties.nom
       }
     };
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1-Pointer summary do no respect the planned order (into the search results). Then, the summary order is always based on response time.
2- Pointer summary do not show the type of the result...
![image](https://user-images.githubusercontent.com/7397743/142053959-442ae11c-02e7-4ace-bf86-52191292a0df.png)

vs 

![image](https://user-images.githubusercontent.com/7397743/142053969-bc47d027-7bb5-41d4-b954-995bb4a20a5c.png)



**What is the new behavior?**
Respect order
Present type.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
