### PR TITLE
fix(export): export to latin1 with no latin1 equivalent characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "typy": "^3.3.0",
     "unorm": "^1.4.1",
     "web-animations-js": "^2.3.2",
+    "windows-1252": "^3.0.4",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/packages/geo/src/lib/import-export/shared/export.service.ts
+++ b/packages/geo/src/lib/import-export/shared/export.service.ts
@@ -8,6 +8,7 @@ import { Observable, Observer } from 'rxjs';
 import * as olformat from 'ol/format';
 import OlFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
+import {encode} from 'windows-1252';
 
 import { ExportFormat, EncodingFormat } from './export.type';
 
@@ -168,7 +169,7 @@ export class ExportService {
     projectionIn: string,
     projectionOut: string
   ) {
-    const featuresText: string = new olformat.GeoJSON().writeFeatures(
+    let featuresText: string = new olformat.GeoJSON().writeFeatures(
       olFeatures,
       {
         dataProjection: projectionOut,
@@ -189,6 +190,12 @@ export class ExportService {
       form.enctype = 'application/x-www-form-urlencoded; charset=utf-8;';
     } else if (encodingType === EncodingFormat.LATIN1) {
       const enctype = 'ISO-8859-1';
+      const featuresJson = JSON.parse(featuresText);
+      featuresJson.features.map(f => {
+          const encodedProperties = String.fromCharCode.apply(null, encode(JSON.stringify(f.properties), { mode: 'replacement' }));
+          f.properties = JSON.parse(encodedProperties);
+      })
+      featuresText = JSON.stringify(featuresJson);
       const encoding = document.createElement('input');
       encoding.setAttribute('type', 'hidden');
       encoding.setAttribute('name', 'encoding');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When exporting to latin1, some special char cause the crash of the conversion service.
The crash is caused by these case.
```
ERROR:  character with byte sequence 0xe2 0x80 0x93 in encoding "UTF8" has no equivalent in encoding "LATIN1"
 ```

![image](https://user-images.githubusercontent.com/7397743/164784819-3504847a-c28c-4e93-99fb-0a0e37f516d0.png)



**What is the new behavior?**
For LATIN-1 export, all the features properties are "sanitize" in Latin1 to ensure to send a LATIN1 encoded string to the service. 
 ```
// If `text` contains a symbol that cannot be represented in windows-1252,
// instead of throwing an error, it becomes U+FFFD.
 ```
FROM https://github.com/mathiasbynens/windows-1252

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
