### PR TITLE
fix(ogcfilter): between operator crash with undefined values for lower and upper boundary

### DIFF
--- a/packages/geo/src/lib/filter/shared/ogc-filter.ts
+++ b/packages/geo/src/lib/filter/shared/ogc-filter.ts
@@ -244,8 +244,8 @@ export class OgcFilterWriter {
       case OgcFilterOperator.PropertyIsBetween.toLowerCase():
         return olfilter.between(
           wfsPropertyName,
-          wfsLowerBoundary,
-          wfsUpperBoundary
+          wfsLowerBoundary || 1e40*-1,
+          wfsUpperBoundary || 1e40
         );
       case OgcFilterOperator.Contains.toLowerCase():
         return olfilter.contains(wfsGeometryName, geometry, wfsSrsName);


### PR DESCRIPTION
…r and upper boundary

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
between operator crash with undefined values


**What is the new behavior?**
fix it.  Used default bound from 1e40 *-1 to 1e40. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
