### PR TITLE
feat(edition): allow absolute url if config is not defined

### DIFF
--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -389,10 +389,13 @@ export class EditionWorkspaceService {
 
     this.sanitizeParameter(feature, workspace);
 
+    const baseUrl = workspace.layer.dataSource.options.edition.baseUrl;
     let url = this.configService.getConfig('edition.url');
 
-    if (workspace.layer.dataSource.options.edition.baseUrl) {
-      url += workspace.layer.dataSource.options.edition.baseUrl;
+    if (!url) {
+      url = baseUrl;
+    } else {
+      url += baseUrl ? baseUrl : '';
     }
 
     if (feature.newFeature) {
@@ -613,7 +616,8 @@ export class EditionWorkspaceService {
   getDomainValues(relation: RelationOptions): Observable<any> {
     let url = relation.url;
     if (!url) {
-      url = this.configService.getConfig('edition.url') + relation.table;
+      url = this.configService.getConfig('edition.url') ?
+        this.configService.getConfig('edition.url') + relation.table : relation.table;
     }
 
     return this.http.get<any>(url).pipe(

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.ts
@@ -123,14 +123,16 @@ export class EditionWorkspace extends Workspace {
 
       dialogRef.afterClosed().subscribe(result => {
         if (result === false) {
+          let id, url;
           const baseUrl = workspace.layer.dataSource.options.edition.baseUrl;
           const deleteUrl = workspace.layer.dataSource.options.edition.deleteUrl;
-          let id;
-          let url;
-          if (baseUrl) {
-            url = this.configService.getConfig('edition.url') + baseUrl + '?' + deleteUrl;
+          if (baseUrl.length) {
+            url = this.configService.getConfig('edition.url') ?
+              this.configService.getConfig('edition.url') + baseUrl + '?' + deleteUrl :
+              baseUrl + '?' + deleteUrl;
           } else {
-            url = this.configService.getConfig('edition.url') + deleteUrl;
+            url = this.configService.getConfig('edition.url') ?
+              this.configService.getConfig('edition.url') + deleteUrl : deleteUrl;
           }
 
           for (const column of workspace.meta.tableTemplate.columns) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Edition url is only defined by config


**What is the new behavior?**
You can now define url absolute path in the layer edition options


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
