### PR TITLE
feat(search-results): Top panel state default options in config

### DIFF
--- a/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
+++ b/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
@@ -68,6 +68,11 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
    */
   @Input() showIcons: boolean = true;
 
+  /**
+   * Determine the top panel default state
+   */
+  @Input() topPanelStateDefault: string = 'expanded';
+
   private hasFeatureEmphasisOnSelection: boolean = false;
 
   private showResultsGeometries$$: Subscription;
@@ -424,19 +429,20 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
     this.tryAddFeatureToMap(result);
     this.searchState.setSelectedResult(result);
 
+    if (this.topPanelState === 'initial') {
+      if (this.topPanelStateDefault !== 'collapsed') {
+        this.topPanelState = 'expanded';
+      } else {
+        this.topPanelState = 'collapsed';
+      }
+    }
+
     if (this.topPanelState === 'expanded') {
       const igoList = this.computeElementRef()[0];
       const selected = this.computeElementRef()[1];
-      setTimeout(() => {
-        // To be sure the flexible component has been displayed yet
-        if (!this.isScrolledIntoView(igoList, selected)) {
-          this.adjustTopPanel(igoList, selected);
-        }
-      }, FlexibleComponent.transitionTime + 50);
-    }
-
-    if (this.topPanelState === 'initial') {
-      this.topPanelState = 'expanded';
+      if (!this.isScrolledIntoView(igoList, selected)) {
+        this.adjustTopPanel(igoList, selected);
+      }
     }
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Top panel state is always expanded by default


**What is the new behavior?**
Top panel state is now configurable by search results tool options
Also fix scroll problem with select result


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
