### PR TITLE
(fix): bad result filter in table view #986

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -21,6 +21,7 @@ import { AuthInterceptor } from '@igo2/auth';
 
 export class WFSDataSource extends DataSource {
   public ol: olSourceVector<OlGeometry>;
+  public mostRecentIdCallOGCFilter: number = 0;
 
   set ogcFilters(value: OgcFiltersOptions) {
     (this.options as OgcFilterableDataSourceOptions).ogcFilters = value;
@@ -85,6 +86,7 @@ export class WFSDataSource extends DataSource {
 
   setOgcFilters(ogcFilters: OgcFiltersOptions, triggerEvent: boolean = false) {
     this.ogcFilters = ogcFilters;
+    this.mostRecentIdCallOGCFilter += 1;
     if (triggerEvent) {
       this.ogcFilters$.next(this.ogcFilters);
     }

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -313,6 +313,7 @@ export class VectorLayer extends Layer {
     threshold: number,
     success, failure) {
 
+    const idAssociatedCall = (this.dataSource as WFSDataSource).mostRecentIdCallOGCFilter;
     const xhr = new XMLHttpRequest();
     const alteredUrlWithKeyAuth = interceptor.alterUrlWithKeyAuth(url);
     let modifiedUrl = url;
@@ -338,7 +339,11 @@ export class VectorLayer extends Layer {
         /*if (features.length === 0 || features.length < threshold ) {
           console.log('No more data to download at this resolution');
         }*/
-        vectorSource.addFeatures(features);
+        // Avoids retrieving an older call that took longer to be process
+        if (idAssociatedCall === (this.dataSource as WFSDataSource).mostRecentIdCallOGCFilter)
+        {
+            vectorSource.addFeatures(features);
+        }
         success(features);
       } else {
         onError();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
The entities displayed in the table do not match the filter. A previous query is used instead of the last query in the table view. 
This results from a return from an observable having taken longer to process and which returns after the last call.

Ex: a 2016 value is entered manually. 20 is already in place and the user successively enters the numbers 1 and 6. 201 and launched as a filter then is followed 2016. 2016 is processed faster than 201. 201 is applied to the tabular view.

**What is the new behavior?**
Behaviour: The entities displayed in the table correspond to the last filter requested.
In the code: Avoids retrieving an older call that took longer to be process.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
refer to issues #986