### PR TITLE
fix(mapOfflineDirective): keep layer's maxResolution on online/offlin…

### DIFF
--- a/packages/geo/src/lib/map/shared/mapOffline.directive.ts
+++ b/packages/geo/src/lib/map/shared/mapOffline.directive.ts
@@ -120,13 +120,13 @@ export class MapOfflineDirective implements AfterViewInit {
           this.networkState.connection === false ||
           this.offlineButtonState.connection === false
         ) {
-          layer.ol.setMaxResolution(0);
+          layer.maxResolution = 0;
           return;
         } else if (
           this.networkState.connection === true ||
           this.offlineButtonState.connection === true
         ) {
-          layer.ol.setMaxResolution(Infinity);
+          layer.maxResolution = layer.options.maxResolution || Infinity;
           return;
         }
       }
@@ -163,12 +163,12 @@ export class MapOfflineDirective implements AfterViewInit {
             this.networkState.connection === false ||
             this.offlineButtonState.connection === false
           ) {
-            layer.ol.setMaxResolution(0);
+            layer.maxResolution = 0;
           } else if (
             this.networkState.connection === true ||
             this.offlineButtonState.connection === true
           ) {
-            layer.ol.setMaxResolution(Infinity);
+            layer.maxResolution = layer.options.maxResolution || Infinity;
           }
         }
       } else {
@@ -176,12 +176,12 @@ export class MapOfflineDirective implements AfterViewInit {
           this.networkState.connection === false ||
           this.offlineButtonState.connection === false
         ) {
-          layer.ol.setMaxResolution(0);
+          layer.maxResolution = 0;
         } else if (
           this.networkState.connection === true ||
           this.offlineButtonState.connection === true
         ) {
-          layer.ol.setMaxResolution(Infinity);
+          layer.maxResolution = layer.options.maxResolution || Infinity;
         }
       }
     });


### PR DESCRIPTION
…e toggle

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
mapOfflineDirective, since version 1.14.0 was causing issues with the resolution range of each layer. If a layer has a max resolution property defined by the getcapabilities, the directive was overriding the value with Infinity. 


**What is the new behavior?**
Keep the current maxresolution of the layer. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
