### PR TITLE
feat(geo): add new option to change coord format

### DIFF
--- a/packages/geo/src/lib/search/search-bar/search-bar.component.html
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.html
@@ -43,6 +43,10 @@
       (pointerSummaryStatus)="pointerSummaryStatus.emit($event)"
       [searchResultsGeometryEnabled]="searchResultsGeometryEnabled"
       (searchResultsGeometryStatus)="searchResultsGeometryStatus.emit($event)"
+
+      [changeSearchCoordsFormatEnabled]="changeSearchCoordsFormatEnabled"
+      (changeSearchCoordsFormatStatus)="changeSearchCoordsFormatStatus.emit($event)"
+
       (searchSourceChange)="onSearchSettingsChange()">
     </igo-search-settings>
   </div>

--- a/packages/geo/src/lib/search/search-bar/search-bar.component.ts
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.ts
@@ -106,6 +106,11 @@ export class SearchBarComponent implements OnInit, OnDestroy {
    */
    @Output() searchResultsGeometryStatus = new EventEmitter<boolean>();
 
+   /**
+   * Event emitted when the coords format setting is changed
+   */
+   @Output() changeSearchCoordsFormatStatus = new EventEmitter<boolean>();
+
   /**
    * Search term
    */
@@ -132,6 +137,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 
   @Input() pointerSummaryEnabled: boolean = false;
   @Input() searchResultsGeometryEnabled: boolean = false;
+  @Input() changeSearchCoordsFormatEnabled: boolean = false;
   /**
    * Whether a float label should be displayed
    */

--- a/packages/geo/src/lib/search/search-results/search-results-item.component.ts
+++ b/packages/geo/src/lib/search/search-results/search-results-item.component.ts
@@ -10,6 +10,10 @@ import {
 import { SearchResult } from '../shared/search.interfaces';
 import { FeatureMotion, moveToOlFeatures } from '../../feature';
 import { IgoMap } from '../../map';
+import { CoordinatesReverseSearchSource } from '../shared/sources/coordinates';
+import { ConfigService, StorageService } from '@igo2/core';
+
+//import { SearchState } from '@igo2/integration'
 
 /**
  * Search results list item
@@ -77,7 +81,17 @@ export class SearchResultsItemComponent {
     return getEntityIcon(this.result);
   }
 
-  constructor() {}
+  private changeSearchCoordsFormatEnabled: boolean = false;
+
+  constructor(private storageService: StorageService) {}
+
+  ngOnInit() {
+    this.changeSearchCoordsFormatEnabled = this.storageService.get('changeSearchCoordsFormatEnabled') as boolean || false;
+    if(this.changeSearchCoordsFormatEnabled && this.result.source.getId() === CoordinatesReverseSearchSource.id) {
+      const coords: [number, number] = this.result.data.geometry.coordinates;
+      this.result.meta.titleHtml = `${coords[1]}, ${coords[0]}`;
+    }  
+  }
 
   onZoomHandler() {
     const olFeature = this.format.readFeature(this.result.data, {

--- a/packages/geo/src/lib/search/search-settings/search-settings.component.html
+++ b/packages/geo/src/lib/search/search-settings/search-settings.component.html
@@ -94,6 +94,13 @@
             (click)="$event.stopPropagation()" [checked]="searchResultsGeometryEnabled" [labelPosition]="'after'">
             {{'igo.geo.search.searchResultsGeometry.title' | translate}}
           </mat-slide-toggle>
+
+          <mat-slide-toggle class="pointer-summary-option" (change)="changeSearchCoordsFormat($event)" tooltip-position="below"
+            matTooltipShowDelay="500" matTooltip="long-lat vs lat-long"
+            (click)="$event.stopPropagation()" [checked]="changeSearchCoordsFormatEnabled" [labelPosition]="'after'">
+            long-lat vs lat-long
+          </mat-slide-toggle>
+
         </span>
       </span>
   </mat-menu>

--- a/packages/geo/src/lib/search/search-settings/search-settings.component.ts
+++ b/packages/geo/src/lib/search/search-settings/search-settings.component.ts
@@ -53,6 +53,7 @@ export class SearchSettingsComponent implements OnInit {
 
   @Input() pointerSummaryEnabled: boolean = false;
   @Input() searchResultsGeometryEnabled: boolean = false;
+  @Input() changeSearchCoordsFormatEnabled: boolean = false;
 
   /**
    * Event emitted when the enabled search source changes
@@ -68,6 +69,11 @@ export class SearchSettingsComponent implements OnInit {
    * Event emitted when the show geometry summary is changed
    */
   @Output() searchResultsGeometryStatus = new EventEmitter<boolean>();
+
+  /**
+   * Event emitted when the coords format is changed
+   */
+  @Output() changeSearchCoordsFormatStatus = new EventEmitter<boolean>();
 
   @HostListener('document:keydown', ['$event'])
   handleKeyboardEvent(event: KeyboardEvent) {
@@ -250,5 +256,10 @@ export class SearchSettingsComponent implements OnInit {
   changeSearchResultsGeometry(event) {
     this.searchResultsGeometryEnabled = event.checked;
     this.searchResultsGeometryStatus.emit(this.searchResultsGeometryEnabled);
+  }
+
+  changeSearchCoordsFormat(event) {
+    this.changeSearchCoordsFormatEnabled = event.checked;
+    this.changeSearchCoordsFormatStatus.emit(this.changeSearchCoordsFormatEnabled);
   }
 }


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

this update relate to the issue [782](https://github.com/infra-geo-ouverte/igo2/issues/782) on igo2


**What is the new behavior?**

Add new option in search settings to Reverse coords format from 'lonlat' to 'latLon'
