### PR TITLE
refactor(search-bar): switched from input to config for search button

### DIFF
--- a/packages/geo/src/lib/search/search-bar/search-bar.component.html
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.html
@@ -5,7 +5,7 @@
       #input
       matInput
       autocomplete="off"
-      [ngClass]="{'hasSearchIcon': searchIcon}"
+      [ngClass]="{'hasSearchIcon': showSearchButton}"
       [disabled]="disabled$ | async"
       [placeholder]="placeholder ? placeholder : (placeholder$ | async) ? (placeholder$.value | translate) : undefined"
       [value]="term$ | async"
@@ -22,10 +22,10 @@
       <mat-icon svgIcon="close"></mat-icon>
     </button>
     
-    <button *ngIf="searchIcon !== undefined"
+    <button *ngIf="showSearchButton"
       mat-icon-button
       [color]="color">
-      <mat-icon [svgIcon]="searchIcon"></mat-icon>
+      <mat-icon svgIcon="magnify"></mat-icon>
     </button>
 
     <igo-search-selector

--- a/packages/geo/src/lib/search/search-bar/search-bar.component.ts
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.ts
@@ -255,8 +255,8 @@ export class SearchBarComponent implements OnInit, OnDestroy {
       .pipe(distinctUntilChanged())
       .subscribe((searchType: string) => this.onSetSearchType(searchType));
 
-    this.showSearchButton = this.configService.getConfig("searchBar.showSearchButton") !== undefined ?
-      this.configService.getConfig("searchBar.showSearchButton") : false;
+    const configValue = this.configService.getConfig("searchBar.showSearchButton");
+    this.showSearchButton = configValue !== undefined ? configValue : false;
   }
 
   /**

--- a/packages/geo/src/lib/search/search-bar/search-bar.component.ts
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.ts
@@ -16,7 +16,7 @@ import {
 import { BehaviorSubject, Subscription, timer } from 'rxjs';
 import { debounce, distinctUntilChanged } from 'rxjs/operators';
 
-import { LanguageService } from '@igo2/core';
+import { ConfigService } from '@igo2/core';
 import { EntityStore } from '@igo2/common';
 
 import { SEARCH_TYPES } from '../shared/search.enums';
@@ -76,6 +76,12 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   private searchType$$: Subscription;
 
   private researches$$: Subscription[];
+
+  /**
+   * whether to show search button or not
+   */
+
+  public showSearchButton: boolean = false;
 
   /**
    * List of available search types
@@ -161,11 +167,6 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   @Input() minLength = 2;
 
   /**
-   * Search icon
-   */
-  @Input() searchIcon: string;
-
-  /**
    * Search Selector
    */
   @Input() searchSelector = false;
@@ -228,7 +229,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   }
 
   constructor(
-    private languageService: LanguageService,
+    private configService: ConfigService,
     private searchService: SearchService,
     private searchSourceService: SearchSourceService
   ) {}
@@ -253,6 +254,9 @@ export class SearchBarComponent implements OnInit, OnDestroy {
     this.searchType$$ = this.searchType$
       .pipe(distinctUntilChanged())
       .subscribe((searchType: string) => this.onSetSearchType(searchType));
+
+    this.showSearchButton = this.configService.getConfig("searchBar.showSearchButton") !== undefined ?
+      this.configService.getConfig("searchBar.showSearchButton") : false;
   }
 
   /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
To add a search button to the search bar, the user must add an input to the component.


**What is the new behavior?**
The user must add a config to the config file


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
See https://github.com/infra-geo-ouverte/igo2/pull/898
