### PR TITLE
feat(feature-details): copy content button alongside the url

### DIFF
--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.html
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.html
@@ -8,6 +8,9 @@
 
       <td *ngIf="feature.properties.target === '_blank' && property.key === 'url'">
         <a href="{{property.value}}" target='_blank' rel="noopener noreferrer"> {{ 'igo.geo.targetHtmlUrl' | translate }} {{title}}</a>
+        <button class="copyClipboard" mat-icon-button (click)="copyTextToClipboard(property.value)">
+          <mat-icon svgIcon="content-copy"></mat-icon>
+        </button>
       </td>
 
       <td id="keyValue" *ngIf="feature.properties.target === undefined">
@@ -23,6 +26,9 @@
 
       <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && (isDoc(property.value) || isUrl(property.value)) && !isImg(property.value)">
         <u [ngStyle]="{'cursor': 'pointer', 'color': 'blue'}" (click)="openSecureUrl(property.value)">{{ 'igo.geo.targetHtmlUrl' | translate }}</u>
+        <button class="copyClipboard" mat-icon-button (click)="copyTextToClipboard(property.value)">
+          <mat-icon svgIcon="content-copy"></mat-icon>
+        </button>
       </td>
 
       <td *ngIf="feature.properties.target === undefined && !isObject(property.value) && isUrl(property.value) && isImg(property.value)">

--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.scss
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.scss
@@ -21,3 +21,8 @@ iframe {
   width: 100%;
   border: 0;
 }
+.copyClipboard {
+  border: none;
+  background: transparent;
+  cursor: pointer
+}

--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.ts
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.ts
@@ -22,7 +22,7 @@ import { Feature } from '../shared';
 import { SearchSource } from '../../search/shared/sources/source';
 import { IgoMap } from '../../map/shared/map';
 import { HttpClient } from '@angular/common/http';
-
+import { Clipboard } from '@igo2/utils';
 @Component({
   selector: 'igo-feature-details',
   templateUrl: './feature-details.component.html',
@@ -261,5 +261,15 @@ export class FeatureDetailsComponent implements OnInit, OnDestroy {
       }
     }
     return feature.properties;
+  }
+
+  /**
+   * Copy the url to a clipboard
+   */
+  copyTextToClipboard(value: string): void {
+    const successful = Clipboard.copy(value);
+    if (successful) {
+      this.messageService.success('igo.geo.query.link.message');
+    }
   }
 }

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -735,7 +735,10 @@
         "maxLength": "{{column}} is longer than {{value}} characters"
       },
       "query": {
-        "featureCountMax": "You may have more feature queryable on {{value}}. Zoom in to ensure you have access to all features."
+        "featureCountMax": "You may have more feature queryable on {{value}}. Zoom in to ensure you have access to all features.",
+        "link": {
+          "message": "Hyperlink copied to clipboard"
+        }
       }
     }
   }

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -735,7 +735,10 @@
         "maxLength": "{{column}} doit être plus court que {{value}} caractères"
       },
       "query": {
-        "featureCountMax": "Vous pourriez avoir plus d'entités interrogeables sur la couche {{value}}. Pour vous en assurer, vous pouvez zoomer et redéclencher l'interrogation."
+        "featureCountMax": "Vous pourriez avoir plus d'entités interrogeables sur la couche {{value}}. Pour vous en assurer, vous pouvez zoomer et redéclencher l'interrogation.",
+        "link": {
+          "message": "Le lien a été copié dans le presse-papier"
+        }
       }
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
On map query, when content is url, only a link is available to open the link


**What is the new behavior?**
Add a button to copy the link

![2022-10-26_17-28-54](https://user-images.githubusercontent.com/7397743/198142018-09570a72-0ca5-4f45-b1be-5385f9479dc8.png)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
