### PR TITLE
Fix2(layer-legend-component) problem with a layer contain many layer

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -49,6 +49,7 @@ export interface Legend {
   style?: { [key: string]: string | number };
   title?: string;
   currentStyle?: string;
+  imgGraphValue?: string;
 }
 
 // refer to https://openlayers.org/en/latest/apidoc/module-ol_tilegrid_TileGrid-TileGrid.html

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.html
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.html
@@ -28,7 +28,7 @@
           <div *ngIf="!(item.collapsed)">
             <div *ngIf="item.url">
               <img #renderedLegend id="{{item.title}}" (load)="onLoadImage(item.title)"
-                src="{{legendGraphic[item.title]}}"
+                src="{{[item.imgGraphValue]}}"
                 alt="{{'igo.geo.layer.legend.loadingLegendText' | translate}}">
               <small *ngIf="imagesHeight[item.title]<16">
                   {{'igo.geo.layer.legend.noLegendScale' | translate}}

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -142,7 +142,7 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
         }
       })
       ).subscribe(function(item, legendGraph) {
-        const idx = this.legendItems$.value.findIndex(leg => leg.title == item.title);
+        const idx = this.legendItems$.value.findIndex(leg => leg.title === item.title);
         this.legendItems$.value[idx].imgGraphValue = legendGraph;
         this.cdRef.detectChanges();
       }.bind(this, item));

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -75,9 +75,6 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
   /**
    * activeLegend
    */
-  public legendGraphic: { [srcKey: string]: string } = {};
-
-  public currentItemTitle: string;
 
   constructor(
     private capabilitiesService: CapabilitiesService,
@@ -135,7 +132,6 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
 
   getLegendGraphic(item: Legend) {
     const secureIMG = new SecureImagePipe(this.http);
-    this.currentItemTitle = item.title;
     secureIMG.transform(item.url).pipe(
       catchError((err) => {
         if (err.error) {
@@ -145,10 +141,11 @@ export class LayerLegendComponent implements OnInit, OnDestroy {
           return err;
         }
       })
-    ).subscribe((legend: string) => {
-      this.legendGraphic[this.currentItemTitle] = legend;
-      this.cdRef.detectChanges();
-    });
+      ).subscribe(function(item, legendGraph) {
+        const idx = this.legendItems$.value.findIndex(leg => leg.title == item.title);
+        this.legendItems$.value[idx].imgGraphValue = legendGraph;
+        this.cdRef.detectChanges();
+      }.bind(this, item));
   }
 
   toggleLegendItem(collapsed: boolean, item: Legend) {


### PR DESCRIPTION
bis problem legend is not corectly show on a layer with many layer when first click is on legend

config to check
 {
      "title": "Subdivisions territoriales forestières",
      "visible" : false,
      "metadata": {
        "url": "https://www.donneesquebec.ca/recherche/fr/dataset/stf",
        "extern": "false"
        },
      "sourceOptions": {
        "queryable": true,
        "queryFormat": "geojson",
        "crossOrigin": "anonymous",
        "queryHtmlTarget": "iframe",
        "url": "https://servicescarto.mffp.gouv.qc.ca/pes/services/Forets/STF_WMS/MapServer/WMSServer?",
        "params": {
            "layers": "Unité aménagement - UA,Territoires forestiers résiduels - TFR,Forêt de proximité - FP,Forêt enseignement et de recherche,Forêt expérimentation - FE,Station forestière Duchesnay,Pépinière publique forestière - PPU,Aires protégées,Autres terrains publics,Terres privées,Territoires autochtones,Lacs et rivières importantes"
        },
        "type": "wms"
      }
    },
 {

      "title": "Lieux habités",
      "visible": false,
      "baseLayer": false,
      "style": "default",
      "sourceOptions": {
        "crossOrigin": "anonymous",
        "url": "https://ws.mapserver.transports.gouv.qc.ca/swtq?",
        "params": {
          "version": "1.3.0",
          "layers": "villagerelais,lieuhabite",
          "srs": "ESPG:3857"
        },
        "type": "wms"
      }
    }
