### PR TITLE
fix(messageModule-storedQuery.ts)- fix duplicate mesage and storedQuery

### DIFF
--- a/packages/core/src/lib/message/message.module.ts
+++ b/packages/core/src/lib/message/message.module.ts
@@ -17,7 +17,7 @@ import { GlobalConfig, ToastrModule } from 'ngx-toastr';
       maxOpened: 4,
       preventDuplicates: true,
       resetTimeoutOnDuplicate: true,
-      countDuplicates: true,
+      countDuplicates: false,
       includeTitleDuplicates: true
     } as GlobalConfig)],
   declarations: [],

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -181,7 +181,7 @@ export class StoredQueriesSearchSource extends SearchSource
       storedqueriesParams
     );
     this.options.params = this.options.params ? this.options.params : {};
-    this.options.params.page = !options.page ? String(options.page) : '1';
+    this.options.params.page = options.page ? String(options.page) : '1';
 
     if (
       new RegExp('.*?gml.*?', 'i').test(this.storedQueriesOptions.outputformat)

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -49,12 +49,12 @@
           "title": "Nothing to import"
         },
         "success": {
-          "text": "Imported file",
-          "title": "The layer '{{value}}' was added to the map"
+          "text": "The layer '{{value}}' was added to the map",
+          "title": "Imported file"
         },
         "unreadable": {
-          "text": "Unreadable file",
-          "title": "The file '{{value}}' is unreadable"
+          "text": "The file '{{value}}' is unreadable",
+          "title": "Unreadable file" 
         },
         "tooLarge": {
           "text": "The file '{{value}}' is too large (Max: {{size}} MB)",


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
message duplicate [x] [710](https://github.com/infra-geo-ouverte/igo2/issues/710)
storedQuery feuilletSNRC not working fine


**What is the new behavior?**

no show count message duplicate 
storedQuery feuillet ok


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

 config to check storedQuery feuillet:

 "storedqueries": {
            "available": true,
            "title": "Feuillets SNRC",
            "searchUrl": "/ws/mffpecofor.fcgi",
            "storedquery_id": "sq250et20kFeuillet",
            "fields": 
                  {"name": "no_feuillet","defaultValue": "0"}
            ,
            "resultTitle": "feuillet",
            "params": {
                "limit": 10
          }
        }
