### PR TITLE
Fix(auth-form): Fixed disabled login submit when using autofill in Chromium browsers

### DIFF
--- a/packages/auth/src/lib/auth-form/auth-intern.component.html
+++ b/packages/auth/src/lib/auth-form/auth-intern.component.html
@@ -1,3 +1,4 @@
+<p>Test Hi</p>
 <form [formGroup]="form" role="form" (ngSubmit)="loginUser(form.value)">
   <div>
     <mat-form-field class="full-width">
@@ -11,7 +12,7 @@
     </mat-form-field>
   </div>
 
-  <button mat-raised-button type="submit" [disabled]="!form.valid || loading">{{'igo.auth.login' | translate}}</button>
+  <button mat-raised-button type="submit">{{'igo.auth.login' | translate}}</button>
   <button *ngIf="allowAnonymous" mat-raised-button class="anonymous" type="button" [disabled]="loading" (click)="loginAnonymous()">
     {{'igo.auth.accessAnonymous' | translate }}
   </button>
@@ -20,3 +21,8 @@
     <font size="3" color="red">{{error}}</font>
   </div>
 </form>
+
+<!--
+This part was removed from the below line to fix Angular issue 30616 : [disabled]="!form.valid || loading
+  <button mat-raised-button type="submit" [disabled]="!form.valid || loading">{{'igo.auth.login' | translate}}</button>*/
+-->

--- a/packages/auth/src/lib/auth-form/auth-intern.component.html
+++ b/packages/auth/src/lib/auth-form/auth-intern.component.html
@@ -12,7 +12,7 @@
     </mat-form-field>
   </div>
 
-  <button mat-raised-button type="submit">{{'igo.auth.login' | translate}}</button>
+  <button mat-raised-button type="submit || loading">{{'igo.auth.login' | translate}}</button>
   <button *ngIf="allowAnonymous" mat-raised-button class="anonymous" type="button" [disabled]="loading" (click)="loginAnonymous()">
     {{'igo.auth.accessAnonymous' | translate }}
   </button>

--- a/packages/auth/src/lib/auth-form/auth-intern.component.html
+++ b/packages/auth/src/lib/auth-form/auth-intern.component.html
@@ -1,4 +1,3 @@
-<p>Test Hi</p>
 <form [formGroup]="form" role="form" (ngSubmit)="loginUser(form.value)">
   <div>
     <mat-form-field class="full-width">
@@ -12,7 +11,7 @@
     </mat-form-field>
   </div>
 
-  <button mat-raised-button type="submit || loading">{{'igo.auth.login' | translate}}</button>
+  <button mat-raised-button type="submit">{{'igo.auth.login' | translate}}</button>
   <button *ngIf="allowAnonymous" mat-raised-button class="anonymous" type="button" [disabled]="loading" (click)="loginAnonymous()">
     {{'igo.auth.accessAnonymous' | translate }}
   </button>


### PR DESCRIPTION
…n to fix Angular issue 30616

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When a user uses autofill in Chromium browser to login, the login form does not detect the content of the fields and proceed as they were empty. By security design, it requires an action in the form by the user to allow the autofill detection (Angular issue 30616). Therefore, the validation of the form does not allow the submit button to validate. Additionnaly, users get confused when they see the submit button grayed out and think they are not allowed to login. 


**What is the new behavior?**
The validation of the form is disabled for the submit button. If the user leaves an empty field or wrong login informations, an error message is displayed but the submit button remains active. 

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
<img width="234" alt="angularbugauth" src="https://user-images.githubusercontent.com/90412486/150580992-e15d8def-6629-4e72-9c57-0d155d7754fd.PNG">