### PR TITLE
fix(search-results): prevent empty message to be shown during typing

### DIFF
--- a/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.html
+++ b/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!store || store.stateView.empty" style="margin: 10px;">
+<div *ngIf="(!store || store.stateView.empty) && (debouncedEmpty$ | async) " style="margin: 10px;">
   <section class="mat-typography">
     <h4><strong>{{ 'igo.integration.searchResultsTool.noResults' | translate }}</strong></h4>
     <p><strong>{{ 'igo.integration.searchResultsTool.doSearch' | translate }}</strong></p>

--- a/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
+++ b/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
@@ -82,6 +82,9 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
   private abstractFocusedResult: Feature;
   private abstractSelectedResult: Feature;
 
+  public debouncedEmpty$ :BehaviorSubject<boolean> = new BehaviorSubject(true);;
+  private debouncedEmpty$$: Subscription;
+
   /**
    * Store holding the search results
    * @internal
@@ -246,6 +249,10 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
         }
       });
     });
+    
+    this.debouncedEmpty$$ = this.store.stateView.empty$.pipe(debounceTime(1500)).subscribe(empty =>
+      this.debouncedEmpty$.next(empty)
+      )
   }
 
   private monitorResultOutOfView() {
@@ -367,6 +374,9 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
     }
     if (this.getRoute$$) {
       this.getRoute$$.unsubscribe();
+    }
+    if (this.debouncedEmpty$$) {
+      this.debouncedEmpty$$.unsubscribe();
     }
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
During typing into the search bar, the empty message was shown while waiting for the query response...


**What is the new behavior?**
Wait at least 1500ms before to show the empty message. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
