### PR TITLE
fix(wms-workspace): duplicated query on non exposed workspace

### DIFF
--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -122,7 +122,7 @@ export class WmsWorkspaceService {
           queryable: true,
           relations: dataSource.options.relations,
           queryTitle: (dataSource.options as QueryableDataSourceOptions).queryTitle,
-          queryFormatAsWms: (dataSource.options as QueryableDataSourceOptions).queryFormatAsWms,
+          queryFormatAsWms: layer.options.workspace?.enabled ? (dataSource.options as QueryableDataSourceOptions).queryFormatAsWms : true,
           params: dataSource.options.paramsWFS,
           ogcFilters: Object.assign({}, dataSource.ogcFilters$.value, {enabled: hasOgcFilters}),
           sourceFields: dataSource.options.sourceFields || undefined


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
WMS layers with wfs params attached, but with workspace.enabled = false, layer was queried twice, on the wms getfeatureinfo and on the vector query.


**What is the new behavior?**
Prevent query wfs features on these conditions.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
