### PR TITLE
refactor(geolocate): allow to always zoom when tracking is set to true

### DIFF
--- a/packages/geo/src/lib/map/shared/controllers/geolocation.ts
+++ b/packages/geo/src/lib/map/shared/controllers/geolocation.ts
@@ -12,7 +12,7 @@ import { IgoMap } from '../map';
 import * as olstyle from 'ol/style';
 import { Overlay } from '../../../overlay/shared/overlay';
 import { FeatureMotion } from '../../../feature/shared/feature.enums';
-import { StorageService } from '@igo2/core';
+import { StorageService, ConfigService } from '@igo2/core';
 import { MapViewOptions } from '../map.interface';
 import { switchMap } from 'rxjs/operators';
 export interface MapGeolocationControllerOptions {
@@ -164,8 +164,12 @@ export class MapGeolocationController extends MapController {
    */
   set followPosition(value: boolean) {
     this._followPosition = value;
-    this.handleFeatureCreation(this.position$.value);
     this.followPosition$.next(value);
+    if (this.configService.getConfig('geolocate.followPosition') === false) {
+      this._followPosition = false;
+      this.followPosition$.next(false);
+    }
+    this.handleFeatureCreation(this.position$.value);
     if (this.storageService && value !== undefined) {
       this.storageService.set('geolocation.followPosition', value);
     }
@@ -182,7 +186,8 @@ export class MapGeolocationController extends MapController {
   constructor(
     private map: IgoMap,
     private options?: MapGeolocationControllerOptions,
-    private storageService?: StorageService) {
+    private storageService?: StorageService,
+    private configService?: ConfigService) {
     super();
     this.geolocationOverlay = new Overlay(this.map);
   }
@@ -220,10 +225,17 @@ export class MapGeolocationController extends MapController {
       },
       projection: this.options.projection,
     });
-
+    let tracking = false;
     this.subscriptions$$.push(this.emissionIntervalSeconds$
       .pipe(switchMap(value => interval(value * 1000)))
-      .subscribe(() => this.onPositionChange(true)));
+      .subscribe(() => {
+        if (tracking === this.tracking) {
+          this.onPositionChange(true);
+        } else {
+          tracking = this.tracking;
+          this.onPositionChange(true, true);
+        }
+      }));
   }
 
   public updateGeolocationOptions(options: MapViewOptions) {

--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -27,7 +27,7 @@ import {
 import { MapViewController } from './controllers/view';
 import { FeatureDataSource } from '../../datasource/shared/datasources/feature-datasource';
 import { MapGeolocationController } from './controllers/geolocation';
-import { StorageService } from '@igo2/core';
+import { StorageService, ConfigService } from '@igo2/core';
 
 // TODO: This class is messy. Clearly define it's scope and the map browser's.
 // Move some stuff into controllers.
@@ -65,7 +65,8 @@ export class IgoMap {
 
   constructor(
     options?: MapOptions,
-    private storageService?: StorageService) {
+    private storageService?: StorageService,
+    private configService?: ConfigService) {
     this.options = Object.assign({}, this.defaultOptions, options);
     this.layerWatcher = new LayerWatcher();
     this.status$ = this.layerWatcher.status$;
@@ -122,7 +123,8 @@ export class IgoMap {
         {
           projection: this.viewController.getOlProjection()
         },
-        this.storageService);
+        this.storageService,
+        this.configService);
       this.geolocationController.setOlMap(this.ol);
       if (this.geolocationController) {
         this.geolocationController.updateGeolocationOptions(this.mapViewOptions);

--- a/packages/integration/src/lib/map/map.state.ts
+++ b/packages/integration/src/lib/map/map.state.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { StorageService } from '@igo2/core';
+import { StorageService, ConfigService } from '@igo2/core';
 
 import { IgoMap, MapService, ProjectionService } from '@igo2/geo';
 // import { BehaviorSubject } from 'rxjs';
@@ -31,7 +31,8 @@ export class MapState {
   constructor(
     private mapService: MapService,
     private projectionService: ProjectionService, // Don't remove this or it'll never be injected,
-    private storageService: StorageService
+    private storageService: StorageService,
+    private configService: ConfigService
   ) {
     this._map = new IgoMap({
       controls: {
@@ -41,7 +42,8 @@ export class MapState {
         }
       }
     },
-    this.storageService);
+    this.storageService,
+    this.configService);
 
     this.mapService.setMap(this.map);
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Geolocate needs two clicks to be zoomed on
No config is available when advanced map tool is not used


**What is the new behavior?**
Geolocate always zoom when tracking is on
Configs are now available to set default tracking and follow position


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
