### PR TITLE
feat(import): controls for import formats

### DIFF
--- a/packages/geo/src/lib/import-export/shared/import.interface.ts
+++ b/packages/geo/src/lib/import-export/shared/import.interface.ts
@@ -1,7 +1,9 @@
+import { ExportFormat } from "./export.type";
+
 export interface ImportExportServiceOptions {
   url: string;
   clientSideFileSizeMaxMb?: number;
   forceNaming?: boolean;
-  formats?: string[];
+  formats?: ExportFormat[];
   configFileToGeoDBService?: string;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
There is no method to control allowed formats during imports.


**What is the new behavior?**
Reuse an existing interface (export config--> formats) to control allowed formats. 
https://github.com/infra-geo-ouverte/igo2-lib/blob/master/packages/geo/src/lib/import-export/shared/import.interface.ts#L5



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
