### PR TITLE
feat-fix(ogc-filter-time*)- add reset and disabled button- fix calendarYear date problem

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -6,7 +6,7 @@ import { WMSDataSourceOptions } from './wms-datasource.interface';
 import { WFSService } from './wfs.service';
 
 import { OgcFilterWriter } from '../../../filter/shared/ogc-filter';
-import { OgcFilterableDataSourceOptions, OgcFiltersOptions } from '../../../filter/shared/ogc-filter.interface';
+import { OgcFilterableDataSourceOptions, OgcFiltersOptions, OgcFilterDuringOptions } from '../../../filter/shared/ogc-filter.interface';
 import { QueryHtmlTarget } from '../../../query/shared/query.enums';
 import {
   formatWFSQueryString,
@@ -117,6 +117,12 @@ export class WMSDataSource extends DataSource {
         || initOgcFilters.radioButtons || initOgcFilters.select)
         ? false
         : true;
+      if (initOgcFilters.advancedOgcFilters){  
+          const filterDuring = initOgcFilters.filters as OgcFilterDuringOptions;
+          if(filterDuring.calendarModeYear) {
+            initOgcFilters.advancedOgcFilters = false;
+          } 
+      }
       if (initOgcFilters.pushButtons){
         initOgcFilters.pushButtons.selectorType = 'pushButton';
       }

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -117,11 +117,11 @@ export class WMSDataSource extends DataSource {
         || initOgcFilters.radioButtons || initOgcFilters.select)
         ? false
         : true;
-      if (initOgcFilters.advancedOgcFilters){  
+      if (initOgcFilters.advancedOgcFilters) {
           const filterDuring = initOgcFilters.filters as OgcFilterDuringOptions;
           if(filterDuring.calendarModeYear) {
             initOgcFilters.advancedOgcFilters = false;
-          } 
+          }
       }
       if (initOgcFilters.pushButtons){
         initOgcFilters.pushButtons.selectorType = 'pushButton';

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
@@ -63,16 +63,16 @@ export class OgcFilterButtonComponent implements OnInit {
     } else if (filter && filter.filters && filter.filters.filters) {
       return filter.filters.filters.length;
     }
-    if (filter.filters && filter.filters.operator === 'During' && filter.filters.active && 
+    if (filter.filters && filter.filters.operator === 'During' && filter.filters.active &&
       filter.interfaceOgcFilters && filter.interfaceOgcFilters[0].active) {
       const filterActiveValue = filter.interfaceOgcFilters[0];
       if (filter.filters.calendarModeYear) {
         // year mode check just year
-        if ((filterActiveValue.begin.substring(0,4) !== this.options.minDate.substring(0,4) ) || 
+        if ((filterActiveValue.begin.substring(0,4) !== this.options.minDate.substring(0,4) ) ||
         (filterActiveValue.end.substring(0,4) !== this.options.maxDate.substring(0,4) )) {
           cnt += 1;
         }
-      } else if ((filterActiveValue.begin != this.options.minDate) || (filterActiveValue.end != this.options.maxDate)) {
+      } else if ((filterActiveValue.begin !== this.options.minDate) || (filterActiveValue.end !== this.options.maxDate)) {
         cnt += 1;
       }
     }

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
@@ -63,6 +63,19 @@ export class OgcFilterButtonComponent implements OnInit {
     } else if (filter && filter.filters && filter.filters.filters) {
       return filter.filters.filters.length;
     }
+    if (filter.filters && filter.filters.operator === 'During' && filter.filters.active && 
+      filter.interfaceOgcFilters && filter.interfaceOgcFilters[0].active) {
+      const filterActiveValue = filter.interfaceOgcFilters[0];
+      if (filter.filters.calendarModeYear) {
+        // year mode check just year
+        if ((filterActiveValue.begin.substring(0,4) !== this.options.minDate.substring(0,4) ) || 
+        (filterActiveValue.end.substring(0,4) !== this.options.maxDate.substring(0,4) )) {
+          cnt += 1;
+        }
+      } else if ((filterActiveValue.begin != this.options.minDate) || (filterActiveValue.end != this.options.maxDate)) {
+        cnt += 1;
+      }
+    }
     return cnt > 0 ? cnt : undefined;
   }
 

--- a/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.scss
@@ -69,7 +69,3 @@
     margin: unset;
   }
 
-  igo-ogc-filter-time ::ng-deep .datetime-input {
-    width: 140px;
-    margin: 10px 0px 5px 10px;
-  }

--- a/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.ts
@@ -426,7 +426,7 @@ export class OgcFilterSelectionComponent implements OnInit {
         });
       }
     }
-    if (this.isTemporalOperator()) {
+    if (this.isTemporalOperator() && this._currentFilter.active) {
       conditions.push(this.datasource.options.ogcFilters.interfaceOgcFilters[0]);
     }
     if (conditions.length >= 1) {

--- a/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.html
+++ b/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.html
@@ -1,5 +1,4 @@
 <div class="datetime-container">
-
   <mat-slide-toggle 
     *ngIf="this.currentFilter.sliderOptions?.enabled"
     [(ngModel)]="sliderMode"
@@ -20,158 +19,197 @@
   </div>
 
   <div *ngIf="!sliderMode">
-            
-      <div class="year-input-container" *ngIf="calendarTypeYear">
-        <!-- to emulate a year-picker, 2 input: first input to show user just year and second input hiden and bind 
-          with the datepicker  -->
-        <mat-form-field  class="year-input">
-          <mat-label>{{'igo.geo.timeFilter.startYear'| translate}}</mat-label>
-          <input 
-            matInput 
-            class="year-input-only-year" 
-            value="{{onlyYearBegin}}"
-            (change)= "yearOnlyInputChange($event, beginDatepicker, 'begin')"
-            >
-          <mat-datepicker-toggle matSuffix [for]="beginDatepicker"></mat-datepicker-toggle>
-    
-          <mat-datepicker
-            panelClass="datepicker-year"
-            #beginDatepicker
-            [startView]="calendarView()"
-            [startAt]="beginValue"
-            (yearSelected)="yearSelected($event, beginDatepicker, 'begin')"
-            >
-          </mat-datepicker>
 
-          <input #beginYear
-            class= "year-input-hide"
-            matInput
-            [matDatepicker]="beginDatepicker"
-            enabled= false
-            readonly= true
-            [value]="beginValue?beginValue:handleDate(datasource.options.minDate)"
-            [min]="handleDate(datasource.options.minDate)"
-            [max]="(endValue && (!restrictedToStep()))?endValue:handleDate(datasource.options.maxDate)"
-            >
- 
-        </mat-form-field>
-
-        <mat-form-field  class="year-input">
-          <mat-label>{{'igo.geo.timeFilter.endYear'| translate}}</mat-label>
-          <input 
-            matInput 
-            class="year-input-only-year" 
-            value="{{onlyYearEnd}}">
-          <mat-datepicker-toggle matSuffix [for]="endDatepicker"></mat-datepicker-toggle>
-          <mat-datepicker
-            panelClass="datepicker-year"
-            #endDatepicker
-            [startView]="calendarView()"
-            [startAt]="endValue"
-            (yearSelected)="yearSelected($event, endDatepicker, 'end')"
-            >
-          </mat-datepicker>
-
-          <input #endYear
-            class= "year-input-hide"
-            matInput
-            [matDatepicker]="endDatepicker"
-            enabled= false
-            readonly= true
-            [value]="endValue?endValue:handleDate(datasource.options.maxDate)"
-            [min]="beginValue?beginValue:handleDate(datasource.options.minDate)"
-            [max]="handleDate(datasource.options.maxDate)"
-            >
-        </mat-form-field>
-
-      </div>
-
-      <div class="datetime-input" *ngIf="calendarType()!=='year'">
-      <mat-form-field class="date-input">
-        <mat-datepicker-toggle matSuffix [for]="beginDatepicker"></mat-datepicker-toggle>
-        <input #begin
+    <div class="year-input-container" *ngIf="calendarTypeYear">
+      <!-- to emulate a year-picker, 2 input: first input to show user just year and second input hiden and bind 
+        with the datepicker  -->
+      <mat-form-field  class="year-input">
+        <mat-label>{{'igo.geo.timeFilter.startYear'| translate}}</mat-label>
+        <input
           matInput
-          [matDatepicker]="beginDatepicker"
-          [placeholder]="'igo.geo.timeFilter.startDate' | translate"
-          [attr.disabled]="!currentFilter.active"
-          (dateChange)="changeTemporalProperty(begin.value, 1)"
-          [matDatepickerFilter]="dateFilter.bind(this, 'begin')"
-          [value]="beginValue?beginValue:handleDate(datasource.options.minDate)"
-          [min]="handleDate(datasource.options.minDate)"
-          [max]="(endValue && (!restrictedToStep()))?endValue:handleDate(datasource.options.maxDate)" >
-        <span class="filler"></span>
+          class="year-input-only-year"
+          value="{{onlyYearBegin}}"
+          (change)= "yearOnlyInputChange($event, beginDatepicker, 'begin')"
+          [disabled]= "filterStateDisable"
+          >
+        <mat-datepicker-toggle matSuffix [for]="beginDatepicker" [disabled]="filterStateDisable"></mat-datepicker-toggle>
+  
         <mat-datepicker
+          panelClass="datepicker-year"
           #beginDatepicker
           [startView]="calendarView()"
           [startAt]="beginValue"
           (yearSelected)="yearSelected($event, beginDatepicker, 'begin')"
-          (monthSelected)="monthSelected($event, beginDatepicker, 'begin')">
+          >
         </mat-datepicker>
+
+        <input #beginYear
+          class= "year-input-hide"
+          matInput
+          [matDatepicker]="beginDatepicker"
+          enabled= false
+          readonly= true
+          [value]="beginValue?beginValue:handleDate(datasource.options.minDate)"
+          [min]="handleDate(datasource.options.minDate)"
+          [max]="(endValue && (!restrictedToStep()))?endValue:handleDate(datasource.options.maxDate)"
+          >
       </mat-form-field>
-      <div class="time-input">
-        <mat-form-field class="hour-input" *ngIf="calendarType()==='datetime'">
-          <mat-label>{{'igo.geo.timeFilter.hour' | translate}}</mat-label>
-          <mat-select
-            [formControl]="beginHourFormControl"
-            [attr.disabled]="!currentFilter.active"
-            (selectionChange)="changeTemporalProperty(begin.value, 1)">
-            <mat-option *ngFor="let hour of beginHours" [value]="hour">{{hour}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="minute-input" *ngIf="calendarType()==='datetime'">
-          <mat-label>{{'igo.geo.timeFilter.minute' | translate}}</mat-label>
-          <mat-select
-            [formControl]="beginMinuteFormControl"
-            [attr.disabled]="!currentFilter.active"
-            (selectionChange)="changeTemporalProperty(begin.value, 1)">
-            <mat-option *ngFor="let minute of beginMinutes" [value]="minute">{{minute}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
+
+      <mat-form-field  class="year-input">
+        <mat-label>{{'igo.geo.timeFilter.endYear'| translate}}</mat-label>
+        <input
+          matInput
+          class="year-input-only-year"
+          value="{{onlyYearEnd}}"
+          (change)= "yearOnlyInputChange($event, endDatepicker, 'end')"
+          [disabled] = "filterStateDisable">
+        <mat-datepicker-toggle matSuffix [for]="endDatepicker" [disabled]="filterStateDisable"></mat-datepicker-toggle>
+        <mat-datepicker
+          panelClass="datepicker-year"
+          #endDatepicker
+          [startView]="calendarView()"
+          [startAt]="endValue"
+          (yearSelected)="yearSelected($event, endDatepicker, 'end')"
+          >
+        </mat-datepicker>
+
+        <input #endYear
+          class= "year-input-hide"
+          matInput
+          [matDatepicker]="endDatepicker"
+          enabled= false
+          readonly= true
+          [value]="endValue?endValue:handleDate(datasource.options.maxDate)"
+          [min]="beginValue?beginValue:handleDate(datasource.options.minDate)"
+          [max]="handleDate(datasource.options.maxDate)"
+          >
+      </mat-form-field>
+      <button class="reset-button" 
+        mat-icon-button
+        color="primary" 
+        (click)="resetFilter()" 
+        [matTooltip]="'igo.geo.filter.resetFilters' | translate" 
+        [disabled]= "filterStateDisable">
+        <mat-icon svgIcon="{{resetIcon}}"></mat-icon>
+      </button>
+      <mat-slide-toggle 
+        class='toggle-filter-state' 
+        (change)="toggleFilterState()" 
+        [matTooltip]="'igo.geo.filter.toggleFilterState' | translate" 
+        tooltip-position="below" 
+        matTooltipShowDelay="500"
+        [checked]="!filterStateDisable">
+      </mat-slide-toggle>
+
     </div>
 
-    <div class="datetime-input" *ngIf="!restrictedToStep() && calendarType()!=='year'">
-      <mat-form-field class="date-input">
-        <mat-datepicker-toggle matSuffix [for]="endDatepicker"></mat-datepicker-toggle>
-          <input #end
+    <div class="datetime-input-container" *ngIf="calendarType()!=='year'">
+      <div class="datetime-input">
+        <mat-form-field class="date-input">
+          <mat-datepicker-toggle matSuffix [for]="beginDatepicker" [disabled]= "filterStateDisable"></mat-datepicker-toggle>
+          <input #begin
             matInput
-            [matDatepicker]="endDatepicker"
-            [placeholder]="'igo.geo.timeFilter.endDate' | translate"
+            [matDatepicker]="beginDatepicker"
+            [placeholder]="'igo.geo.timeFilter.startDate' | translate"
             [attr.disabled]="!currentFilter.active"
-            (dateChange)="changeTemporalProperty(end.value, 2)"
-            [matDatepickerFilter]="dateFilter.bind(this, 'end')"
-            [value]="endValue?endValue:handleDate(datasource.options.maxDate)"
-            [min]="beginValue?beginValue:handleDate(datasource.options.minDate)"
-            [max]="handleDate(datasource.options.maxDate)" >
+            (dateChange)="changeTemporalProperty(begin.value, 1)"
+            [matDatepickerFilter]="dateFilter.bind(this, 'begin')"
+            [value]="beginValue?beginValue:handleDate(datasource.options.minDate)"
+            [min]="handleDate(datasource.options.minDate)"
+            [max]="(endValue && (!restrictedToStep()))?endValue:handleDate(datasource.options.maxDate)" 
+            [disabled]= "filterStateDisable">
           <span class="filler"></span>
-          <mat-datepicker #endDatepicker
+          <mat-datepicker
+            #beginDatepicker
             [startView]="calendarView()"
-            [startAt]="endValue"
-            (yearSelected)="yearSelected($event, endDatepicker, 'end')"
-            (monthSelected)="monthSelected($event, endDatepicker, 'end')">
-        </mat-datepicker>
-      </mat-form-field>
-      <div class="time-input">
-        <mat-form-field class="hour-input" *ngIf="calendarType()==='datetime'" >
-          <mat-label>{{'igo.geo.timeFilter.hour' | translate}}</mat-label>
-          <mat-select
-            [formControl]="endHourFormControl"
-            [attr.disabled]="!currentFilter.active"
-            (selectionChange)="changeTemporalProperty(end.value, 2)">
-            <mat-option *ngFor="let hour of endHours" [value]="hour">{{hour}}</mat-option>
-          </mat-select>
+            [startAt]="beginValue"
+            (yearSelected)="yearSelected($event, beginDatepicker, 'begin')"
+            (monthSelected)="monthSelected($event, beginDatepicker, 'begin')">
+          </mat-datepicker>
         </mat-form-field>
-        <mat-form-field class="minute-input" *ngIf="calendarType()==='datetime'">
-          <mat-label>{{'igo.geo.timeFilter.minute' | translate}}</mat-label>
-          <mat-select
-            [formControl]="endMinuteFormControl"
-            [attr.disabled]="!currentFilter.active"
-            (selectionChange)="changeTemporalProperty(end.value, 2)">
-            <mat-option *ngFor="let minute of endMinutes" [value]="minute">{{minute}}</mat-option>
-          </mat-select>
-        </mat-form-field>
+
+        <div class="time-input">
+          <mat-form-field class="hour-input" *ngIf="calendarType()==='datetime'">
+            <mat-label>{{'igo.geo.timeFilter.hour' | translate}}</mat-label>
+            <mat-select
+              [formControl]="beginHourFormControl"
+              [attr.disabled]="!currentFilter.active"
+              (selectionChange)="changeTemporalProperty(begin.value, 1)">
+              <mat-option *ngFor="let hour of beginHours" [value]="hour">{{hour}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="minute-input" *ngIf="calendarType()==='datetime'">
+            <mat-label>{{'igo.geo.timeFilter.minute' | translate}}</mat-label>
+            <mat-select
+              [formControl]="beginMinuteFormControl"
+              [attr.disabled]="!currentFilter.active"
+              (selectionChange)="changeTemporalProperty(begin.value, 1)">
+              <mat-option *ngFor="let minute of beginMinutes" [value]="minute">{{minute}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
       </div>
+
+      <div class="datetime-input" *ngIf="!restrictedToStep()">
+        <mat-form-field class="date-input">
+          <mat-datepicker-toggle matSuffix [for]="endDatepicker" [disabled]= "filterStateDisable"></mat-datepicker-toggle>
+            <input #end
+              matInput
+              [matDatepicker]="endDatepicker"
+              [placeholder]="'igo.geo.timeFilter.endDate' | translate"
+              [attr.disabled]="!currentFilter.active"
+              (dateChange)="changeTemporalProperty(end.value, 2)"
+              [matDatepickerFilter]="dateFilter.bind(this, 'end')"
+              [value]="endValue?endValue:handleDate(datasource.options.maxDate)"
+              [min]="beginValue?beginValue:handleDate(datasource.options.minDate)"
+              [max]="handleDate(datasource.options.maxDate)" 
+              [disabled]= "filterStateDisable">
+            <span class="filler"></span>
+            <mat-datepicker #endDatepicker
+              [startView]="calendarView()"
+              [startAt]="endValue"
+              (yearSelected)="yearSelected($event, endDatepicker, 'end')"
+              (monthSelected)="monthSelected($event, endDatepicker, 'end')">
+          </mat-datepicker>
+        </mat-form-field>
+
+        <div class="time-input">
+          <mat-form-field class="hour-input" *ngIf="calendarType()==='datetime'" >
+            <mat-label>{{'igo.geo.timeFilter.hour' | translate}}</mat-label>
+            <mat-select
+              [formControl]="endHourFormControl"
+              [attr.disabled]="!currentFilter.active"
+              (selectionChange)="changeTemporalProperty(end.value, 2)">
+              <mat-option *ngFor="let hour of endHours" [value]="hour">{{hour}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="minute-input" *ngIf="calendarType()==='datetime'">
+            <mat-label>{{'igo.geo.timeFilter.minute' | translate}}</mat-label>
+            <mat-select
+              [formControl]="endMinuteFormControl"
+              [attr.disabled]="!currentFilter.active"
+              (selectionChange)="changeTemporalProperty(end.value, 2)">
+              <mat-option *ngFor="let minute of endMinutes" [value]="minute">{{minute}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </div>
+
+      <button class="reset-button" 
+        mat-icon-button color="primary"
+        (click)="resetFilter()" 
+        [matTooltip]="'igo.geo.filter.resetFilters' | translate" 
+        [disabled]= "filterStateDisable">
+        <mat-icon svgIcon="{{resetIcon}}"></mat-icon>
+      </button>
+      <mat-slide-toggle 
+        class="toggle-filter-state" 
+        (change)="toggleFilterState()" 
+        tooltip-position="below" 
+        matTooltipShowDelay="500"
+        [matTooltip]="'igo.geo.filter.toggleFilterState' | translate" 
+        [checked]= "!filterStateDisable">
+      </mat-slide-toggle>
     </div>
   </div>
-
 </div>

--- a/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.scss
+++ b/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.scss
@@ -1,3 +1,4 @@
+@import '../../../../../core/src/style/partial/media';
 
 ::ng-deep input {
   text-align: center !important;
@@ -10,35 +11,41 @@
 
 .datetime-input {
   display: inline-block;
-  margin: 5px 25px;
-}
+  width: 117px; 
+  margin: 10px 0px 5px 10px;
 
-.year-input-container {
-  display: inline-block;
-  margin: 5px 25px;
+  @include mobile {
+    width: 36%;
+    margin: 0px 0px;
+  }
 }
 
 .date-input {
-  width: 120px;
+  width: 100px;
   margin-right: 25px;
 }
 
 .time-input {
-  display: inherit;
   margin-right: 25px;
+  
+  @include mobile {
+    margin-right: 5px;
+  }
 }
 
 .hour-input, .minute-input {
-  width: 40px;
-}
-
-.minute-input {
-  margin-left: 10px;
+  width: 35px;
+  margin-left: 7px;
 }
 
 .year-input {
-  width: 120px;
-  margin-right: 25px;
+  width: 98px;
+  margin: 10px 18px 5px 12px;
+  
+  @include mobile {
+    width: 33%;
+    margin: 0px 0px 0px 10px;
+  }
 }
 
 .year-input-hide {
@@ -53,7 +60,24 @@
   margin-right: 25px;
 }
 
-// to disable selection the month and day for year picker
+.reset-button {
+  width: 25px;
+  
+  @include mobile {
+    padding-left: 6px;
+  }
+}
+
+.toggle-filter-state {
+  padding-left: 15px;
+
+  @include mobile {
+    padding-left: 7px;
+  }
+}
+
+
+// to disable selection month and day for year picker
 ::ng-deep .datepicker-year ::ng-deep .mat-calendar-arrow {
   display: none;
 }

--- a/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.ts
@@ -526,7 +526,7 @@ export class OgcFilterTimeComponent implements OnInit {
       this.filterStateDisable = false;
     }
     if(this.calendarType() === 'datetime') {
-      if (this.filterStateDisable == true) {
+      if (this.filterStateDisable === true) {
         this.beginHourFormControl.disable();
         this.beginMinuteFormControl.disable();
         this.endHourFormControl.disable();
@@ -541,7 +541,7 @@ export class OgcFilterTimeComponent implements OnInit {
   }
   getDateFromStringWithoutTime(stringDate: string): Date {
     // warning create date with no time make a date UTC with TZ and the date create maybe not the same year, month and day
-    // exemple: 
+    // exemple:
     // new Date('2022-01-01') -> Fri Dec 31 2021 19:00:00 GMT-0500 (heure normale de l’Est nord-américain)
     // to create same date as string, add time 00 in the creation
     // new Date('2022-01-01 00:00:00') -> Sat Jan 01 2022 00:00:00 GMT-0500 (heure normale de l’Est nord-américain)
@@ -550,7 +550,7 @@ export class OgcFilterTimeComponent implements OnInit {
     let day = '01';
     if (stringDate.length === 10) {
        const dateItems = stringDate.split('-');
-        if (dateItems.length != 3) {
+        if (dateItems.length !== 3) {
           throw new Error('Error in config date begin-end for ogcFilter: Date without time format need to be YYYY-MM-DD or YYYY');
         } else {
           year = dateItems[0];
@@ -586,7 +586,7 @@ export class OgcFilterTimeComponent implements OnInit {
       maxDefaultDate = this.getDateFromStringWithoutTime(maxDefaultISOString);
     } else {
       minDefaultDate= this.parseFilter(filterOriginConfig.begin);
-      maxDefaultDate= this.parseFilter(filterOriginConfig.end);    
+      maxDefaultDate= this.parseFilter(filterOriginConfig.end);
       minDefaultISOString = minDefaultDate.toISOString();
       maxDefaultISOString = maxDefaultDate.toISOString();
     }

--- a/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-time/ogc-filter-time.component.ts
@@ -566,7 +566,6 @@ export class OgcFilterTimeComponent implements OnInit {
   }
 
   resetFilter() {
-    debugger;
     let filterOriginConfig = this.datasource.options.ogcFilters.filters as OgcFilterDuringOptions;
 
     let minDefaultDate;
@@ -585,8 +584,8 @@ export class OgcFilterTimeComponent implements OnInit {
       minDefaultDate = this.getDateFromStringWithoutTime(minDefaultISOString);
       maxDefaultDate = this.getDateFromStringWithoutTime(maxDefaultISOString);
     } else {
-      minDefaultDate= this.parseFilter(filterOriginConfig.begin);
-      maxDefaultDate= this.parseFilter(filterOriginConfig.end);
+      minDefaultDate = this.parseFilter(filterOriginConfig.begin);
+      maxDefaultDate = this.parseFilter(filterOriginConfig.end);
       minDefaultISOString = minDefaultDate.toISOString();
       maxDefaultISOString = maxDefaultDate.toISOString();
     }

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -850,6 +850,8 @@ export class OgcFilterWriter {
     processedFilter: string,
     layersOrTypenames: string
   ): string {
+
+    if (!processedFilter) {return undefined};
     let appliedFilter = '';
     if (processedFilter.length === 0 && layersOrTypenames.indexOf(',') === -1) {
       appliedFilter = processedFilter;
@@ -872,6 +874,8 @@ export class OgcFilterWriter {
   public parseFilterOptionDate(value: string, defaultValue?: string): string {
     if (!value) {
       return defaultValue;
+    } else if (value === 'today') {
+      return undefined;
     } else if (moment(value).isValid()) {
       return value;
     } else {

--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -851,7 +851,7 @@ export class OgcFilterWriter {
     layersOrTypenames: string
   ): string {
 
-    if (!processedFilter) {return undefined};
+    if (!processedFilter) {return undefined;};
     let appliedFilter = '';
     if (processedFilter.length === 0 && layersOrTypenames.indexOf(',') === -1) {
       appliedFilter = processedFilter;

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -188,7 +188,7 @@
         "selectField": "Choose a field"
       },
       "filter": {
-        "resetFilters": "(Apply no filters)",
+        "resetFilters": "Reset default values",
         "addFilter": "Add an empty filter to the current list",
         "removeFilter": "Remove the current filter from the filters's list",
         "toggleFilterState": "Enable/disable the current filter",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -187,7 +187,7 @@
         "selectField": "Choisir un champ"
       },
       "filter": {
-        "resetFilters": "réinitialiser valeurs par defaut",
+        "resetFilters": "réinitialiser valeurs par défaut",
         "addFilter": "Ajouter un filtre vide à la liste courante",
         "removeFilter": "Supprimer le présent filtre à la liste des filtres",
         "toggleFilterState": "Activer/désactiver le présent filtre",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -187,7 +187,7 @@
         "selectField": "Choisir un champ"
       },
       "filter": {
-        "resetFilters": "réinitialiser valeurs par défaut",
+        "resetFilters": "Réinitialiser les valeurs par défaut",
         "addFilter": "Ajouter un filtre vide à la liste courante",
         "removeFilter": "Supprimer le présent filtre à la liste des filtres",
         "toggleFilterState": "Activer/désactiver le présent filtre",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -187,7 +187,7 @@
         "selectField": "Choisir un champ"
       },
       "filter": {
-        "resetFilters": "(Appliquer aucun filtre)",
+        "resetFilters": "réinitialiser valeurs par defaut",
         "addFilter": "Ajouter un filtre vide à la liste courante",
         "removeFilter": "Supprimer le présent filtre à la liste des filtres",
         "toggleFilterState": "Activer/désactiver le présent filtre",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -183,7 +183,6 @@
           "Contains": "Retourne les entités complètement contenues par la géométrie fournie (Contains)"
         }
       },
-      
       "sourceFields": {
         "selectField": "Choisir un champ"
       },

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -183,6 +183,7 @@
           "Contains": "Retourne les entités complètement contenues par la géométrie fournie (Contains)"
         }
       },
+      
       "sourceFields": {
         "selectField": "Choisir un champ"
       },


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
[694] (https://github.com/infra-geo-ouverte/igo2/issues/694) (Done only for OGC-filter)
[695](https://github.com/infra-geo-ouverte/igo2/issues/695)
[467](https://github.com/infra-geo-ouverte/igo2/issues/467)
[328](https://github.com/infra-geo-ouverte/igo2/issues/328)

**What is the new behavior?**

Only for OGCFilterTime
- add reset and disabled button
- fix badge in layer option when ogcTime is actif
- fix problem in calendarYearMode when no time is give in date creation
- fix value 'today' trow angular warning Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

**Other information**:
@matrottier maybe you can test thatPR with your ogcFilterTime config. 
