### PR TITLE
feat(workspace*) Wks color selection is now the same as queryOverlayStyle.selection config

### DIFF
--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -23,6 +23,7 @@ import { VectorLayer } from '../../layer';
 import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap } from '../../map';
 import { SourceFieldsOptionsParams, FeatureDataSource, RelationOptions } from '../../datasource';
+import { getCommonVectorSelectedStyle} from '../../utils'
 
 import { FeatureWorkspace } from './feature-workspace';
 import { skipWhile, take } from 'rxjs/operators';
@@ -30,8 +31,6 @@ import { ConfigService, StorageService } from '@igo2/core';
 
 import olFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
-import {Circle, Fill, Stroke, Style} from 'ol/style';
-import {asArray as ColorAsArray } from 'ol/color';
 
 @Injectable({
   providedIn: 'root'
@@ -83,36 +82,15 @@ export class FeatureWorkspaceService {
     const inMapExtentStrategy = new FeatureStoreInMapExtentStrategy({});
     const inMapResolutionStrategy = new FeatureStoreInMapResolutionStrategy({});
     const selectedRecordStrategy = new EntityStoreFilterSelectionStrategy({});
-    let styles = undefined;
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
-    if (confQueryOverlayStyle.selection) {
-      let colorArray = ColorAsArray(confQueryOverlayStyle.selection.fillColor);
-      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity;
-      const fill = new Fill({
-        color: colorArray
-      });
-      const stroke = new Stroke({
-        color: confQueryOverlayStyle.selection.strokeColor,
-        width: confQueryOverlayStyle.selection.strokeWidth,
-      });
-      styles = [
-        new Style({
-          image: new Circle({
-            fill: fill,
-            stroke: stroke,
-            radius: 5,
-          }),
-          fill: fill,
-          stroke: stroke,
-        }),
-      ];
-    }
-
+ 
     const selectionStrategy = new FeatureStoreSelectionStrategy({
       layer: new VectorLayer({
         zIndex: 300,
         source: new FeatureDataSource(),
-        style: styles,
+        style: (feature) => {
+          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}))
+        },
         showInLayerList: false,
         exportable: false,
         browsable: false

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -23,7 +23,7 @@ import { VectorLayer } from '../../layer';
 import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap } from '../../map';
 import { SourceFieldsOptionsParams, FeatureDataSource, RelationOptions } from '../../datasource';
-import { getCommonVectorSelectedStyle} from '../../utils'
+import { getCommonVectorSelectedStyle} from '../../utils';
 
 import { FeatureWorkspace } from './feature-workspace';
 import { skipWhile, take } from 'rxjs/operators';
@@ -83,13 +83,13 @@ export class FeatureWorkspaceService {
     const inMapResolutionStrategy = new FeatureStoreInMapResolutionStrategy({});
     const selectedRecordStrategy = new EntityStoreFilterSelectionStrategy({});
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
- 
+
     const selectionStrategy = new FeatureStoreSelectionStrategy({
       layer: new VectorLayer({
         zIndex: 300,
         source: new FeatureDataSource(),
         style: (feature) => {
-          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}))
+          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}));
         },
         showInLayerList: false,
         exportable: false,

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -87,8 +87,7 @@ export class FeatureWorkspaceService {
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
     if (confQueryOverlayStyle.selection) {
       let colorArray = ColorAsArray(confQueryOverlayStyle.selection.fillColor);
-      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity
-      debugger;
+      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity;
       const fill = new Fill({
         color: colorArray
       });
@@ -98,7 +97,7 @@ export class FeatureWorkspaceService {
       });
       styles = [
         new Style({
-          image: new Circle({ 
+          image: new Circle({
             fill: fill,
             stroke: stroke,
             radius: 5,

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -23,15 +23,13 @@ import { VectorLayer } from '../../layer';
 import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap } from '../../map';
 import { SourceFieldsOptionsParams, FeatureDataSource, RelationOptions } from '../../datasource';
+import { getCommonVectorSelectedStyle} from '../../utils'
 
 import { WfsWorkspace } from './wfs-workspace';
 import { skipWhile, take } from 'rxjs/operators';
 import { StorageService, ConfigService } from '@igo2/core';
 import olFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
-import {Circle, Fill, Stroke, Style} from 'ol/style';
-import {asArray as ColorAsArray } from 'ol/color';
-
 @Injectable({
   providedIn: 'root'
 })
@@ -80,35 +78,15 @@ export class WfsWorkspaceService {
     const inMapExtentStrategy = new FeatureStoreInMapExtentStrategy({});
     const inMapResolutionStrategy = new FeatureStoreInMapResolutionStrategy({});
     const selectedRecordStrategy = new EntityStoreFilterSelectionStrategy({});
-    let styles = undefined;
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
-    if (confQueryOverlayStyle.selection) {
-      let colorArray = ColorAsArray(confQueryOverlayStyle.selection.fillColor);
-      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity;
-      const fill = new Fill({
-        color: colorArray
-      });
-      const stroke = new Stroke({
-        color: confQueryOverlayStyle.selection.strokeColor,
-        width: confQueryOverlayStyle.selection.strokeWidth,
-      });
-      styles = [
-        new Style({
-          image: new Circle({ // for point feature with wks noQuery
-            fill: fill,
-            stroke: stroke,
-            radius: 5,
-          }),
-          fill: fill,
-          stroke: stroke,
-        }),
-      ];
-    }
+
     const selectionStrategy = new FeatureStoreSelectionStrategy({
       layer: new VectorLayer({
         zIndex: 300,
         source: new FeatureDataSource(),
-        style: styles,
+        style: (feature) => {
+          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}))
+        },
         showInLayerList: false,
         exportable: false,
         browsable: false

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -84,8 +84,7 @@ export class WfsWorkspaceService {
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
     if (confQueryOverlayStyle.selection) {
       let colorArray = ColorAsArray(confQueryOverlayStyle.selection.fillColor);
-      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity
-      debugger;
+      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity;
       const fill = new Fill({
         color: colorArray
       });

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -23,7 +23,7 @@ import { VectorLayer } from '../../layer';
 import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap } from '../../map';
 import { SourceFieldsOptionsParams, FeatureDataSource, RelationOptions } from '../../datasource';
-import { getCommonVectorSelectedStyle} from '../../utils'
+import { getCommonVectorSelectedStyle} from '../../utils';
 
 import { WfsWorkspace } from './wfs-workspace';
 import { skipWhile, take } from 'rxjs/operators';
@@ -85,7 +85,7 @@ export class WfsWorkspaceService {
         zIndex: 300,
         source: new FeatureDataSource(),
         style: (feature) => {
-          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}))
+          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}));
         },
         showInLayerList: false,
         exportable: false,

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -185,8 +185,7 @@ export class WmsWorkspaceService {
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
     if (confQueryOverlayStyle.selection) {
       let colorArray = ColorAsArray(confQueryOverlayStyle.selection.fillColor);
-      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity
-      debugger;
+      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity;
       const fill = new Fill({
         color: colorArray
       });

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -28,7 +28,7 @@ import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap } from '../../map';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { WfsWorkspace } from './wfs-workspace';
-import { getCommonVectorSelectedStyle} from '../../utils'
+import { getCommonVectorSelectedStyle} from '../../utils';
 
 import olFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
@@ -187,7 +187,7 @@ export class WmsWorkspaceService {
         zIndex: 300,
         source: new FeatureDataSource(),
         style: (feature) => {
-          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}))
+          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}));
         },
         showInLayerList: false,
         exportable: false,

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -28,11 +28,10 @@ import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap } from '../../map';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { WfsWorkspace } from './wfs-workspace';
+import { getCommonVectorSelectedStyle} from '../../utils'
 
 import olFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
-import {Circle, Fill, Stroke, Style} from 'ol/style';
-import {asArray as ColorAsArray } from 'ol/color';
 
 @Injectable({
   providedIn: 'root'
@@ -181,35 +180,15 @@ export class WmsWorkspaceService {
     const inMapExtentStrategy = new FeatureStoreInMapExtentStrategy({});
     const inMapResolutionStrategy = new FeatureStoreInMapResolutionStrategy({});
     const selectedRecordStrategy = new EntityStoreFilterSelectionStrategy({});
-    let styles = undefined;
     const confQueryOverlayStyle= this.configService.getConfig('queryOverlayStyle');
-    if (confQueryOverlayStyle.selection) {
-      let colorArray = ColorAsArray(confQueryOverlayStyle.selection.fillColor);
-      colorArray[3] = confQueryOverlayStyle.selection.fillOpacity;
-      const fill = new Fill({
-        color: colorArray
-      });
-      const stroke = new Stroke({
-        color: confQueryOverlayStyle.selection.strokeColor,
-        width: confQueryOverlayStyle.selection.strokeWidth,
-      });
-      styles = [
-        new Style({
-          image: new Circle({ // need for point feature with wks noQuery
-            fill: fill,
-            stroke: stroke,
-            radius: 5,
-          }),
-          fill: fill,
-          stroke: stroke,
-        }),
-      ];
-    }
+
     const selectionStrategy = new FeatureStoreSelectionStrategy({
       layer: new VectorLayer({
         zIndex: 300,
         source: new FeatureDataSource(),
-        style: styles,
+        style: (feature) => {
+          return getCommonVectorSelectedStyle(Object.assign({}, {feature}, confQueryOverlayStyle.selection || {}))
+        },
         showInLayerList: false,
         exportable: false,
         browsable: false


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://github.com/infra-geo-ouverte/igo2/issues/765


**What is the new behavior?**
The color selection is now the same as config queryOverlayStyle.selection
        "fillColor" 
        "fillOpacity"
        "strokeColor"
        "strokeWidth"      

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No


**Other information**:
config to test:
```
 "queryOverlayStyle": {

    "selection": {
        "markerColor": [0,137,123], 
        "markerOpacity": 1.0, 
        "markerOutlineColor": [255,255,255],        
        "fillColor": "#c9f2d0", 
        "fillOpacity": 0.0,     
        "strokeColor": "#2effff",       
        "strokeWidth": 3                
    },
```

layerContext to test:
  {     
        "title": "WMS-WFS avec table attribut sans query",
        "visible": true,
        "id": 1,
        "workspace": {
          "enabled": true,
          "maxResolution": 300,
          "queryOptions": {
            "mapQueryOnOpenTab": false,
            "tabQuery": false
          }
        },
        "sourceOptions": {
          "queryable": true,
          "queryTitle": "photographies aériennes",
          "crossOrigin": "anonymous",
          "queryFormat": "gml2",
          "queryHtmlTarget": "iframe",
          "queryFormatAsWms": true,
          "type": "wms",
          "optionsFromCapabilities": true,
          "url": "/ws/mffpecofor.fcgi",
          "params": {
            "layers": "nord_photo_oblique",
            "version": "1.3.0"
          },
          "urlWfs": "/ws/mffpecofor.fcgi",
          "paramsWFS": {
            "featureTypes": "nord_photo_oblique",
            "maxFeatures": 1000,
            "version": "2.0.0"
          },
          "sourceFields": [
            {"name": "LATITUDE", "alias": "latitude"},
            {"name": "LONGITUDE", "alias": "longitude"},
            {"name": "NOM_PHOTO", "alias": "nom photo"} 
          ] 
        }
      },
      {
        "title": "Vector geojson d'appel WFS",
        "id": "vector2",
        "workspace": {
          "enabled": true,
          "queryOptions": {
              "mapQueryOnOpenTab": false,
              "tabQuery": false
          }
      },
        "sourceOptions": {
          "type": "vector",
          "url": "https://ws.mapserver.transports.gouv.qc.ca/swtq?service=WFS&request=GetFeature&version=1.1.0&typename=aeroport_piste&outputFormat=geojson",
          "queryable": true,
          "queryFormat": "geojson",
          "queryTitle": "nomnavcana"
        }
      },
    {
      "title": "feux tab + filtre",
      "id": "test",
      "visible": true,
      "workspace": {
          "enabled": true,
          "maxResolution": 300,
          "queryOptions": {
              "mapQueryOnOpenTab": false,
              "tabQuery": false
          }
      },
      "metadata": {
      "extern": true
      },
      "sourceOptions": {
        "crossOrigin": "anonymous",
        "queryable": true,
        "queryFormat": "htmlgml2",
        "queryHtmlTarget": "iframe",
            "queryFormatAsWms": true,
            "type": "wms",
            "optionsFromCapabilities": true,
            "url": "/ws/mffpecofor.fcgi", 
            "params": {
                "layers": "ca_feux_close_scale",
                "version": "1.3.0"
            },
            "urlWfs": "/ws/mffpecofor.fcgi",
            "paramsWFS": {
              "featureTypes": "ca_feux_close_scale",
              "fieldNameGeometry": "the_geom",
              "maxFeatures": 3000,
              "version": "2.0.0"
            },
           
            "timeFilterable": false,
            "ogcFilters": {
                "enabled": true,
                "editable": true,
                "allowedOperatorsType": "basic",
                "pushButtons": {
                  "groups": [
                    {"title": "Group 1 Title","name": "1","ids": ["id1"]}
                  ],
                  "bundles": [
                    {
                      "id": "id1",
                      "logical": "Or",
                      "title": "Type feu",
                      "selectors": [
                      {
                          "title": "total",
                          "color": "0,137,123",
                          "filters": {
                              "operator": "PropertyIsEqualTo",
                              "propertyName": "symbologie",
                              "expression": "BR"
                          }
                      },
                        {
                          "title": "partiel",
                          "color": "0,137,123",
                          "filters": {
                            "operator": "PropertyIsEqualTo",
                            "propertyName": "symbologie",
                            "expression": "BRP"
                          }
                        }
                      ]
                    }
                  ]
                  },
                "filters":
                {
                  "operator": "During",
                  "propertyName": "annee_date",
                  "begin": "1890-01-01",
                  "end": "2021-01-01",
                  "calendarModeYear": true,
                  "restrictToStep": false
                } 
            },
            "stepDate": "P1Y",
            "minDate": "1890-01-01",
            "maxDate": "2022-01-01"

        }       
      }
