### PR TITLE
fix(ogcFilters): fix advancedOgcFilters when filters not defined

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -117,7 +117,7 @@ export class WMSDataSource extends DataSource {
         || initOgcFilters.radioButtons || initOgcFilters.select)
         ? false
         : true;
-      if (initOgcFilters.advancedOgcFilters) {
+      if (initOgcFilters.advancedOgcFilters && initOgcFilters.filters) {
           const filterDuring = initOgcFilters.filters as OgcFilterDuringOptions;
           if(filterDuring.calendarModeYear) {
             initOgcFilters.advancedOgcFilters = false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When ogcFilters.filters is not defined, but sourceFields is (regular advanced ogcFilters), datasource does not load


**What is the new behavior?**
When ogcFilters.filters is not defined, but sourceFields is (regular advanced ogcFilters), datasource does load with specified advanced filters


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
