### PR TITLE
Change lat/lon to wkt for edition

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -60,6 +60,7 @@ export interface EditionOptions {
   deleteUrl: string;
   modifyUrl: string;
   geomType: Type;
+  geomDatabaseProj?: string;
   hasGeometry: boolean;
   addWithDraw?: boolean;
   messages?: any[];

--- a/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
@@ -11,6 +11,7 @@ export interface FeatureDataSourceOptions extends DataSourceOptions {
   formatType?: string;
   formatOptions?: any;
 
+  params?: any;
   features?: olFeature<OlGeometry>[];
   format?: olFormatFeature;
   url?: string;

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -428,7 +428,8 @@ export class EditionWorkspaceService {
   public addFeature(feature, workspace: EditionWorkspace, url: string, headers: {[key: string]: any}) {
     if (workspace.layer.dataSource.options.edition.hasGeometry) {
       const projDest = workspace.layer.options.sourceOptions.edition.geomDatabaseProj;
-      feature.properties[workspace.layer.dataSource.options.params.fieldNameGeometry] = this.wktFormat.writeGeometry(
+      feature.properties[workspace.layer.dataSource.options.params.fieldNameGeometry] =
+      'SRID=' + projDest.replace("EPSG:", "") + ';' + this.wktFormat.writeGeometry(
         this.geoJsonFormat.readFeature(feature.geometry).getGeometry().transform('EPSG:4326', projDest),
         { dataProjection: projDest });
     }
@@ -534,9 +535,10 @@ export class EditionWorkspaceService {
       const projDest = workspace.layer.options.sourceOptions.edition.geomDatabaseProj;
       // Remove 3e dimension
       feature.geometry.coordinates = removeZ(feature.geometry.coordinates);
-      feature.properties[workspace.layer.dataSource.options.params.fieldNameGeometry] = this.wktFormat.writeGeometry(
-        this.geoJsonFormat.readFeature(feature.geometry).getGeometry().transform('EPSG:4326', projDest),
-        { dataProjection: projDest });
+      feature.properties[workspace.layer.dataSource.options.params.fieldNameGeometry] =
+        'SRID=' + projDest.replace("EPSG:", "") + ';' + this.wktFormat.writeGeometry(
+          this.geoJsonFormat.readFeature(feature.geometry).getGeometry().transform('EPSG:4326', projDest),
+          { dataProjection: projDest });
     }
 
     for (const property in feature.properties) {

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -34,6 +34,8 @@ import { IgoMap } from '../../map';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { EditionWorkspace } from './edition-workspace';
 
+import WKT from 'ol/format/WKT';
+import GeoJSON from 'ol/format/GeoJSON';
 import olFeature from 'ol/Feature';
 import olSourceImageWMS from 'ol/source/ImageWMS';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
@@ -49,6 +51,8 @@ export class EditionWorkspaceService {
   public relationLayers$ = new BehaviorSubject<ImageLayer[] | VectorLayer[]>(undefined);
   public rowsInMapExtentCheckCondition$ = new BehaviorSubject<boolean>(true);
   public loading = false;
+  public wktFormat = new WKT();
+  public geoJsonFormat = new GeoJSON();
 
   get zoomAuto(): boolean {
     return this.storageService.get('zoomAuto') as boolean;
@@ -422,11 +426,11 @@ export class EditionWorkspaceService {
   }
 
   public addFeature(feature, workspace: EditionWorkspace, url: string, headers: {[key: string]: any}) {
-    // TODO: adapt to any kind of geometry
     if (workspace.layer.dataSource.options.edition.hasGeometry) {
-      //feature.properties[geom] = feature.geometry;
-      feature.properties["longitude"] = feature.geometry.coordinates[0];
-      feature.properties["latitude"] = feature.geometry.coordinates[1];
+      const projDest = workspace.layer.options.sourceOptions.edition.geomDatabaseProj;
+      feature.properties[workspace.layer.dataSource.options.params.fieldNameGeometry] = this.wktFormat.writeGeometry(
+        this.geoJsonFormat.readFeature(feature.geometry).getGeometry().transform('EPSG:4326', projDest),
+        { dataProjection: projDest });
     }
 
     for (const property in feature.properties) {
@@ -526,11 +530,13 @@ export class EditionWorkspaceService {
   }
 
   public modifyFeature(feature, workspace: EditionWorkspace, url: string, headers: {[key: string]: any}, protocole = 'patch' ) {
-    //TODO: adapt to any kind of geometry
     if (workspace.layer.dataSource.options.edition.hasGeometry) {
-      //feature.properties[geom] = feature.geometry;
-      feature.properties["longitude"] = feature.geometry.coordinates[0];
-      feature.properties["latitude"] = feature.geometry.coordinates[1];
+      const projDest = workspace.layer.options.sourceOptions.edition.geomDatabaseProj;
+      // Remove 3e dimension
+      feature.geometry.coordinates = removeZ(feature.geometry.coordinates);
+      feature.properties[workspace.layer.dataSource.options.params.fieldNameGeometry] = this.wktFormat.writeGeometry(
+        this.geoJsonFormat.readFeature(feature.geometry).getGeometry().transform('EPSG:4326', projDest),
+        { dataProjection: projDest });
     }
 
     for (const property in feature.properties) {
@@ -773,4 +779,10 @@ function getColumnKeyWithoutPropertiesTag(column: string) {
     return column.split('.')[1];
   }
   return column;
+}
+
+function removeZ(coords: any) {
+  if (coords.length === 0) return coords;
+  if (typeof coords[0] === 'number') return coords.slice(0, 2);
+  return coords.map(removeZ);
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

Use lat/lon to save geometry (Point only) in edition

**What is the new behavior?**

Use wkt to save geometry in edition

**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**

Remove the trigger on database table (the one who convert lat/lon in geometry). Add the geometry database projection "geomDatabaseProj" parameter in layer definition at sourceOptions->edition

**Other information**:
