### PR TITLE
fix(layer-list): follow checked or focused layer on layer displacement

### DIFF
--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.html
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.html
@@ -66,7 +66,7 @@
       matTooltipShowDelay="500"
       [matTooltip]="(sortAlpha || onlyVisible || keyword) ? ('igo.geo.layer.filterLowerLayer' | translate) : ('igo.geo.layer.lowerLayer' | translate)"
       [disabled]="lowerDisabled"
-      (click)="moveActiveLayer(activeLayer,layerListDisplacement.Lower)">
+      (click)="moveActiveLayer(activeLayer,layerListDisplacement.Lower, true)">
       <mat-icon [matBadge]="(sortAlpha || onlyVisible || keyword) ? '!' : ''" matBadgeColor="warn" matBadgeSize="medium" [matBadgeHidden]="lowerDisabled"
                 svgIcon="arrow-down"></mat-icon>
     </button>
@@ -79,7 +79,7 @@
       matTooltipShowDelay="500"
       [matTooltip]="(sortAlpha || onlyVisible || keyword) ? ('igo.geo.layer.filterRaiseLayer' | translate) : ('igo.geo.layer.raiseLayer' | translate)"
       [disabled]="raiseDisabled"
-      (click)="moveActiveLayer(activeLayer,layerListDisplacement.Raise)">
+      (click)="moveActiveLayer(activeLayer,layerListDisplacement.Raise, true)">
       <mat-icon [matBadge]="(sortAlpha || onlyVisible || keyword) ? '!' : ''" matBadgeColor="warn" matBadgeSize="medium" [matBadgeHidden]="raiseDisabled"
                 svgIcon="arrow-up"></mat-icon>
     </button>

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -920,25 +920,6 @@ export class LayerListComponent implements OnInit, OnDestroy {
     return elemBottom <= docViewBottom && elemTop >= docViewTop;
   }
 
-  computeElementRef(type?: string) {
-    const checkItems = this.elRef.nativeElement.getElementsByClassName(
-      'mat-checkbox-checked'
-    );
-    const checkItem =
-      type === 'lower'
-        ? this.elRef.nativeElement.getElementsByClassName(
-          'mat-checkbox-checked'
-        )[checkItems.length - 1]
-        : this.elRef.nativeElement.getElementsByClassName(
-          'mat-checkbox-checked'
-        )[0];
-    const igoList = this.elRef.nativeElement.getElementsByTagName(
-      'igo-list'
-    )[0];
-
-    return [igoList, checkItem];
-  }
-
   removeProblemLayerInList(layersList: Layer[]): Layer[] {
     for (const layer of layersList) {
       if (layer.olLoadingProblem === true) {

--- a/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
+++ b/packages/geo/src/lib/layer/layer-list/layer-list.component.ts
@@ -11,6 +11,8 @@ import {
 } from '@angular/core';
 import type { TemplateRef } from '@angular/core';
 
+import scrollIntoView from 'scroll-into-view-if-needed';
+
 import { FloatLabelType } from '@angular/material/form-field';
 import { LayerListControlsEnum, LayerListDisplacement } from './layer-list.enum';
 import { LayerListSelectVisibleEnum } from './layer-list.enum';
@@ -404,7 +406,7 @@ export class LayerListComponent implements OnInit, OnDestroy {
     return false;
   }
 
-  moveActiveLayer(activeLayer: Layer, actiontype: LayerListDisplacement) {
+  moveActiveLayer(activeLayer: Layer, actiontype: LayerListDisplacement, fromUi: boolean = false) {
     const sortedLayersToMove = [];
     getRootParentByProperty(this.map,activeLayer,LinkedProperties.ZINDEX);
     let rootParentByProperty = getRootParentByProperty(this.map,activeLayer,LinkedProperties.ZINDEX);
@@ -421,9 +423,9 @@ export class LayerListComponent implements OnInit, OnDestroy {
     });
 
     if (actiontype === LayerListDisplacement.Raise) {
-      this.raiseLayers(sortedLayersToMove, false);
+      this.raiseLayers(sortedLayersToMove, fromUi);
     } else if (actiontype === LayerListDisplacement.Lower) {
-      this.lowerLayers(sortedLayersToMove, false);
+      this.lowerLayers(sortedLayersToMove, fromUi);
     }
   }
 
@@ -485,9 +487,22 @@ export class LayerListComponent implements OnInit, OnDestroy {
     this.map.raiseLayers(layersToRaise);
     if (fromUi) {
       setTimeout(() => {
-        const elements = this.computeElementRef();
-        if (!this.isScrolledIntoView(elements[0], elements[1].offsetParent)) {
-          elements[0].scrollTop = elements[1].offsetParent.offsetTop;
+        const checkItems = this.elRef.nativeElement.getElementsByClassName('mat-checkbox-checked');
+        const itemFocused = this.elRef.nativeElement.getElementsByClassName('igo-layer-item-focused');
+        let targetToScroll;
+        if (checkItems.length) {
+          targetToScroll = checkItems[0];
+        }
+        if (itemFocused.length) {
+          targetToScroll = itemFocused[0];
+        }
+        if (targetToScroll) {
+          scrollIntoView(targetToScroll, {
+            scrollMode: 'if-needed',
+            behavior: 'smooth',
+            block: 'end',
+            inline: 'nearest'
+          });
         }
       }, 100);
     }
@@ -552,12 +567,22 @@ export class LayerListComponent implements OnInit, OnDestroy {
     this.map.lowerLayers(layersToLower);
     if (fromUi) {
       setTimeout(() => {
-        const elements = this.computeElementRef('lower');
-        if (!this.isScrolledIntoView(elements[0], elements[1].offsetParent)) {
-          elements[0].scrollTop =
-            elements[1].offsetParent.offsetTop +
-            elements[1].offsetParent.offsetHeight -
-            elements[0].clientHeight;
+        const checkItems = this.elRef.nativeElement.getElementsByClassName('mat-checkbox-checked');
+        const itemFocused = this.elRef.nativeElement.getElementsByClassName('igo-layer-item-focused');
+        let targetToScroll;
+        if (checkItems.length) {
+          targetToScroll = checkItems[checkItems.length-1];
+        }
+        if (itemFocused.length) {
+          targetToScroll = itemFocused[0];
+        }
+        if (targetToScroll) {
+          scrollIntoView(targetToScroll, {
+            scrollMode: 'if-needed',
+            behavior: 'smooth',
+            block: 'end',
+            inline: 'nearest'
+          });
         }
       }, 100);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Layer lis was not scrolling during layer(s) displacement.


**What is the new behavior?**
If you raise layer(s), the list will scroll to follow the first item.
If you lower layer(s), the list will scroll to follow the last item. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
