### PR TITLE
Hover projection

### DIFF
--- a/packages/context/src/lib/context-manager/shared/map-context.directive.ts
+++ b/packages/context/src/lib/context-manager/shared/map-context.directive.ts
@@ -59,7 +59,7 @@ export class MapContextDirective implements OnInit, OnDestroy {
     // this.component.map.ol.setTarget(target);
 
     const viewContext: ContextMapView = context.map.view;
-    if (!this.component.view || viewContext.keepCurrentView !== true) {
+    if (!this.component.view || viewContext.keepCurrentView !== true || context.map.view.projection !== this.map.projection) {
       this.component.view = viewContext as MapViewOptions;
     }
     if (this.component.map.geolocationController) {

--- a/packages/geo/src/lib/map/shared/hover-feature.directive.ts
+++ b/packages/geo/src/lib/map/shared/hover-feature.directive.ts
@@ -148,7 +148,7 @@ export class HoverFeatureDirective implements OnInit, OnDestroy {
       zIndex: 901,
       renderMode: "vector",
       declutter: true,
-      source: new olVectorTileSource({}),
+      source: new olVectorTileSource({projection: this.map.projection}),
       style: (feature, resolution) => {
         if (this.mvtStyleOptions && feature.getId() in this.selectionMVT) {
           return this.createHoverStyle(feature, this.mvtStyleOptions, resolution);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
If a view projection is define, (not the default one), the igoHoverDirective cause app to crash....

On context change, the view was not reloaded if the projection was different.

**What is the new behavior?**
Provide proj to vectortile source in hover directive to fix it. 

On context change, change the view depite the keepcurrentview property. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
