### PR TITLE
fix(auth Interceptor): withCredentials & token conflict

### DIFF
--- a/packages/auth/src/lib/shared/auth.interceptor.ts
+++ b/packages/auth/src/lib/shared/auth.interceptor.ts
@@ -55,6 +55,7 @@ export class AuthInterceptor implements HttpInterceptor {
       req = originalReq.clone({
         withCredentials
       });
+      return next.handle(req);
     }
     this.refreshToken();
     const token = this.tokenService.get();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
withCredentials & token  were in conflicts. If you were authenticated by credentials (kerberos), the token was also provided and was deleting the credential value ....


**What is the new behavior?**
Return request to ve authenticated by kerberos. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
