### PR TITLE
feat(edition): allow send config option / url call for dom / add, modify, delete disabled button config

### DIFF
--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -646,6 +646,7 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
         value = value ? '&#10003;' : ''; // check mark
       }
     } else if (column.type === 'list' && value && column.domainValues) {
+      const entity = record.entity as any;
       if (column.multiple) {
         let list_id;
         typeof value === 'string' ? list_id = value.match(/[\w.-]+/g).map(Number) : list_id = value;
@@ -663,26 +664,34 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
 
         this.isEdition(record) ? value = list_id : value = list_option;
       } else {
+        if (!this.isEdition(record) && column.linkColumnForce) {
+          value = entity?.properties[this.getColumnKeyWithoutPropertiesTag(column.linkColumnForce)];
+        } else {
+          column.domainValues.forEach(option => {
+            if (typeof value === 'string' && /^\d+$/.test(value)) {
+              value = parseInt(value);
+            }
+            if (option.value === value || option.id === value) {
+              this.isEdition(record) ? value = option.id : value = option.value;
+            }
+          });
+        }
+      }
+    } else if (column.type === 'autocomplete' && value && column.domainValues) {
+      const entity = record.entity as any;
+      if (!this.isEdition(record) && column.linkColumnForce) {
+        value = entity?.properties[this.getColumnKeyWithoutPropertiesTag(column.linkColumnForce)];
+      } else {
         column.domainValues.forEach(option => {
           if (typeof value === 'string' && /^\d+$/.test(value)) {
             value = parseInt(value);
           }
           if (option.value === value || option.id === value) {
-            this.isEdition(record) ? value = option.id : value = option.value;
+            value = option.value;
           }
         });
       }
-    } else if (column.type === 'autocomplete' && value && column.domainValues) {
-      column.domainValues.forEach(option => {
-        if (typeof value === 'string' && /^\d+$/.test(value)) {
-          value = parseInt(value);
-        }
-        if (option.value === value || option.id === value) {
-          value = option.value;
-        }
-      });
-    }
-    else if (column.type === 'date') {
+    } else if (column.type === 'date') {
       if (this.isEdition(record)) {
         if (value) {
           let date = moment(value);

--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -334,6 +334,12 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
         });
 
         this.formGroup.controls[column.name].setValue(formControlValue);
+        if (this.isEdition(record) && column.linkColumnForce) {
+          const entity = record.entity as any;
+          this.formGroup.controls[column.name].setValue(
+            entity?.properties[this.getColumnKeyWithoutPropertiesTag(column.linkColumnForce)]
+          );
+        }
       } else if (column.type === 'date') {
         if (column.visible) {
           if (item[key]) {

--- a/packages/common/src/lib/entity/shared/entity.interfaces.ts
+++ b/packages/common/src/lib/entity/shared/entity.interfaces.ts
@@ -111,6 +111,7 @@ export interface EntityTableColumn {
   renderer?: EntityTableColumnRenderer;
   valueAccessor?: (entity: object, record: EntityRecord<object>) => any;
   visible?: boolean;
+  linkColumnForce?: string;
   sort?: boolean;
   type?: string;
   multiple?: boolean;

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -70,9 +70,10 @@ export interface EditionOptions {
 export interface RelationOptions {
   title: string;
   name: string;
+  table?: string;
+  url?: string;
   alias?: string;
   icon?: string;
-  table: string;
   parent?: string;
   tooltip?: string;
 }
@@ -82,6 +83,7 @@ export interface SourceFieldsValidationParams {
   maxLength?: number;
   minLength?: number;
   readonly?: boolean;
+  send?: boolean;
 }
 
 export interface Legend {

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -48,6 +48,7 @@ export interface SourceFieldsOptionsParams {
   primary?: boolean;
   visible?: boolean;
   validation?: SourceFieldsValidationParams;
+  linkColumnForce?: string;
   multiple?: boolean;
   tooltip?: string;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -65,6 +65,9 @@ export interface EditionOptions {
   addHeaders?: { [key: string]: any };
   modifyHeaders?: { [key: string]: any };
   modifyProtocol?: string;
+  addButton?: boolean;
+  modifyButton?: boolean;
+  deleteButton?: boolean;
 }
 
 export interface RelationOptions {

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -573,9 +573,9 @@ export class EditionWorkspaceService {
     feature.edition = false;
     this.adding$.next(false);
     workspace.deleteDrawings();
+    workspace.entityStore.stateView.clear();
 
     if (feature.newFeature) {
-      workspace.entityStore.stateView.clear();
       workspace.entityStore.delete(feature);
       workspace.deactivateDrawControl();
 

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -235,12 +235,14 @@ export class EditionWorkspaceService {
           editMode: false,
           icon: 'pencil',
           color: 'primary',
+          disabled: layer.dataSource.options.edition.modifyButton === false ? true : false,
           click: (feature) => { workspace.editFeature(feature, workspace); }
         },
         {
           editMode: false,
           icon: 'delete',
           color: 'warn',
+          disabled: layer.dataSource.options.edition.deleteButton === false ? true : false,
           click: (feature) => { workspace.deleteFeature(feature, workspace); }
         },
         {

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -308,6 +308,7 @@ export class EditionWorkspaceService {
         primary: field.primary === true ? true : false,
         visible: field.visible,
         validation: field.validation,
+        linkColumnForce: field.linkColumnForce,
         type: field.type,
         domainValues: undefined,
         relation: undefined,

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -315,7 +315,7 @@ export class EditionWorkspaceService {
       };
 
       if (field.type === 'list' || field.type === 'autocomplete') {
-        this.getDomainValues(field.relation.table).subscribe(result => {
+        this.getDomainValues(field.relation).subscribe(result => {
           column.domainValues = result;
           column.relation = field.relation;
         });
@@ -406,7 +406,7 @@ export class EditionWorkspaceService {
 
     for (const property in feature.properties) {
       for (const sf of workspace.layer.dataSource.options.sourceFields) {
-        if (sf.name === property && sf.validation?.readonly) {
+        if ((sf.name === property && sf.validation?.readonly) || (sf.name === property && sf.validation?.send === false)) {
           delete feature.properties[property];
         }
       }
@@ -510,7 +510,8 @@ export class EditionWorkspaceService {
 
     for (const property in feature.properties) {
       for (const sf of workspace.layer.dataSource.options.sourceFields) {
-        if ((sf.name === property && sf.validation?.readonly) || property === 'boundedBy') {
+        if ((sf.name === property && sf.validation?.readonly) || (sf.name === property && sf.validation?.send === false)
+          || property === 'boundedBy') {
           delete feature.properties[property];
         }
       }
@@ -587,14 +588,18 @@ export class EditionWorkspaceService {
     }
   }
 
-  getDomainValues(table: string): Observable<any> {
-    let url = this.configService.getConfig('edition.url') + table;
+  getDomainValues(relation: RelationOptions): Observable<any> {
+    let url = relation.url;
+    if (!url) {
+      url = this.configService.getConfig('edition.url') + relation.table;
+    }
 
     return this.http.get<any>(url).pipe(
       map(result => {
         return result;
       }),
       catchError((err: HttpErrorResponse) => {
+        err.error.caught = true;
         return throwError(err);
       })
     );

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.ts
@@ -158,7 +158,7 @@ export class EditionWorkspace extends Workspace {
 
       // Update domain list
       if (column.type === 'list' || column.type === 'autocomplete') {
-        this.editionWorkspaceService.getDomainValues(column.relation.table).subscribe(result => {
+        this.editionWorkspaceService.getDomainValues(column.relation).subscribe(result => {
           column.domainValues = result;
         });
       }

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.ts
@@ -65,8 +65,12 @@ export class EditionWorkspace extends Workspace {
     })
   });
 
-  private filterClauseFunc = (record: EntityRecord<object>) => {
+  private newFeaturefilterClauseFunc = (record: EntityRecord<object>) => {
     return record.state.newFeature === true;
+  };
+
+  private editFeaturefilterClauseFunc = (record: EntityRecord<object>) => {
+    return record.state.edit === true;
   };
 
   public fillColor: string;
@@ -180,6 +184,8 @@ export class EditionWorkspace extends Workspace {
       feature.original_properties = JSON.parse(JSON.stringify(feature.properties));
       feature.original_geometry = feature.geometry;
       feature.idkey = id;
+      workspace.entityStore.state.updateAll({ edit: false });
+      workspace.entityStore.stateView.filter(this.editFeaturefilterClauseFunc);
       this.addFeatureToStore(feature, workspace);
     } else {
       // Only for edition with it's own geometry
@@ -187,7 +193,7 @@ export class EditionWorkspace extends Workspace {
         feature.newFeature = true;
         this.editionWorkspaceService.adding$.next(true);
         workspace.entityStore.state.updateAll({ newFeature: false });
-        workspace.entityStore.stateView.filter(this.filterClauseFunc);
+        workspace.entityStore.stateView.filter(this.newFeaturefilterClauseFunc);
         if (editionOpt.addWithDraw) {
           const geometryType = editionOpt.geomType;
           this.onGeometryTypeChange(geometryType, feature, workspace);
@@ -279,6 +285,8 @@ export class EditionWorkspace extends Workspace {
       }) as any;
 
       feature.geometry = geometry;
+    } else {
+      workspace.entityStore.state.update(feature, { edit: true }, true);
     }
 
     feature.projection = 'EPSG:4326';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Nothing discriminate which source field you really want to send on add/modify action
Predefined url are not considered for relation http call
add, remove and modify buttons are always available
Edit mode shows all other features (in edit mode or not) and causes some problems with multiple domain value


**What is the new behavior?**
"send" config allow to send or not send sourceFields on add/modify action
"url" can now be part of relation options config
add, remove and modify buttons can now be set to disabled directly by layer edition options
Edit mode only shows the feature in edit mode


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

