### PR TITLE
refactor(search-results): stop propagation from search-add-button

### DIFF
--- a/packages/geo/src/lib/search/search-results/search-results-add-button.component.html
+++ b/packages/geo/src/lib/search/search-results/search-results-add-button.component.html
@@ -1,4 +1,5 @@
 <button
+igoStopPropagation
 (mouseenter)="onMouseEvent($event)" (mouseleave)="onMouseEvent($event)"
 *ngIf="layer.meta.dataType === 'Layer'"
 mat-icon-button


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Feature details popup show also on search-add-button click. It causes recurrent overflow and display problems.

**What is the new behavior?**
Feature details popup doesn't show on search-add-button click, only on the search-results selection.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

