### PR TITLE
feat(network): prevent showing 2 different network state simultaneously

### DIFF
--- a/packages/core/src/lib/network/network.service.ts
+++ b/packages/core/src/lib/network/network.service.ts
@@ -13,6 +13,7 @@ export class NetworkService implements OnDestroy {
   private stateChangeEventEmitter = new EventEmitter<ConnectionState>();
   private onlineSubscription: Subscription;
   private offlineSubscription: Subscription;
+  private previousMessageId;
 
   private state: ConnectionState = {
     connection: window.navigator.onLine
@@ -27,19 +28,27 @@ export class NetworkService implements OnDestroy {
 
   private checkNetworkState() {
     this.onlineSubscription = fromEvent(window, 'online').subscribe(() => {
+      if (this.previousMessageId) {
+        this.messageService.remove(this.previousMessageId);
+      }
       const translate = this.injector.get(LanguageService).translate;
       const message = translate.instant('igo.core.network.online.message');
       const title = translate.instant('igo.core.network.online.title');
-      this.messageService.info(message, title);
+      const messageObj = this.messageService.info(message, title);
+      this.previousMessageId = messageObj.toastId;
       this.state.connection = true;
       this.emitEvent();
     });
 
     this.offlineSubscription = fromEvent(window, 'offline').subscribe(() => {
+      if (this.previousMessageId) {
+        this.messageService.remove(this.previousMessageId);
+      }
       const translate = this.injector.get(LanguageService).translate;
       const message = translate.instant('igo.core.network.offline.message');
       const title = translate.instant('igo.core.network.offline.title');
-      this.messageService.info(message, title);
+      const messageObj = this.messageService.info(message, title);
+      this.previousMessageId = messageObj.toastId;
       this.state.connection = false;
       this.emitEvent();
     });

--- a/packages/geo/src/lib/map/shared/mapOffline.directive.ts
+++ b/packages/geo/src/lib/map/shared/mapOffline.directive.ts
@@ -35,6 +35,8 @@ export class MapOfflineDirective implements AfterViewInit {
     return this.component.map;
   }
 
+  private previousMessageId;
+
   constructor(
     component: MapBrowserComponent,
     private networkService: NetworkService,
@@ -46,18 +48,23 @@ export class MapOfflineDirective implements AfterViewInit {
 
   ngAfterViewInit() {
     this.map.offlineButtonToggle$.subscribe((offlineButtonToggle: boolean) => {
+      if (this.previousMessageId) {
+        this.messageService.remove(this.previousMessageId);
+      }
       this.offlineButtonStatus = offlineButtonToggle;
       const translate = this.languageService.translate;
       if (this.offlineButtonStatus && this.networkState.connection) {
         const message = translate.instant('igo.geo.network.offline.message');
         const title = translate.instant('igo.geo.network.offline.title');
-        this.messageService.info(message, title);
+        const messageObj = this.messageService.info(message, title);
+        this.previousMessageId = messageObj.toastId;
         this.offlineButtonState.connection = false;
         this.changeLayer();
       } else if (!this.offlineButtonStatus && !this.networkState.connection) {
         const message = translate.instant('igo.geo.network.offline.message');
         const title = translate.instant('igo.geo.network.offline.title');
-        this.messageService.info(message, title);
+        const messageObj = this.messageService.info(message, title);
+        this.previousMessageId = messageObj.toastId;
         this.offlineButtonState.connection = false;
         this.changeLayer();
       } else if (!this.offlineButtonStatus && this.networkState.connection) {
@@ -71,7 +78,10 @@ export class MapOfflineDirective implements AfterViewInit {
         titleObs.subscribe((title1: string) => {
           title = title1;
         });
-        this.messageService.info(message, title);
+        if (message) {
+          const messageObj = this.messageService.info(message, title);
+          this.previousMessageId = messageObj.toastId;
+        }
         this.offlineButtonState.connection = true;
         this.changeLayer();
       }
@@ -131,7 +141,7 @@ export class MapOfflineDirective implements AfterViewInit {
           ) {
             return;
           }
-          // layer.ol.getSource().setUrl(sourceOptions.pathOffline);
+          (layer.ol.getSource() as any).setUrl(sourceOptions.pathOffline);
         } else if (
           (sourceOptions.pathOffline &&
             this.networkState.connection === false) ||
@@ -144,7 +154,7 @@ export class MapOfflineDirective implements AfterViewInit {
           ) {
             return;
           }
-          // layer.ol.getSource().setUrl(sourceOptions.url);
+          (layer.ol.getSource() as any).setUrl(sourceOptions.url);
         } else {
           if (
             this.networkState.connection === false ||


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Multiple message (toast) are show on network changes,


**What is the new behavior?**
Prevent it. Only keep the current network state in toast. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
