### PR TITLE
fix(entity-table): fix formControl (edition) with no properties entity

### DIFF
--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -278,7 +278,7 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
    * More than one row can be edited at the same time
    */
   private enableEdit(record: EntityRecord<any>) {
-    const item = record.entity.properties;
+    const item = record.entity.properties || record.entity;
     this.template.columns.forEach(column => {
       column.title = column.validation?.mandatory && !column.title.includes('*') ? column.title + ' *' : column.title;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When an entity has no properties, error was raised at the formControl instanciation for edition mode


**What is the new behavior?**
When an entity has no properties, the formControl is created with the entity directly


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
