### PR TITLE
fix(query): don't show message when feature count is 1 or less

### DIFF
--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -314,7 +314,6 @@ export class QueryService {
         features = this.extractGML2Data(res, layer, allowedFieldsAndAlias);
         break;
     }
-
     if (features.length > 0 && features[0].geometry === null) {
       const geomToAdd = this.createGeometryFromUrlClick(url);
 
@@ -330,7 +329,7 @@ export class QueryService {
 
     if (
       featureCount.test(url) &&
-      ((wmsDatasource.params?.FEATURE_COUNT && features.length === this.featureCount) ||
+      ((wmsDatasource.params?.FEATURE_COUNT && this.featureCount > 1 && features.length === this.featureCount) ||
       (!wmsDatasource.params?.FEATURE_COUNT && features.length === this.defaultFeatureCount))) {
       this.languageService.translate.get('igo.geo.query.featureCountMax', {value: layer.title}).subscribe(message => {
         const messageObj = this.messageService.info(message);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When layer feature count is set to 1, message always show


**What is the new behavior?**
When feature count is less than 1, never show the message


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
