### PR TITLE
feat(layerSync): prevent refresh of linked layer if applied OGC filters are the same

### DIFF
--- a/packages/geo/src/lib/layer/utils/layerSync-watcher.ts
+++ b/packages/geo/src/lib/layer/utils/layerSync-watcher.ts
@@ -172,7 +172,9 @@ export class LayerSyncWatcher extends Watcher {
                         const layerType = layerToApply.ol.getProperties().sourceOptions.type;
                         (layerToApply.dataSource as OgcFilterableDataSource).setOgcFilters(ogcFilters, false);
                         if (layerType === 'wfs') {
-                            layerToApply.ol.getSource().refresh();
+                            if (ogcFilters !== (layerToApply.dataSource as OgcFilterableDataSource).ogcFilters$.value) {
+                                layerToApply.ol.getSource().refresh();
+                            }
                         }
                         if (layerType === 'wms') {
                             let appliedOgcFilter;
@@ -200,8 +202,10 @@ export class LayerSyncWatcher extends Watcher {
                             l.bidirectionnal !== false && l.linkedIds.indexOf(currentLinkedId) !== -1) {
                             const layerType = layer.ol.getProperties().sourceOptions.type;
                             if (layerType === 'wfs') {
-                                (layer.dataSource as OgcFilterableDataSource).setOgcFilters(ogcFilters, true);
-                                layer.ol.getSource().refresh();
+                                if (ogcFilters !== (layer.dataSource as OgcFilterableDataSource).ogcFilters$.value) {
+                                    (layer.dataSource as OgcFilterableDataSource).setOgcFilters(ogcFilters, true);
+                                    layer.ol.getSource().refresh();
+                                }                                
                             }
                             if (layerType === 'wms') {
                                 let appliedOgcFilter;

--- a/packages/geo/src/lib/layer/utils/layerSync-watcher.ts
+++ b/packages/geo/src/lib/layer/utils/layerSync-watcher.ts
@@ -205,7 +205,7 @@ export class LayerSyncWatcher extends Watcher {
                                 if (ogcFilters !== (layer.dataSource as OgcFilterableDataSource).ogcFilters$.value) {
                                     (layer.dataSource as OgcFilterableDataSource).setOgcFilters(ogcFilters, true);
                                     layer.ol.getSource().refresh();
-                                }                                
+                                }
                             }
                             if (layerType === 'wms') {
                                 let appliedOgcFilter;


### PR DESCRIPTION
…r are the same

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Linked wfs layer were refreshed despite the provided ogcfilters were identical to the previous. 


**What is the new behavior?**
Prevent refresh for the same ogcfilters.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
