### PR TITLE
fix(search-results): hide empty result during typing

### DIFF
--- a/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.html
+++ b/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.html
@@ -7,7 +7,7 @@
 </div>
 
 <igo-flexible
-  *ngIf="store && (store.stateView.empty$ | async)===false"
+  *ngIf="term.length >= 2 && (debouncedEmpty$ | async) === false"
   #topPanel
   initial="100%"
   initialMobile="100%"


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
this update relate to the issue [792](https://github.com/infra-geo-ouverte/igo2/issues/792) on igo2


**What is the new behavior?**
To hide empty message during typing
