### PR TITLE
fix: Don't fail when creating form fields or groups without validator

### DIFF
--- a/packages/common/src/lib/form/shared/form.service.ts
+++ b/packages/common/src/lib/form/shared/form.service.ts
@@ -35,8 +35,10 @@ export class FormService {
       control.addControl(field.name, field.control);
     });
 
-    const validators = this.getValidators(options.validator); // convert string to actual validator
-    control.setValidators(validators);
+    if (options.validator) {
+      const validators = this.getValidators(options.validator); // convert string to actual validator
+      control.setValidators(validators);
+    }
 
     return Object.assign({}, config, {fields, control}) as FormFieldGroup;
   }
@@ -49,8 +51,10 @@ export class FormService {
     };
     const control = this.formBuilder.control(state);
 
-    const validators = this.getValidators(options.validator); // convert string to actual validator
-    control.setValidators(validators);
+    if (options.validator) {
+      const validators = this.getValidators(options.validator); // convert string to actual validator
+      control.setValidators(validators);
+    }
 
     return Object.assign({type: 'text'}, config, {control}) as FormField;
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
A form field or group without validator in its options will raise an error when created.


**What is the new behavior?**
No error is raised and the field or group is created normally.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
