### PR TITLE
feat(Query-directive,Workspace,*) 2-New query behavior workspace and combine wmswfs

### DIFF
--- a/packages/common/src/lib/workspace/shared/workspace.interfaces.ts
+++ b/packages/common/src/lib/workspace/shared/workspace.interfaces.ts
@@ -7,4 +7,8 @@ export interface WorkspaceOptions {
   entityStore?: EntityStore<object>;
   actionStore?: ActionStore;
   meta?: {[key: string]: any};
+  noMapQueryOnOpenTab?: boolean;
+  noQueryOnClickInTab?: boolean;
+  minResolution?: number;
+  maxResolution?: number;
 }

--- a/packages/common/src/lib/workspace/shared/workspace.ts
+++ b/packages/common/src/lib/workspace/shared/workspace.ts
@@ -153,5 +153,11 @@ export class Workspace<E extends object = object> {
   private onStateChange() {
     this.change.next();
   }
+  
+  getNoQueryOnClickInTab(): boolean {
+    if (this.options && this.options.noQueryOnClickInTab){
+      return this.options.noQueryOnClickInTab;
+    }
+  }
 
 }

--- a/packages/common/src/lib/workspace/shared/workspace.ts
+++ b/packages/common/src/lib/workspace/shared/workspace.ts
@@ -153,7 +153,7 @@ export class Workspace<E extends object = object> {
   private onStateChange() {
     this.change.next();
   }
-  
+
   getNoQueryOnClickInTab(): boolean {
     if (this.options && this.options.noQueryOnClickInTab){
       return this.options.noQueryOnClickInTab;

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
@@ -21,4 +21,5 @@ export interface WFSDataSourceOptionsParams {
   outputFormatDownload?: string;
   srsName?: string;
   xmlFilter?: string;
+  combineLayerWFSMapQuerySameAsWms?: boolean;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -90,5 +90,11 @@ export class WFSDataSource extends DataSource {
     }
   }
 
+  getCombineLayerWFSMapQuerySameAsWms(): boolean {
+    if (this.options.paramsWFS && this.options.paramsWFS.combineLayerWFSMapQuerySameAsWms) {
+      return this.options.paramsWFS.combineLayerWFSMapQuerySameAsWms;
+    }
+    else return false;
+  }
   public onUnwatch() { }
 }

--- a/packages/geo/src/lib/query/shared/query.directive.ts
+++ b/packages/geo/src/lib/query/shared/query.directive.ts
@@ -345,9 +345,9 @@ export class QueryDirective implements AfterViewInit, OnDestroy {
   }
 
   private noQueryWorkspaceCondition(): boolean {
-    if (this.queryService.activeWorkspace && 
+    if (this.queryService.activeWorkspace &&
       this.queryService.workspaceIsOpen &&
-      this.queryService.activeWorkspace.inResolutionRange$.value && 
+      this.queryService.activeWorkspace.inResolutionRange$.value &&
       this.queryService.activeWorkspace.options.noMapQueryOnOpenTab) {
         return true;
     } else {

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -42,6 +42,8 @@ import { MapExtent } from '../../map/shared/map.interface';
 })
 export class QueryService {
   public queryEnabled = true;
+  public activeWorkspace;
+  public workspaceIsOpen = false;
 
   constructor(private http: HttpClient) {}
 

--- a/packages/geo/src/lib/query/shared/query.utils.ts
+++ b/packages/geo/src/lib/query/shared/query.utils.ts
@@ -14,6 +14,15 @@ export function layerIsQueryable(layer: AnyLayer): boolean {
   return dataSource.options.queryable === true;
 }
 
+export function getShortLayerId(layer: AnyLayer): string {
+  return layer.id.toString().split('.')[0];
+}
+
+export function setLayerQueryable(layer: AnyLayer, queryable: boolean) {
+  let dataSource = layer.dataSource as QueryableDataSource;
+  dataSource.options.queryable = queryable;
+}
+
 /**
  * Whether an OL layer is queryable
  * @param layer Layer

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -47,8 +47,14 @@ export class FeatureWorkspaceService {
     if (layer.options.workspace?.enabled === false) {
       return;
     }
+    let wksConfig;
+    if (layer.options.workspace) {
+      wksConfig = layer.options.workspace;
+    } else {
+      wksConfig = {};
+    };
+    
     layer.options.workspace = Object.assign({}, layer.options.workspace, {enabled: true});
-
     layer.options.workspace = Object.assign({}, layer.options.workspace,
       {
         enabled: true,
@@ -56,18 +62,22 @@ export class FeatureWorkspaceService {
         workspaceId: layer.id
       } as GeoWorkspaceOptions);
 
+    delete wksConfig['enabled'];
+    const wksOptions = Object.assign(wksConfig,
+      {
+        id: layer.id,
+        title: layer.title,
+        layer,
+        map,
+        entityStore: this.createFeatureStore(layer, map),
+        actionStore: new ActionStore([]),
+        meta: {
+          tableTemplate: undefined
+        }
+      });
 
-    const wks = new FeatureWorkspace({
-      id: layer.id,
-      title: layer.title,
-      layer,
-      map,
-      entityStore: this.createFeatureStore(layer, map),
-      actionStore: new ActionStore([]),
-      meta: {
-        tableTemplate: undefined
-      }
-    });
+    const wks = new FeatureWorkspace(wksOptions);
+
     this.createTableTemplate(wks, layer);
     return wks;
 

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -53,7 +53,7 @@ export class FeatureWorkspaceService {
     } else {
       wksConfig = {};
     };
-    
+
     layer.options.workspace = Object.assign({}, layer.options.workspace, {enabled: true});
     layer.options.workspace = Object.assign({}, layer.options.workspace,
       {

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -45,6 +45,12 @@ export class WfsWorkspaceService {
     if (layer.options.workspace?.enabled === false) {
       return;
     }
+    let wksConfig;
+    if (layer.options.workspace) {
+      wksConfig = layer.options.workspace;
+    } else {
+      wksConfig = {};
+    };
 
     layer.options.workspace = Object.assign({}, layer.options.workspace,
       {
@@ -53,7 +59,9 @@ export class WfsWorkspaceService {
         workspaceId: layer.id
       } as GeoWorkspaceOptions);
 
-    const wks = new WfsWorkspace({
+    delete wksConfig['enabled'];
+    const wksOptions = Object.assign(wksConfig,
+      {
       id: layer.id,
       title: layer.title,
       layer,
@@ -64,6 +72,8 @@ export class WfsWorkspaceService {
         tableTemplate: undefined
       }
     });
+    const wks = new WfsWorkspace(wksOptions);
+
     this.createTableTemplate(wks, layer);
     return wks;
 

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -82,7 +82,7 @@ export class WmsWorkspaceService {
     layer.options.linkedLayers.linkId = layer.options.linkedLayers.linkId ? layer.options.linkedLayers.linkId : wmsLinkId,
       layer.options.linkedLayers.links = clonedLinks;
     interface WFSoptions extends WFSDataSourceOptions, OgcFilterableDataSourceOptions { }
-    
+
     let wksConfig;
     if (layer.options.workspace) {
       wksConfig = layer.options.workspace;
@@ -122,7 +122,7 @@ export class WmsWorkspaceService {
         map.addLayer(workspaceLayer);
         layer.ol.setProperties({ linkedLayers: { linkId: layer.options.linkedLayers.linkId, links: clonedLinks } }, false);
         workspaceLayer.dataSource.ol.refresh();
-        
+
         delete wksConfig['enabled'];
         let wksOptions = Object.assign(wksConfig,
           {
@@ -135,7 +135,7 @@ export class WmsWorkspaceService {
             meta: {
               tableTemplate: undefined
             }
-          } 
+          }
         );
         wks = new WfsWorkspace(wksOptions);
 

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -82,6 +82,14 @@ export class WmsWorkspaceService {
     layer.options.linkedLayers.linkId = layer.options.linkedLayers.linkId ? layer.options.linkedLayers.linkId : wmsLinkId,
       layer.options.linkedLayers.links = clonedLinks;
     interface WFSoptions extends WFSDataSourceOptions, OgcFilterableDataSourceOptions { }
+    
+    let wksConfig;
+    if (layer.options.workspace) {
+      wksConfig = layer.options.workspace;
+    } else {
+      wksConfig = {};
+    };
+
     let wks;
     this.layerService
       .createAsyncLayer({
@@ -114,18 +122,23 @@ export class WmsWorkspaceService {
         map.addLayer(workspaceLayer);
         layer.ol.setProperties({ linkedLayers: { linkId: layer.options.linkedLayers.linkId, links: clonedLinks } }, false);
         workspaceLayer.dataSource.ol.refresh();
+        
+        delete wksConfig['enabled'];
+        let wksOptions = Object.assign(wksConfig,
+          {
+            id: layer.id,
+            title: layer.title,
+            layer: workspaceLayer,
+            map,
+            entityStore: this.createFeatureStore(workspaceLayer, map),
+            actionStore: new ActionStore([]),
+            meta: {
+              tableTemplate: undefined
+            }
+          } 
+        );
+        wks = new WfsWorkspace(wksOptions);
 
-        wks = new WfsWorkspace({
-          id: layer.id,
-          title: layer.title,
-          layer: workspaceLayer,
-          map,
-          entityStore: this.createFeatureStore(workspaceLayer, map),
-          actionStore: new ActionStore([]),
-          meta: {
-            tableTemplate: undefined
-          }
-        });
         this.createTableTemplate(wks, workspaceLayer);
 
         workspaceLayer.options.workspace.workspaceId = workspaceLayer.id;

--- a/packages/integration/src/lib/workspace/workspace.state.ts
+++ b/packages/integration/src/lib/workspace/workspace.state.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import {
   EntityRecord,Workspace, WorkspaceStore, Widget,
   EntityStoreFilterCustomFuncStrategy, EntityStoreFilterSelectionStrategy } from '@igo2/common';
-import { WfsWorkspace, FeatureWorkspace } from '@igo2/geo';
+import { WfsWorkspace, FeatureWorkspace, QueryService } from '@igo2/geo';
 import { FeatureActionsService } from './shared/feature-actions.service';
 import { WfsActionsService } from './shared/wfs-actions.service';
 import { StorageService } from '@igo2/core';
@@ -19,6 +19,7 @@ import { StorageService } from '@igo2/core';
 export class WorkspaceState implements OnDestroy {
 
   public workspacePanelExpanded: boolean = false;
+  public workspacePanelExpanded$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   readonly workspaceEnabled$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   readonly rowsInMapExtentCheckCondition$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
@@ -55,9 +56,13 @@ export class WorkspaceState implements OnDestroy {
   constructor(
     private featureActionsService: FeatureActionsService,
     private wfsActionsService: WfsActionsService,
-    private storageService: StorageService
+    private storageService: StorageService,
+    public queryService: QueryService
   ) {
     this.initWorkspaces();
+    this.workspacePanelExpanded$.subscribe(isOpen => {
+      this.queryService.workspaceIsOpen = isOpen;
+    });
   }
 
   /**
@@ -66,6 +71,9 @@ export class WorkspaceState implements OnDestroy {
    * to make sure only one widget is active at a time.
    */
   private initWorkspaces() {
+    this.workspace$.subscribe(val => {
+      this.queryService.activeWorkspace = val;
+    });
     this._store = new WorkspaceStore([]);
     this._store.stateView
       .firstBy$((record: EntityRecord<Workspace>) => record.state.active === true)


### PR DESCRIPTION
*** link to PR IGO2 (need to be integrate at same time to work fine )
[pull-689](https://github.com/infra-geo-ouverte/igo2/pull/689)

What is the current behavior? (You can also link to an open issue here)
workspace:
- click in workspace table =­­ query open
- click on feature when workspace is open = query open

combineWMS-WFS layer - paramWFS
- click on feature when in resolution wfs = query in GML open (not in html or htmlgml2)
[igo2-634](https://github.com/infra-geo-ouverte/igo2/issues/634)

What is the new behavior?
3 new param to change query behavior

workspace:
"noQueryOnClickInTab": true,
"noMapQueryOnOpenTab": true

paramWFS:
"combineLayerWFSMapQuerySameAsWms": true

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No


