### PR TITLE
fix (context) Export context bug local layer

### DIFF
--- a/packages/context/src/lib/context-import-export/context-import-export/context-import-export.component.ts
+++ b/packages/context/src/lib/context-import-export/context-import-export/context-import-export.component.ts
@@ -58,7 +58,7 @@ export class ContextImportExportComponent implements OnInit {
       (configFileSizeMb ? configFileSizeMb : 30) * Math.pow(1024, 2);
     this.fileSizeMb = this.clientSideFileSizeMax / Math.pow(1024, 2);
     this.layerList = this.contextService.getContextLayers(this.map);
-    this.userControlledLayerList = this.layerList.filter(layer => layer.showInLayerList);
+    this.userControlledLayerList = this.layerList.filter(layer => layer.showInLayerList && !layer.isIgoInternalLayer);
   }
 
   importFiles(files: File[]) {


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/infra-geo-ouverte/igo2/issues/711


**What is the new behavior?**
Now the local import layer is not present in the layer selection to export. 
So, user do not have possibility to export local layer and no bug appear.



