### PR TITLE
feat(geo): add splitTextToSize to optimise long comment on more lines

### DIFF
--- a/packages/geo/src/lib/print/shared/print.service.ts
+++ b/packages/geo/src/lib/print/shared/print.service.ts
@@ -43,7 +43,7 @@ export class PrintService {
     subtitleFontStyle: 'bold',
     commentFont: 'courier',
     commentFontStyle: 'normal',
-    commentFontSize: 16
+    commentFontSize: 12
   };
 
   constructor(
@@ -75,7 +75,7 @@ export class PrintService {
       doc.internal.pageSize.height
     ];
 
-    const margins = [10, 10, 10, 10];
+    const margins = [5, 10, 10, 10];
     const width = dimensions[0] - margins[3] - margins[1];
     const height = dimensions[1] - margins[0] - margins[2];
     const size = [width, height];
@@ -135,7 +135,7 @@ export class PrintService {
         );
     }
     if (options.comment !== '') {
-      this.addComment(doc, options.comment);
+      this.addComment(doc, options.comment, width);
     }
 
     this.addMap(doc, map, resolution, size, margins).subscribe(
@@ -376,16 +376,17 @@ export class PrintService {
    * * @param  doc - pdf document
    * * @param  comment - Comment to add in the document
    */
-  private addComment(doc: jsPDF, comment: string) {
-    const commentMarginLeft = 20; //margin left and bottom is fix
-    const commentMarginBottom = 5;
+  private addComment(doc: jsPDF, comment: string, width: number) {
+    const commentMarginLeft = 10; //margin left and bottom is fix
+    const commentMarginBottom = 10;
     const marginTop = doc.internal.pageSize.height - commentMarginBottom;
     this. addTextInPdfDoc(doc,comment,
       this.TEXTPDFFONT.commentFont,
       this.TEXTPDFFONT.commentFontStyle,
       this.TEXTPDFFONT.commentFontSize,
       commentMarginLeft,
-      marginTop
+      marginTop,
+      width
     );
   }
 
@@ -395,11 +396,16 @@ export class PrintService {
     textFontStyle: string,
     textFontSize: number,
     textMarginLeft: number,
-    textMarginTop: number)
+    textMarginTop: number,
+    width?: number)
     {
       doc.setFont(textFont, textFontStyle);
       doc.setFontSize(textFontSize);
-      doc.text(textToAdd, textMarginLeft, textMarginTop);
+      let text = textToAdd;
+      if(width) {
+        text = doc.splitTextToSize(textToAdd, width);
+      }
+      doc.text(text, textMarginLeft, textMarginTop);
     }
 
   /**
@@ -418,7 +424,7 @@ export class PrintService {
     scale: boolean
   ) {
     const translate = this.languageService.translate;
-    const projScaleSize = 16;
+    const projScaleSize = 12;
     const projScaleMarginLeft = 20;
     const marginBottom = 15;
     const heightPixels = doc.internal.pageSize.height - marginBottom;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

This update relate to the issue [385](https://github.com/infra-geo-ouverte/igo2/issues/385) in igo2.

**What is the new behavior?**

Allow a long comment on more than one line in print issue