### PR TITLE
fix (query.utils) fix when queryLayersFeatures is false

### DIFF
--- a/packages/geo/src/lib/query/shared/query.utils.ts
+++ b/packages/geo/src/lib/query/shared/query.utils.ts
@@ -31,7 +31,7 @@ export function olLayerIsQueryable(olLayer: OlLayer<OlSource>): boolean {
  */
 export function layerFeatureIsQueryable(layer: AnyLayer): boolean {
   const dataSource = layer.dataSource as QueryableDataSource;
-  return dataSource.options.queryLayerFeatures ? (dataSource.options.queryLayerFeatures === true) : true;
+  return typeof dataSource.options.queryLayerFeatures !== 'undefined' ? (dataSource.options.queryLayerFeatures === true) : true;
 }
 
 /**

--- a/packages/geo/src/lib/query/shared/query.utils.ts
+++ b/packages/geo/src/lib/query/shared/query.utils.ts
@@ -31,7 +31,7 @@ export function olLayerIsQueryable(olLayer: OlLayer<OlSource>): boolean {
  */
 export function layerFeatureIsQueryable(layer: AnyLayer): boolean {
   const dataSource = layer.dataSource as QueryableDataSource;
-  return typeof dataSource.options.queryLayerFeatures !== 'undefined' ? (dataSource.options.queryLayerFeatures === true) : true;
+  return dataSource.options.queryLayerFeatures !== undefined ? (dataSource.options.queryLayerFeatures === true) : true;
 }
 
 /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When queryLayerFeatures is "false", return true. 
#947 was bad. fixed non-existent queryLayerFeatures but was wrong when queryLayerFeatures was "false"

**What is the new behavior?**
return false when false ! 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
