### PR TITLE
fix(ogcfilter): propertyislike operator crash with undefined values

### DIFF
--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -268,7 +268,7 @@ export class OgcFilterWriter {
       case OgcFilterOperator.PropertyIsLike.toLowerCase():
         return olfilter.like(
           wfsPropertyName,
-          wfsPattern.replace(/[()_]/gi, wfsSingleChar),
+          wfsPattern ? wfsPattern.replace(/[()_]/gi, wfsSingleChar): wfsWildCard,
           wfsWildCard,
           wfsSingleChar,
           wfsEscapeChar,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
propertyislike operator crash with undefined values


**What is the new behavior?**
fix


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
