### PR TITLE
refactor(*): remove language service where used to translate a message

### DIFF
--- a/demo/src/app/geo/spatial-filter/spatial-filter.component.ts
+++ b/demo/src/app/geo/spatial-filter/spatial-filter.component.ts
@@ -243,12 +243,8 @@ export class AppSpatialFilterComponent implements OnInit, OnDestroy {
 
               if (features.length >= 10000) {
                 this.messageService.alert(
-                  this.languageService.translate.instant(
-                    'igo.geo.spatialFilter.maxSizeAlert'
-                  ),
-                  this.languageService.translate.instant(
-                    'igo.geo.spatialFilter.warning'
-                  ),
+                  'igo.geo.spatialFilter.maxSizeAlert',
+                  'igo.geo.spatialFilter.warning',
                   { timeOut: 10000 }
                 );
               }
@@ -261,12 +257,8 @@ export class AppSpatialFilterComponent implements OnInit, OnDestroy {
       this.loading = false;
       if (zeroResults) {
         this.messageService.alert(
-          this.languageService.translate.instant(
-            'igo.geo.spatialFilter.zeroResults'
-          ),
-          this.languageService.translate.instant(
-            'igo.geo.spatialFilter.warning'
-          ),
+          'igo.geo.spatialFilter.zeroResults',
+          'igo.geo.spatialFilter.warning',
           { timeOut: 10000 }
         );
       }

--- a/packages/auth/src/lib/shared/auth.service.ts
+++ b/packages/auth/src/lib/shared/auth.service.ts
@@ -171,11 +171,7 @@ export class AuthService {
             this.languageService.setLanguage(tokenDecoded.user.locale);
           }
           if (tokenDecoded.user.isExpired) {
-            this.languageService.translate
-              .get('igo.auth.error.Password expired')
-              .subscribe((expiredAlert) =>
-                this.messageService.alert(expiredAlert)
-              );
+              this.messageService.alert('igo.auth.error.Password expired');
           }
         }
         this.authenticate$.next(true);

--- a/packages/context/src/lib/context-import-export/context-import-export/context-import-export.component.ts
+++ b/packages/context/src/lib/context-import-export/context-import-export/context-import-export.component.ts
@@ -3,7 +3,7 @@ import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms
 import { BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
-import { MessageService, LanguageService, ConfigService } from '@igo2/core';
+import { MessageService, ConfigService } from '@igo2/core';
 import { Layer, VectorLayer } from '@igo2/geo';
 import type { IgoMap } from '@igo2/geo';
 
@@ -41,7 +41,6 @@ export class ContextImportExportComponent implements OnInit {
   constructor(
     private contextImportService: ContextImportService,
     private contextExportService: ContextExportService,
-    private languageService: LanguageService,
     private messageService: MessageService,
     private formBuilder: UntypedFormBuilder,
     private config: ConfigService,
@@ -104,7 +103,6 @@ export class ContextImportExportComponent implements OnInit {
       file,
       context,
       this.messageService,
-      this.languageService,
       this.contextService
     );
   }
@@ -115,18 +113,17 @@ export class ContextImportExportComponent implements OnInit {
       file,
       error,
       this.messageService,
-      this.languageService,
       this.fileSizeMb
     );
   }
 
   private onFileExportError(error: Error) {
     this.loading$.next(false);
-    handleFileExportError(error, this.messageService, this.languageService);
+    handleFileExportError(error, this.messageService);
   }
 
   private onFileExportSuccess() {
-    handleFileExportSuccess(this.messageService, this.languageService);
+    handleFileExportSuccess(this.messageService);
   }
 
   selectAll(e) {

--- a/packages/context/src/lib/context-import-export/shared/context-export.utils.ts
+++ b/packages/context/src/lib/context-import-export/shared/context-export.utils.ts
@@ -1,37 +1,27 @@
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { ExportNothingToExportError } from './context-export.errors';
 
 export function handleFileExportError(
     error: Error,
-    messageService: MessageService,
-    languageService: LanguageService
+    messageService: MessageService
   ) {
     if (error instanceof ExportNothingToExportError) {
-      this.handleNothingToExportError(messageService, languageService);
+      this.handleNothingToExportError(messageService);
       return;
     }
-    const translate = languageService.translate;
-    const title = translate.instant('igo.context.contextImportExport.export.failed.title');
-    const message = translate.instant('igo.context.contextImportExport.export.failed.text');
-    messageService.error(message, title);
+    messageService.error(
+      'igo.context.contextImportExport.export.failed.text',
+      'igo.context.contextImportExport.export.failed.title');
 }
 
 export function handleFileExportSuccess(
-    messageService: MessageService,
-    languageService: LanguageService
+    messageService: MessageService
   ) {
-    const translate = languageService.translate;
-    const title = translate.instant('igo.context.contextImportExport.export.success.title');
-    const message = translate.instant('igo.context.contextImportExport.export.success.text');
-    messageService.success(message, title);
+    messageService.success('igo.context.contextImportExport.export.success.text', 'igo.context.contextImportExport.export.success.title');
 }
 
 export function handleNothingToExportError(
     messageService: MessageService,
-    languageService: LanguageService
   ) {
-    const translate = languageService.translate;
-    const title = translate.instant('igo.context.contextImportExport.export.nothing.title');
-    const message = translate.instant('igo.context.contextImportExport.export.nothing.text');
-    messageService.error(message, title);
+    messageService.error('igo.context.contextImportExport.export.nothing.text', 'igo.context.contextImportExport.export.nothing.title');
 }

--- a/packages/context/src/lib/context-import-export/shared/context-import.utils.ts
+++ b/packages/context/src/lib/context-import-export/shared/context-import.utils.ts
@@ -14,7 +14,7 @@ import {
   ClusterDataSourceOptions,
   ClusterDataSource
 } from '@igo2/geo';
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { DetailedContext } from '../../context-manager/shared/context.interface';
 import { ContextService } from '../../context-manager/shared/context.service';
 import OlFeature from 'ol/Feature';
@@ -23,11 +23,10 @@ export function handleFileImportSuccess(
   file: File,
   context: DetailedContext,
   messageService: MessageService,
-  languageService: LanguageService,
   contextService: ContextService
 ) {
   if (Object.keys(context).length <= 0) {
-    handleNothingToImportError(file, messageService, languageService);
+    handleNothingToImportError(file, messageService);
     return;
   }
 
@@ -35,24 +34,17 @@ export function handleFileImportSuccess(
 
   addContextToContextList(context, contextTitle, contextService);
 
-  const translate = languageService.translate;
-  const messageTitle = translate.instant(
-    'igo.context.contextImportExport.import.success.title'
-  );
-  const message = translate.instant(
+  messageService.success(
     'igo.context.contextImportExport.import.success.text',
-    {
+    'igo.context.contextImportExport.import.success.title', undefined, {
       value: contextTitle
-    }
-  );
-  messageService.success(message, messageTitle);
+    });
 }
 
 export function handleFileImportError(
   file: File,
   error: Error,
   messageService: MessageService,
-  languageService: LanguageService,
   sizeMb?: number
 ) {
   sizeMb = sizeMb ? sizeMb : 30;
@@ -65,7 +57,6 @@ export function handleFileImportError(
     file,
     error,
     messageService,
-    languageService,
     sizeMb
   );
 }
@@ -74,78 +65,57 @@ export function handleInvalidFileImportError(
   file: File,
   error: Error,
   messageService: MessageService,
-  languageService: LanguageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant(
-    'igo.context.contextImportExport.import.invalid.title'
-  );
-  const message = translate.instant(
+  messageService.error(
     'igo.context.contextImportExport.import.invalid.text',
+    'igo.context.contextImportExport.import.invalid.title',
+    undefined,
     {
       value: file.name,
       mimeType: file.type
     }
   );
-  messageService.error(message, title);
 }
 
 export function handleSizeFileImportError(
   file: File,
   error: Error,
   messageService: MessageService,
-  languageService: LanguageService,
   sizeMb: number
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant(
-    'igo.context.contextImportExport.import.tooLarge.title'
-  );
-  const message = translate.instant(
+  messageService.error(
     'igo.context.contextImportExport.import.tooLarge.text',
+    'igo.context.contextImportExport.import.tooLarge.title',
+    undefined,
     {
       value: file.name,
       size: sizeMb
-    }
-  );
-  messageService.error(message, title);
+    });
 }
 
 export function handleUnreadbleFileImportError(
   file: File,
   error: Error,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant(
-    'igo.context.contextImportExport.import.unreadable.title'
-  );
-  const message = translate.instant(
+  messageService.error(
     'igo.context.contextImportExport.import.unreadable.text',
+    'igo.context.contextImportExport.import.unreadable.title',
+    undefined,
     {
       value: file.name
-    }
-  );
-  messageService.error(message, title);
+    });
 }
 
 export function handleNothingToImportError(
   file: File,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant(
-    'igo.context.contextImportExport.import.empty.title'
-  );
-  const message = translate.instant(
+  messageService.error(
     'igo.context.contextImportExport.import.empty.text',
-    {
-      value: file.name
-    }
-  );
-  messageService.error(message, title);
+    'igo.context.contextImportExport.import.empty.title',
+    undefined,
+    { value: file.name });
 }
 
 export function addContextToContextList(

--- a/packages/context/src/lib/context-manager/context-edit/context-edit-binding.directive.ts
+++ b/packages/context/src/lib/context-manager/context-edit/context-edit-binding.directive.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 
 import { Context, DetailedContext } from '../shared/context.interface';
 import { ContextService } from '../shared/context.service';
@@ -28,12 +28,13 @@ export class ContextEditBindingDirective implements OnInit, OnDestroy {
   onEdit(context: Context) {
     const id = this.component.context.id;
     this.contextService.update(id, context).subscribe(() => {
-      const translate = this.languageService.translate;
-      const message = translate.instant('igo.context.contextManager.dialog.saveMsg', {
+      this.messageService.success(
+        'igo.context.contextManager.dialog.saveMsg',
+        'igo.context.contextManager.dialog.saveTitle',
+        undefined,
+      {
         value: context.title || this.component.context.title
       });
-      const title = translate.instant('igo.context.contextManager.dialog.saveTitle');
-      this.messageService.success(message, title);
       this.contextService.setEditedContext(undefined);
       this.submitSuccessed.emit(context);
     });
@@ -42,8 +43,7 @@ export class ContextEditBindingDirective implements OnInit, OnDestroy {
   constructor(
     @Self() component: ContextEditComponent,
     private contextService: ContextService,
-    private messageService: MessageService,
-    private languageService: LanguageService
+    private messageService: MessageService
   ) {
     this.component = component;
   }

--- a/packages/context/src/lib/context-manager/context-form/context-form.component.ts
+++ b/packages/context/src/lib/context-manager/context-form/context-form.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 
 import { ObjectUtils, Clipboard } from '@igo2/utils';
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { Context } from '../shared/context.interface';
 
 @Component({
@@ -49,7 +49,6 @@ export class ContextFormComponent implements OnInit {
 
   constructor(
     private formBuilder: UntypedFormBuilder,
-    private languageService: LanguageService,
     private messageService: MessageService
   ) {}
 
@@ -73,14 +72,7 @@ export class ContextFormComponent implements OnInit {
     const text = this.prefix + '-' + this.form.value.uri.replace(' ', '');
     const successful = Clipboard.copy(text);
     if (successful) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.context.contextManager.dialog.copyTitle'
-      );
-      const msg = translate.instant(
-        'igo.context.contextManager.dialog.copyMsg'
-      );
-      this.messageService.success(msg, title);
+      this.messageService.success('igo.context.contextManager.dialog.copyMsg', 'igo.context.contextManager.dialog.copyTitle');
     }
   }
 

--- a/packages/context/src/lib/context-manager/context-list/context-list-binding.directive.ts
+++ b/packages/context/src/lib/context-manager/context-list/context-list-binding.directive.ts
@@ -49,17 +49,13 @@ export class ContextListBindingDirective implements OnInit, OnDestroy {
     const contextFromMap = this.contextService.getContextFromMap(map);
 
     const msgSuccess = () => {
-      const translate = this.languageService.translate;
-      const message = translate.instant(
+      this.messageService.success(
         'igo.context.contextManager.dialog.saveMsg',
+        'igo.context.contextManager.dialog.saveTitle',
+        undefined,
         {
           value: context.title
-        }
-      );
-      const title = translate.instant(
-        'igo.context.contextManager.dialog.saveTitle'
-      );
-      this.messageService.success(message, title);
+        });
     };
 
     if (context.imported) {
@@ -94,17 +90,14 @@ export class ContextListBindingDirective implements OnInit, OnDestroy {
         this.messageService.remove(this.previousMessageId);
       }
       this.contextService.defaultContextId$.next(context.id);
-      const translate = this.languageService.translate;
-      const message = translate.instant(
+      const messageObj = this.messageService.success(
         'igo.context.contextManager.dialog.favoriteMsg',
-        {
-          value: context.title
-        }
+      'igo.context.contextManager.dialog.favoriteTitle',
+      undefined,
+      {
+        value: context.title
+      }
       );
-      const title = translate.instant(
-        'igo.context.contextManager.dialog.favoriteTitle'
-      );
-      const messageObj = this.messageService.success(message, title);
       this.previousMessageId = messageObj.toastId;
       this.cdRef.detectChanges();
     });
@@ -132,16 +125,11 @@ export class ContextListBindingDirective implements OnInit, OnDestroy {
           this.contextService
             .delete(context.id, context.imported)
             .subscribe(() => {
-              const message = translate.instant(
+              this.messageService.info(
                 'igo.context.contextManager.dialog.deleteMsg',
-                {
-                  value: context.title
-                }
-              );
-              const title = translate.instant(
-                'igo.context.contextManager.dialog.deleteTitle'
-              );
-              this.messageService.info(message, title);
+                'igo.context.contextManager.dialog.deleteTitle',
+                undefined,
+                {value: context.title});
             });
         }
       });
@@ -154,17 +142,11 @@ export class ContextListBindingDirective implements OnInit, OnDestroy {
       uri: context.uri + '-copy'
     };
     this.contextService.clone(context.id, properties).subscribe(() => {
-      const translate = this.languageService.translate;
-      const message = translate.instant(
+      this.messageService.success(
         'igo.context.contextManager.dialog.cloneMsg',
-        {
-          value: context.title
-        }
-      );
-      const title = translate.instant(
-        'igo.context.contextManager.dialog.cloneTitle'
-      );
-      this.messageService.success(message, title);
+        'igo.context.contextManager.dialog.cloneTitle',
+        undefined,
+        { value: context.title });
     });
   }
 
@@ -177,17 +159,11 @@ export class ContextListBindingDirective implements OnInit, OnDestroy {
     );
     context.title = title;
     this.contextService.create(context).subscribe(() => {
-      const translate = this.languageService.translate;
-      const titleD = translate.instant(
-        'igo.context.bookmarkButton.dialog.createTitle'
-      );
-      const message = translate.instant(
+      this.messageService.success(
         'igo.context.bookmarkButton.dialog.createMsg',
-        {
-          value: context.title
-        }
-      );
-      this.messageService.success(message, titleD);
+        'igo.context.bookmarkButton.dialog.createTitle',
+        undefined,
+        { value: context.title });
       this.contextService.loadContext(context.uri);
     });
   }

--- a/packages/context/src/lib/context-manager/context-permissions/context-permissions-binding.directive.ts
+++ b/packages/context/src/lib/context-manager/context-permissions/context-permissions-binding.directive.ts
@@ -27,15 +27,11 @@ export class ContextPermissionsBindingDirective implements OnInit, OnDestroy {
 
   @HostListener('addPermission', ['$event'])
   onAddPermission(permission: ContextPermission) {
-    const translate = this.languageService.translate;
+
     if (!permission.profil) {
-      const message = translate.instant(
-        'igo.context.contextManager.errors.addPermissionEmpty'
-      );
-      const title = translate.instant(
-        'igo.context.contextManager.errors.addPermissionTitle'
-      );
-      this.messageService.error(message, title);
+      this.messageService.error(
+        'igo.context.contextManager.errors.addPermissionEmpty',
+        'igo.context.contextManager.errors.addPermissionTitle');
       return;
     }
     const contextId = this.component.context.id;
@@ -50,16 +46,11 @@ export class ContextPermissionsBindingDirective implements OnInit, OnDestroy {
           this.component.permissions[permission.typePermission].push(p);
         }
         const profil = permission.profil;
-        const message = translate.instant(
+        this.messageService.success(
           'igo.context.permission.dialog.addMsg',
-          {
-            value: profil
-          }
-        );
-        const title = translate.instant(
-          'igo.context.permission.dialog.addTitle'
-        );
-        this.messageService.success(message, title);
+          'igo.context.permission.dialog.addTitle',
+          undefined,
+          { value: profil });
         this.cd.detectChanges();
       });
   }
@@ -78,17 +69,11 @@ export class ContextPermissionsBindingDirective implements OnInit, OnDestroy {
         this.component.permissions[permission.typePermission].splice(index, 1);
 
         const profil = permission.profil;
-        const translate = this.languageService.translate;
-        const message = translate.instant(
+        this.messageService.success(
           'igo.context.permission.dialog.deleteMsg',
-          {
-            value: profil
-          }
-        );
-        const title = translate.instant(
-          'igo.context.permission.dialog.deleteTitle'
-        );
-        this.messageService.success(message, title);
+          'igo.context.permission.dialog.deleteTitle',
+          undefined,
+          { value: profil });
         this.cd.detectChanges();
       });
   }
@@ -97,17 +82,11 @@ export class ContextPermissionsBindingDirective implements OnInit, OnDestroy {
   onScopeChanged(context: Context) {
     const scope = context.scope;
     this.contextService.update(context.id, { scope }).subscribe(() => {
-      const translate = this.languageService.translate;
-      const message = translate.instant(
+      this.messageService.success(
         'igo.context.permission.dialog.scopeChangedMsg',
-        {
-          value: translate.instant('igo.context.permission.scope.' + scope)
-        }
-      );
-      const title = translate.instant(
-        'igo.context.permission.dialog.scopeChangedTitle'
-      );
-      this.messageService.success(message, title);
+        'igo.context.permission.dialog.scopeChangedTitle',
+        undefined,
+        { value: 'igo.context.permission.scope.' + scope });
     });
   }
 

--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -739,7 +739,9 @@ export class ContextService {
         'igo.context.contextManager.errors.addPermission'
       );
     }
-    this.messageService.error(error.error.message, error.error.title);
+    this.messageService.error(
+      'igo.context.contextManager.errors.addPermission',
+      'igo.context.contextManager.errors.addPermissionTitle');
   }
 
   private handleContextsChange(

--- a/packages/context/src/lib/context-map-button/bookmark-button/bookmark-button.component.ts
+++ b/packages/context/src/lib/context-map-button/bookmark-button/bookmark-button.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { take } from 'rxjs/operators';
 
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import type { IgoMap } from '@igo2/geo';
 
 import { ContextService } from '../../context-manager/shared/context.service';
@@ -35,7 +35,6 @@ export class BookmarkButtonComponent {
   constructor(
     private dialog: MatDialog,
     private contextService: ContextService,
-    private languageService: LanguageService,
     private messageService: MessageService
   ) {}
 
@@ -49,17 +48,11 @@ export class BookmarkButtonComponent {
           const context = this.contextService.getContextFromMap(this.map);
           context.title = title;
           this.contextService.create(context).subscribe(() => {
-            const translate = this.languageService.translate;
-            const titleD = translate.instant(
-              'igo.context.bookmarkButton.dialog.createTitle'
-            );
-            const message = translate.instant(
+            this.messageService.success(
               'igo.context.bookmarkButton.dialog.createMsg',
-              {
-                value: context.title
-              }
-            );
-            this.messageService.success(message, titleD);
+              'igo.context.bookmarkButton.dialog.createTitle',
+              undefined,
+              { value: context.title });
             this.contextService.loadContext(context.uri);
           });
         }

--- a/packages/context/src/lib/context-map-button/poi-button/poi-button.component.ts
+++ b/packages/context/src/lib/context-map-button/poi-button/poi-button.component.ts
@@ -66,23 +66,17 @@ export class PoiButtonComponent implements OnInit, OnDestroy {
 
   deletePoi(poi: Poi) {
     if (poi && poi.id) {
-      const translate = this.languageService.translate;
       this.confirmDialogService
-        .open(translate.instant('igo.context.poiButton.dialog.confirmDelete'))
+        .open(this.languageService.translate.instant('igo.context.poiButton.dialog.confirmDelete'))
         .subscribe(confirm => {
           if (confirm) {
             this.poiService.delete(poi.id).subscribe(
               () => {
-                const title = translate.instant(
-                  'igo.context.poiButton.dialog.deleteTitle'
-                );
-                const message = translate.instant(
+                this.messageService.info(
                   'igo.context.poiButton.dialog.deleteMsg',
-                  {
-                    value: poi.title
-                  }
-                );
-                this.messageService.info(message, title);
+                  'igo.context.poiButton.dialog.deleteTitle',
+                  undefined,
+                  { value: poi.title });
                 this.pois = this.pois.filter(p => p.id !== poi.id);
               },
               err => {
@@ -130,17 +124,11 @@ export class PoiButtonComponent implements OnInit, OnDestroy {
           poi.title = title;
           this.poiService.create(poi).subscribe(
             newPoi => {
-              const translate = this.languageService.translate;
-              const titleD = translate.instant(
-                'igo.context.poiButton.dialog.createTitle'
-              );
-              const message = translate.instant(
+              this.messageService.success(
                 'igo.context.poiButton.dialog.createMsg',
-                {
-                  value: poi.title
-                }
-              );
-              this.messageService.success(message, titleD);
+                'igo.context.poiButton.dialog.createTitle',
+                undefined,
+                { value: poi.title });
               poi.id = newPoi.id;
               this.pois.push(poi);
             },

--- a/packages/context/src/lib/share-map/share-map/share-map-api.component.ts
+++ b/packages/context/src/lib/share-map/share-map/share-map-api.component.ts
@@ -45,13 +45,11 @@ export class ShareMapApiComponent implements OnInit {
     this.shareMapService.createContextShared(this.map, inputs).subscribe(
       rep => {
         this.idContextShared = rep.id;
-        const title = this.languageService.translate.instant(
-          'igo.context.contextManager.dialog.saveTitle'
-        );
-        const msg = this.languageService.translate.instant('igo.context.contextManager.dialog.saveMsg', {
-          value: inputs.title
-        });
-        this.messageService.success(msg, title);
+        this.messageService.success(
+          'igo.context.contextManager.dialog.saveMsg',
+          'igo.context.contextManager.dialog.saveTitle',
+          undefined,
+          { value: inputs.title });
       },
       err => {
         err.error.title = this.languageService.translate.instant(
@@ -67,13 +65,11 @@ export class ShareMapApiComponent implements OnInit {
     inputs.uri = this.userId ? `${this.userId}-${values.uri}` : values.uri;
     this.shareMapService.updateContextShared(this.map, inputs, this.idContextShared).subscribe(
       rep => {
-        const title = this.languageService.translate.instant(
-          'igo.context.contextManager.dialog.saveTitle'
-        );
-        const msg = this.languageService.translate.instant('igo.context.contextManager.dialog.saveMsg', {
-          value: inputs.title
-        });
-        this.messageService.success(msg, title);
+        this.messageService.success(
+          'igo.context.contextManager.dialog.saveMsg',
+          'igo.context.contextManager.dialog.saveTitle',
+          undefined,
+          { value: inputs.title });
       },
       err => {
         err.error.title = this.languageService.translate.instant(
@@ -87,12 +83,9 @@ export class ShareMapApiComponent implements OnInit {
   copyTextToClipboard(textArea) {
     const successful = Clipboard.copy(textArea);
     if (successful) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.context.shareMap.dialog.copyTitle'
-      );
-      const msg = translate.instant('igo.context.shareMap.dialog.copyMsg');
-      this.messageService.success(msg, title);
+      this.messageService.success(
+        'igo.context.shareMap.dialog.copyMsg',
+        'igo.context.shareMap.dialog.copyTitle');
     }
   }
 

--- a/packages/context/src/lib/share-map/share-map/share-map-url.component.ts
+++ b/packages/context/src/lib/share-map/share-map/share-map-url.component.ts
@@ -53,7 +53,9 @@ export class ShareMapUrlComponent implements AfterViewInit, OnInit, OnDestroy {
   copyTextToClipboard(textArea) {
     const successful = Clipboard.copy(textArea);
     if (successful) {
-      this.messageService.success('igo.context.shareMap.dialog.copyMsg', 'igo.context.shareMap.dialog.copyTitle');
+      this.messageService.success(
+        'igo.context.shareMap.dialog.copyMsg',
+        'igo.context.shareMap.dialog.copyTitle');
     }
   }
 }

--- a/packages/core/src/lib/network/network.service.ts
+++ b/packages/core/src/lib/network/network.service.ts
@@ -3,7 +3,6 @@ import { Observable, Subscription, fromEvent } from 'rxjs';
 import { debounceTime, startWith } from 'rxjs/operators';
 
 import { MessageService } from '../message/shared/message.service';
-import { LanguageService } from '../language/shared/language.service';
 import { ConnectionState } from './network.interfaces';
 
 @Injectable({
@@ -31,10 +30,9 @@ export class NetworkService implements OnDestroy {
       if (this.previousMessageId) {
         this.messageService.remove(this.previousMessageId);
       }
-      const translate = this.injector.get(LanguageService).translate;
-      const message = translate.instant('igo.core.network.online.message');
-      const title = translate.instant('igo.core.network.online.title');
-      const messageObj = this.messageService.info(message, title);
+      const messageObj = this.messageService.info(
+        'igo.core.network.online.message',
+        'igo.core.network.online.title');
       this.previousMessageId = messageObj.toastId;
       this.state.connection = true;
       this.emitEvent();
@@ -44,10 +42,9 @@ export class NetworkService implements OnDestroy {
       if (this.previousMessageId) {
         this.messageService.remove(this.previousMessageId);
       }
-      const translate = this.injector.get(LanguageService).translate;
-      const message = translate.instant('igo.core.network.offline.message');
-      const title = translate.instant('igo.core.network.offline.title');
-      const messageObj = this.messageService.info(message, title);
+      const messageObj = this.messageService.info(
+        'igo.core.network.offline.message',
+        'igo.core.network.offline.title');
       this.previousMessageId = messageObj.toastId;
       this.state.connection = false;
       this.emitEvent();

--- a/packages/geo/src/lib/catalog/catalog-library/catalog-library.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/catalog-library.component.ts
@@ -10,7 +10,7 @@ import {
 import { MatDialog } from '@angular/material/dialog';
 
 import { EntityStore } from '@igo2/common';
-import { LanguageService, MessageService, StorageService } from '@igo2/core';
+import { MessageService, StorageService } from '@igo2/core';
 import { ObjectUtils } from '@igo2/utils';
 import { Observable, Subscription } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -72,7 +72,6 @@ export class CatalogLibaryComponent implements OnInit, OnDestroy {
   constructor(
     private capabilitiesService: CapabilitiesService,
     private messageService: MessageService,
-    private languageService: LanguageService,
     private storageService: StorageService,
     private dialog: MatDialog
   ) {}
@@ -137,13 +136,7 @@ export class CatalogLibaryComponent implements OnInit, OnDestroy {
     }
 
     if (this.store.get(id)) {
-      const title = this.languageService.translate.instant(
-        'igo.geo.catalog.library.inlist.title'
-      );
-      const message = this.languageService.translate.instant(
-        'igo.geo.catalog.library.inlist.message'
-      );
-      this.messageService.alert(message, title);
+      this.messageService.alert('igo.geo.catalog.library.inlist.message', 'igo.geo.catalog.library.inlist.title');
       return;
     }
     this.unsubscribeAddingCatalog();
@@ -152,14 +145,16 @@ export class CatalogLibaryComponent implements OnInit, OnDestroy {
     .getCapabilities(addedCatalog.type as any, addedCatalog.url, addedCatalog.version)
       .pipe(
         catchError((e) => {
-          const title = this.languageService.translate.instant('igo.geo.catalog.unavailableTitle');
           if (e.error) {
             this.addCatalogDialog(true, addedCatalog);
             e.error.caught = true;
             return e;
           }
-          const message = this.languageService.translate.instant('igo.geo.catalog.unavailable', { value: addedCatalog.url });
-          this.messageService.error(message, title);
+          this.messageService.error(
+            'igo.geo.catalog.unavailable',
+            'igo.geo.catalog.unavailableTitle',
+            undefined,
+            { value: addedCatalog.url });
           throw e;
         })
       )

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -343,18 +343,11 @@ export class CatalogService {
       .getCapabilities(sType as any, catalog.url, catalog.version)
       .pipe(
         catchError((e) => {
-          const title = this.languageService.translate.instant(
-            'igo.geo.catalog.unavailableTitle'
-          );
-          const message =
-          catalog.title ? this.languageService.translate.instant(
-            'igo.geo.catalog.unavailable',
-            { value: catalog.title }
-          ) : this.languageService.translate.instant(
-            'igo.geo.catalog.someUnavailable'
-          );
-
-          this.messageService.error(message, title);
+          this.messageService.error(
+            catalog.title ? 'igo.geo.catalog.unavailable' : 'igo.geo.catalog.someUnavailable',
+            'igo.geo.catalog.unavailableTitle',
+            undefined,
+            { value: catalog.title });
           console.error(e);
           return of(undefined);
         })
@@ -702,9 +695,8 @@ export class CatalogService {
     !capabilities.layers ? [] : capabilities.layers.filter(layer => !layer.type || layer.type === 'Feature Layer');
     if (!capabilities.layers) {
       this.messageService.error(
-        this.languageService.translate.instant('igo.geo.catalog.someUnavailable'),
-        this.languageService.translate.instant('igo.geo.catalog.unavailableTitle')
-      );
+        'igo.geo.catalog.someUnavailable',
+        'igo.geo.catalog.unavailableTitle');
     }
 
     const regexes = (catalog.regFilters || []).map(

--- a/packages/geo/src/lib/datasource/shared/datasource.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasource.service.ts
@@ -166,15 +166,11 @@ export class DataSourceService {
       observables.push(
         this.capabilitiesService.getWMSOptions(context).pipe(
           catchError(e => {
-            const title = this.languageService.translate.instant(
-              'igo.geo.dataSource.unavailableTitle'
-            );
-            const message = this.languageService.translate.instant(
+            this.messageService.error(
               'igo.geo.dataSource.unavailable',
-              { value: context.params.LAYERS }
-            );
-
-            this.messageService.error(message, title);
+              'igo.geo.dataSource.unavailableTitle',
+              undefined,
+              { value: context.params.LAYERS });
             throw e;
           })
         )
@@ -222,15 +218,11 @@ export class DataSourceService {
           return options ? new WMTSDataSource(options) : undefined;
         }),
         catchError(() => {
-          const title = this.languageService.translate.instant(
-            'igo.geo.dataSource.unavailableTitle'
-          );
-          const message = this.languageService.translate.instant(
+          this.messageService.error(
             'igo.geo.dataSource.unavailable',
-            { value: context.layer }
-          );
-
-          this.messageService.error(message, title);
+            'igo.geo.dataSource.unavailableTitle',
+            undefined,
+            { value: context.layer });
           return of(undefined);
         })
       );
@@ -271,15 +263,11 @@ export class DataSourceService {
     const observables = [];
     observables.push(this.capabilitiesService.getArcgisOptions(context).pipe(
       catchError(e => {
-        const title = this.languageService.translate.instant(
-          'igo.geo.dataSource.unavailableTitle'
-        );
-        const message = this.languageService.translate.instant(
+        this.messageService.error(
           'igo.geo.dataSource.unavailable',
-          { value: context.layer }
-        );
-
-        this.messageService.error(message, title);
+          'igo.geo.dataSource.unavailableTitle',
+          undefined,
+          { value: context.layer });
         throw e;
       })
     ));
@@ -321,15 +309,11 @@ export class DataSourceService {
 
     observables.push(this.capabilitiesService.getImageArcgisOptions(context).pipe(
       catchError(e => {
-        const title = this.languageService.translate.instant(
-          'igo.geo.dataSource.unavailableTitle'
-        );
-        const message = this.languageService.translate.instant(
+        this.messageService.error(
           'igo.geo.dataSource.unavailable',
-          { value: context.params.LAYERS }
-        );
-
-        this.messageService.error(message, title);
+          'igo.geo.dataSource.unavailableTitle',
+          undefined,
+          { value: context.params.LAYERS });
         throw e;
       })
     ));
@@ -370,15 +354,11 @@ export class DataSourceService {
     const observables = [];
     observables.push(this.capabilitiesService.getImageArcgisOptions(context).pipe(
       catchError(e => {
-        const title = this.languageService.translate.instant(
-          'igo.geo.dataSource.unavailableTitle'
-        );
-        const message = this.languageService.translate.instant(
+        this.messageService.error(
           'igo.geo.dataSource.unavailable',
-          { value: context.params.LAYERS }
-        );
-
-        this.messageService.error(message, title);
+          'igo.geo.dataSource.unavailableTitle',
+          undefined,
+          { value: context.params.LAYERS });
         throw e;
       })
     ));

--- a/packages/geo/src/lib/directions/directions-buttons/directions-buttons.component.ts
+++ b/packages/geo/src/lib/directions/directions-buttons/directions-buttons.component.ts
@@ -40,14 +40,9 @@ export class DirectionsButtonsComponent {
   copyLinkToClipboard() {
     const successful = Clipboard.copy(this.getUrl());
     if (successful) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.geo.directionsForm.dialog.copyTitle'
-      );
-      const msg = translate.instant(
-        'igo.geo.directionsForm.dialog.copyMsgLink'
-      );
-      this.messageService.success(msg, title);
+      this.messageService.success(
+        'igo.geo.directionsForm.dialog.copyMsgLink',
+        'igo.geo.directionsForm.dialog.copyTitle');
     }
   }
 
@@ -59,12 +54,9 @@ export class DirectionsButtonsComponent {
     const directionsBody = this.directionsToText();
     const successful = Clipboard.copy(directionsBody);
     if (successful) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.geo.directionsForm.dialog.copyTitle'
-      );
-      const msg = translate.instant('igo.geo.directionsForm.dialog.copyMsg');
-      this.messageService.success(msg, title);
+      this.messageService.success(
+        'igo.geo.directionsForm.dialog.copyMsg',
+        'igo.geo.directionsForm.dialog.copyTitle');
     }
   }
 

--- a/packages/geo/src/lib/download/shared/download.service.ts
+++ b/packages/geo/src/lib/download/shared/download.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import olProjection from 'ol/proj/Projection';
 import * as olproj from 'ol/proj';
 
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 
 import { Layer } from '../../layer/shared';
 import { OgcFilterWriter, OgcFilterableDataSourceOptions } from '../../filter/shared';
@@ -16,16 +16,13 @@ import { DataSourceOptions } from '../../datasource/shared/datasources/datasourc
 export class DownloadService {
 
   constructor(
-    private messageService: MessageService,
-    private languageService: LanguageService
+    private messageService: MessageService
   ) {}
 
   open(layer: Layer) {
-    const translate = this.languageService.translate;
-    const title = translate.instant('igo.geo.download.title');
     this.messageService.success(
-      translate.instant('igo.geo.download.start'),
-      title
+      'igo.geo.download.start',
+      'igo.geo.download.title'
     );
 
     const DSOptions: DataSourceOptions = layer.dataSource.options;

--- a/packages/geo/src/lib/filter/spatial-filter/spatial-filter-item/spatial-filter-item.component.ts
+++ b/packages/geo/src/lib/filter/spatial-filter/spatial-filter-item/spatial-filter-item.component.ts
@@ -379,8 +379,7 @@ export class SpatialFilterItemComponent implements OnDestroy, OnInit {
           (this.measureUnit === MeasureLengthUnit.Kilometers && value > 100)) {
             this.bufferFormControl.setValue(0);
             this.buffer = 0;
-            this.messageService.alert(this.languageService.translate.instant('igo.geo.spatialFilter.bufferAlert'),
-              this.languageService.translate.instant('igo.geo.spatialFilter.warning'));
+            this.messageService.alert('igo.geo.spatialFilter.bufferAlert','igo.geo.spatialFilter.warning');
         }
     });
 
@@ -763,8 +762,7 @@ export class SpatialFilterItemComponent implements OnDestroy, OnInit {
           this.radiusFormControl.value < 0 ||
           (this.measureUnit === MeasureLengthUnit.Meters && this.radiusFormControl.value >= 100000) ||
           (this.measureUnit === MeasureLengthUnit.Kilometers && this.radiusFormControl.value >= 100)) {
-          this.messageService.alert(this.languageService.translate.instant('igo.geo.spatialFilter.radiusAlert'),
-            this.languageService.translate.instant('igo.geo.spatialFilter.warning'));
+          this.messageService.alert('igo.geo.spatialFilter.radiusAlert', 'igo.geo.spatialFilter.warning');
           this.radius = 1000;
           this.measureUnit === MeasureLengthUnit.Meters ?
             this.radiusFormControl.setValue(this.radius) :
@@ -775,8 +773,7 @@ export class SpatialFilterItemComponent implements OnDestroy, OnInit {
       } else {
         if (formValue) {
           if (formValue >= 100000) {
-            this.messageService.alert(this.languageService.translate.instant('igo.geo.spatialFilter.radiusAlert'),
-              this.languageService.translate.instant('igo.geo.spatialFilter.warning'));
+            this.messageService.alert('igo.geo.spatialFilter.radiusAlert', 'igo.geo.spatialFilter.warning');
             this.formControl.reset();
             return;
           }

--- a/packages/geo/src/lib/filter/spatial-filter/spatial-filter-list/spatial-filter-list.component.ts
+++ b/packages/geo/src/lib/filter/spatial-filter/spatial-filter-list/spatial-filter-list.component.ts
@@ -15,7 +15,7 @@ import { Subscription } from 'rxjs';
 import { UntypedFormControl } from '@angular/forms';
 import { Feature } from '../../../feature';
 import { MeasureLengthUnit } from '../../../measure/shared';
-import { LanguageService, MessageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { Layer } from '../../../layer';
 
 @Component({
@@ -87,8 +87,7 @@ export class SpatialFilterListComponent implements OnInit, OnDestroy {
 
   constructor(
     private spatialFilterService: SpatialFilterService,
-    private messageService: MessageService,
-    private languageService: LanguageService) {}
+    private messageService: MessageService) {}
 
   ngOnInit() {
     this.formValueChanges$$ = this.formControl.valueChanges.subscribe((value) => {
@@ -137,8 +136,7 @@ export class SpatialFilterListComponent implements OnInit, OnDestroy {
             (this.measureUnit === MeasureLengthUnit.Meters && value > 100000) ||
             (this.measureUnit === MeasureLengthUnit.Kilometers && value > 100)) {
             this.bufferFormControl.setValue(0);
-            this.messageService.alert(this.languageService.translate.instant('igo.geo.spatialFilter.bufferAlert'),
-              this.languageService.translate.instant('igo.geo.spatialFilter.warning'));
+            this.messageService.alert('igo.geo.spatialFilter.bufferAlert', 'igo.geo.spatialFilter.warning');
         }
     });
   }

--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -526,7 +526,7 @@ export class ImportExportComponent implements OnDestroy, OnInit {
         }
       }
 
-      const translate = this.languageService.translate;
+
       let geomTypes: { geometryType: string, features: any[] }[] = [];
       if (data.format === ExportFormat.Shapefile || data.format === ExportFormat.GPX) {
         olFeatures.forEach((olFeature) => {
@@ -559,9 +559,7 @@ export class ImportExportComponent implements OnDestroy, OnInit {
         geomTypes = geomTypes.filter(geomType => ['LineString', 'Point'].includes(geomType.geometryType));
         const gpxFeatureCntPointOrPoly = geomTypes.length;
         if (gpxFeatureCnt > gpxFeatureCntPointOrPoly) {
-          const title = translate.instant('igo.geo.export.gpx.error.poly.title');
-          const message = translate.instant('igo.geo.export.gpx.error.poly.text');
-          this.messageService.error(message, title, { timeOut: 20000 });
+          this.messageService.error('igo.geo.export.gpx.error.poly.text', 'igo.geo.export.gpx.error.poly.title', { timeOut: 20000 });
         }
       } else if ((data.format === ExportFormat.CSVsemicolon || data.format === ExportFormat.CSVcomma) && data.combineLayers) {
         geomTypes.forEach(geomType => geomTypesCSV.push(geomType));
@@ -595,9 +593,7 @@ export class ImportExportComponent implements OnDestroy, OnInit {
 
       if (geomTypes.length === 0) {
         this.loading$.next(false);
-        const title = translate.instant('igo.geo.export.nothing.title');
-        const message = translate.instant('igo.geo.export.nothing.text');
-        this.messageService.error(message, title, { timeOut: 20000 });
+        this.messageService.error('igo.geo.export.nothing.text', 'igo.geo.export.nothing.title', { timeOut: 20000 });
 
       } else {
         if (!(data.format === ExportFormat.CSVsemicolon || data.format === ExportFormat.CSVcomma) || !data.combineLayers) {
@@ -750,8 +746,7 @@ export class ImportExportComponent implements OnDestroy, OnInit {
         file,
         features,
         this.map,
-        this.messageService,
-        this.languageService
+        this.messageService
       );
     } else {
       handleFileImportSuccess(
@@ -759,7 +754,6 @@ export class ImportExportComponent implements OnDestroy, OnInit {
         features,
         this.map,
         this.messageService,
-        this.languageService,
         this.styleListService,
         this.styleService
       );
@@ -772,25 +766,23 @@ export class ImportExportComponent implements OnDestroy, OnInit {
       file,
       error,
       this.messageService,
-      this.languageService,
       this.fileSizeMb
     );
   }
 
   private onPopupBlockedError(preCheck: boolean = true) {
     this.loading$.next(false);
-    const translate = this.languageService.translate;
-    const title = translate.instant('igo.geo.export.popupBlocked.title');
-    const extraMessage = preCheck ?
-      translate.instant('igo.geo.export.popupBlocked.selectAgain') :
-      translate.instant('igo.geo.export.popupBlocked.retry');
-    const message = translate.instant('igo.geo.export.popupBlocked.text', { extraMessage });
-    this.messageService.error(message, title, { timeOut: 20000 });
+    const extraMessage = preCheck ? 'igo.geo.export.popupBlocked.selectAgain' : 'igo.geo.export.popupBlocked.retry';
+    this.messageService.error(
+      'igo.geo.export.popupBlocked.text',
+      'igo.geo.export.popupBlocked.title',
+      { timeOut: 20000 },
+      {extraMessage});
   }
 
   private onFileExportError(error: Error) {
     this.loading$.next(false);
-    handleFileExportError(error, this.messageService, this.languageService);
+    handleFileExportError(error, this.messageService);
   }
 
   private loadConfig() {
@@ -896,17 +888,16 @@ export class ImportExportComponent implements OnDestroy, OnInit {
         if (layers && layers.length) {
           if (layers.length > 1) {
             this.messageService.alert(
-              this.languageService.translate.instant('igo.geo.export.customList.text', { value: layersWithCustomFormats.join() }),
-              this.languageService.translate.instant('igo.geo.export.customList.title')
+              'igo.geo.export.customList.text',
+              'igo.geo.export.customList.title',
+              undefined,
+              { value: layersWithCustomFormats.join() }
             );
           }
         }
       } else {
         this.formats$.next([]);
-        this.messageService.alert(
-          this.languageService.translate.instant('igo.geo.export.noFormat.text'),
-          this.languageService.translate.instant('igo.geo.export.noFormat.title')
-        );
+        this.messageService.alert('igo.geo.export.noFormat.text','igo.geo.export.noFormat.title');
       }
       return;
     } else {
@@ -972,7 +963,7 @@ export class ImportExportComponent implements OnDestroy, OnInit {
   }
 
   private onFileExportSuccess() {
-    handleFileExportSuccess(this.messageService, this.languageService);
+    handleFileExportSuccess(this.messageService);
   }
 
   onImportExportChange(event) {

--- a/packages/geo/src/lib/import-export/shared/drop-geo-file.directive.ts
+++ b/packages/geo/src/lib/import-export/shared/drop-geo-file.directive.ts
@@ -2,7 +2,7 @@ import { Directive, HostListener, EventEmitter, OnInit, OnDestroy } from '@angul
 
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import { MessageService, LanguageService, ConfigService } from '@igo2/core';
+import { MessageService, ConfigService } from '@igo2/core';
 import { DragAndDropDirective } from '@igo2/common';
 
 import { Feature } from '../../feature/shared/feature.interfaces';
@@ -32,7 +32,6 @@ export class DropGeoFileDirective extends DragAndDropDirective implements OnInit
   constructor(
     private component: MapBrowserComponent,
     private importService: ImportService,
-    private languageService: LanguageService,
     private styleListService: StyleListService,
     private styleService: StyleService,
     private config: ConfigService,
@@ -130,9 +129,9 @@ export class DropGeoFileDirective extends DragAndDropDirective implements OnInit
 
   private onFileImportSuccess(file: File, features: Feature[]) {
     if (!this.config.getConfig('importWithStyle')) {
-      handleFileImportSuccess(file, features, this.map, this.messageService, this.languageService);
+      handleFileImportSuccess(file, features, this.map, this.messageService);
     } else {
-      handleFileImportSuccess(file, features, this.map, this.messageService, this.languageService,
+      handleFileImportSuccess(file, features, this.map, this.messageService,
                                this.styleListService, this.styleService);
     }
   }
@@ -142,7 +141,6 @@ export class DropGeoFileDirective extends DragAndDropDirective implements OnInit
       file,
       error,
       this.messageService,
-      this.languageService,
       this.config.getConfig('importExport.clientSideFileSizeMaxMb'));
   }
 }

--- a/packages/geo/src/lib/import-export/shared/export.utils.ts
+++ b/packages/geo/src/lib/import-export/shared/export.utils.ts
@@ -3,44 +3,32 @@ import {
   EntityTableColumn,
   EntityTableColumnRenderer
 } from '@igo2/common';
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { downloadContent } from '@igo2/utils';
 
 import { ExportNothingToExportError } from './export.errors';
 
 export function handleFileExportError(
   error: Error,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
   if (error instanceof ExportNothingToExportError) {
-    handleNothingToExportError(messageService, languageService);
+    handleNothingToExportError(messageService);
     return;
   }
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.export.failed.title');
-  const message = translate.instant('igo.geo.export.failed.text');
-  messageService.error(message, title);
+  messageService.error('igo.geo.export.failed.text', 'igo.geo.export.failed.title');
 }
 
 export function handleFileExportSuccess(
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.export.success.title');
-  const message = translate.instant('igo.geo.export.success.text');
-  messageService.success(message, title);
+  messageService.success('igo.geo.export.success.text', 'igo.geo.export.success.title');
 }
 
 export function handleNothingToExportError(
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.export.nothing.title');
-  const message = translate.instant('igo.geo.export.nothing.text');
-  messageService.error(message, title);
+  messageService.error('igo.geo.export.nothing.text', 'igo.geo.export.nothing.title');
 }
 
 /**

--- a/packages/geo/src/lib/import-export/shared/import.utils.ts
+++ b/packages/geo/src/lib/import-export/shared/import.utils.ts
@@ -2,7 +2,7 @@ import * as olStyle from 'ol/style';
 import OlFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
 
-import { MessageService, LanguageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 
 import { FeatureDataSource } from '../../datasource/shared/datasources/feature-datasource';
 import { FeatureDataSourceOptions } from '../../datasource/shared/datasources/feature-datasource.interface';
@@ -178,12 +178,11 @@ export function handleFileImportSuccess(
   features: Feature[],
   map: IgoMap,
   messageService: MessageService,
-  languageService: LanguageService,
   styleListService?: StyleListService,
   styleService?: StyleService
 ) {
   if (features.length === 0) {
-    handleNothingToImportError(file, messageService, languageService);
+    handleNothingToImportError(file, messageService);
     return;
   }
 
@@ -200,20 +199,17 @@ export function handleFileImportSuccess(
       styleService
     );
   }
-
-  const translate = languageService.translate;
-  const messageTitle = translate.instant('igo.geo.dropGeoFile.success.title');
-  const message = translate.instant('igo.geo.dropGeoFile.success.text', {
-    value: layerTitle
-  });
-  messageService.success(message, messageTitle);
+  messageService.success(
+    'igo.geo.dropGeoFile.success.text',
+    'igo.geo.dropGeoFile.success.title',
+    undefined,
+    { value: layerTitle });
 }
 
 export function handleFileImportError(
   file: File,
   error: Error,
   messageService: MessageService,
-  languageService: LanguageService,
   sizeMb?: number
 ) {
   sizeMb = sizeMb ? sizeMb : 30;
@@ -228,7 +224,6 @@ export function handleFileImportError(
     file,
     error,
     messageService,
-    languageService,
     sizeMb
   );
 }
@@ -236,85 +231,79 @@ export function handleFileImportError(
 export function handleInvalidFileImportError(
   file: File,
   error: Error,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.dropGeoFile.invalid.title');
-  const message = translate.instant('igo.geo.dropGeoFile.invalid.text', {
-    value: file.name,
-    mimeType: file.type
-  });
-  messageService.error(message, title);
+  messageService.error(
+    'igo.geo.dropGeoFile.invalid.text',
+    'igo.geo.dropGeoFile.invalid.title',
+    undefined,
+    {
+      value: file.name,
+      mimeType: file.type
+    });
 }
 
 export function handleUnreadbleFileImportError(
   file: File,
   error: Error,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.dropGeoFile.unreadable.title');
-  const message = translate.instant('igo.geo.dropGeoFile.unreadable.text', {
-    value: file.name
-  });
-  messageService.error(message, title);
+  messageService.error('igo.geo.dropGeoFile.unreadable.text',
+    'igo.geo.dropGeoFile.unreadable.title',
+    undefined,
+    { value: file.name });
 }
 
 export function handleSizeFileImportError(
   file: File,
   error: Error,
   messageService: MessageService,
-  languageService: LanguageService,
   sizeMb: number
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.dropGeoFile.tooLarge.title');
-  const message = translate.instant('igo.geo.dropGeoFile.tooLarge.text', {
-    value: file.name,
-    size: sizeMb
-  });
-  messageService.error(message, title);
+  messageService.error(
+    'igo.geo.dropGeoFile.tooLarge.text',
+    'igo.geo.dropGeoFile.tooLarge.title',
+    undefined,
+    {
+      value: file.name,
+      size: sizeMb
+    });
 }
 
 export function handleNothingToImportError(
   file: File,
   messageService: MessageService,
-  languageService: LanguageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.dropGeoFile.empty.title');
-  const message = translate.instant('igo.geo.dropGeoFile.empty.text', {
-    value: file.name,
-    mimeType: file.type
-  });
-  messageService.error(message, title);
+  messageService.error(
+    'igo.geo.dropGeoFile.empty.text',
+    'igo.geo.dropGeoFile.empty.title',
+    undefined,
+    {
+      value: file.name,
+      mimeType: file.type
+    });
 }
 
 export function handleSRSImportError(
   file: File,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const translate = languageService.translate;
-  const title = translate.instant('igo.geo.dropGeoFile.invalidSRS.title');
-  const message = translate.instant('igo.geo.dropGeoFile.invalidSRS.text', {
-    value: file.name,
-    mimeType: file.type
-  });
-  messageService.error(message, title);
+  messageService.error(
+    'igo.geo.dropGeoFile.invalidSRS.text',
+    'igo.geo.dropGeoFile.invalidSRS.title',
+    undefined,
+    {
+      value: file.name,
+      mimeType: file.type
+    });
 }
 
 export function handleOgreServerImportError(
   file: File,
   error: Error,
-  messageService: MessageService,
-  languageService: LanguageService
+  messageService: MessageService
 ) {
-  const title = languageService.translate.instant('igo.geo.dropGeoFile.ogreServer.title');
-  const message = languageService.translate.instant('igo.geo.dropGeoFile.ogreServer.text');
-  messageService.error(message, title);
+  messageService.error('igo.geo.dropGeoFile.ogreServer.text', 'igo.geo.dropGeoFile.ogreServer.title');
 }
 
 export function getFileExtension(file: File): string {

--- a/packages/geo/src/lib/layer/shared/layer.service.ts
+++ b/packages/geo/src/lib/layer/shared/layer.service.ts
@@ -43,7 +43,7 @@ import {
 
 import { computeMVTOptionsOnHover } from '../utils/layer.utils';
 import { StyleService } from './style.service';
-import { LanguageService, MessageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { GeoNetworkService } from '../../offline/shared/geo-network.service';
 import { StyleLike as OlStyleLike } from 'ol/style/Style';
 
@@ -57,7 +57,6 @@ export class LayerService {
     private dataSourceService: DataSourceService,
     private geoNetwork: GeoNetworkService,
     private messageService: MessageService,
-    private languageService: LanguageService,
     @Optional() private authInterceptor: AuthInterceptor
   ) {}
 
@@ -129,7 +128,7 @@ export class LayerService {
   }
 
   private createImageLayer(layerOptions: ImageLayerOptions): ImageLayer {
-    return new ImageLayer(layerOptions, this.messageService, this.languageService, this.authInterceptor);
+    return new ImageLayer(layerOptions, this.messageService, this.authInterceptor);
   }
 
   private createTileLayer(layerOptions: TileLayerOptions): TileLayer {

--- a/packages/geo/src/lib/layer/utils/image-watcher.ts
+++ b/packages/geo/src/lib/layer/utils/image-watcher.ts
@@ -1,6 +1,6 @@
 import olSourceImage from 'ol/source/Image';
 import { uuid, Watcher, SubjectStatus } from '@igo2/utils';
-import { LanguageService, MessageService } from '@igo2/core';
+import { MessageService } from '@igo2/core';
 import { ImageLayer } from '../shared/layers/image-layer';
 
 
@@ -12,14 +12,12 @@ export class ImageWatcher extends Watcher {
   private source: olSourceImage;
 
   private messageService: MessageService;
-  private languageService: LanguageService;
 
-  constructor(layer: ImageLayer, messageService: MessageService, languageService: LanguageService) {
+  constructor(layer: ImageLayer, messageService: MessageService) {
     super();
     this.source = layer.options.source.ol;
     this.id = uuid();
     this.messageService = messageService;
-    this.languageService = languageService;
   }
 
   protected watch() {
@@ -74,14 +72,11 @@ export class ImageWatcher extends Watcher {
     if (!event.image.__watchers__) {
       return;
     }
-    const title = this.languageService.translate.instant(
-      'igo.geo.dataSource.unavailableTitle'
-    );
-    const message = this.languageService.translate.instant(
-      'igo.geo.dataSource.unavailable', {value: event.target.params_.LAYERS}
-    );
-
-    this.messageService.error(message, title);
+    this.messageService.error(
+      'igo.geo.dataSource.unavailable',
+      'igo.geo.dataSource.unavailableTitle',
+      undefined,
+      { value: event.target.params_.LAYERS });
     this.loaded = -1;
     this.loading = 0;
     this.status = SubjectStatus.Error;

--- a/packages/geo/src/lib/map/shared/mapOffline.directive.ts
+++ b/packages/geo/src/lib/map/shared/mapOffline.directive.ts
@@ -2,8 +2,7 @@ import { Directive, AfterViewInit } from '@angular/core';
 import {
   NetworkService,
   ConnectionState,
-  MessageService,
-  LanguageService
+  MessageService
 } from '@igo2/core';
 
 import { IgoMap } from './map';
@@ -40,48 +39,37 @@ export class MapOfflineDirective implements AfterViewInit {
   constructor(
     component: MapBrowserComponent,
     private networkService: NetworkService,
-    private messageService: MessageService,
-    private languageService: LanguageService
+    private messageService: MessageService
   ) {
     this.component = component;
   }
 
   ngAfterViewInit() {
+    const initial = window.navigator.onLine;
     this.map.offlineButtonToggle$.subscribe((offlineButtonToggle: boolean) => {
       if (this.previousMessageId) {
         this.messageService.remove(this.previousMessageId);
       }
       this.offlineButtonStatus = offlineButtonToggle;
-      const translate = this.languageService.translate;
       if (this.offlineButtonStatus && this.networkState.connection) {
-        const message = translate.instant('igo.geo.network.offline.message');
-        const title = translate.instant('igo.geo.network.offline.title');
-        const messageObj = this.messageService.info(message, title);
+        const messageObj = this.messageService.info(
+          'igo.geo.network.offline.message',
+          'igo.geo.network.offline.title');
         this.previousMessageId = messageObj.toastId;
         this.offlineButtonState.connection = false;
         this.changeLayer();
       } else if (!this.offlineButtonStatus && !this.networkState.connection) {
-        const message = translate.instant('igo.geo.network.offline.message');
-        const title = translate.instant('igo.geo.network.offline.title');
-        const messageObj = this.messageService.info(message, title);
+        const messageObj = this.messageService.info(
+          'igo.geo.network.offline.message',
+          'igo.geo.network.offline.title');
         this.previousMessageId = messageObj.toastId;
         this.offlineButtonState.connection = false;
         this.changeLayer();
-      } else if (!this.offlineButtonStatus && this.networkState.connection) {
-        let message;
-        let title;
-        const messageObs = translate.get('igo.geo.network.online.message');
-        const titleObs = translate.get('igo.geo.network.online.title');
-        messageObs.subscribe((message1: string) => {
-          message = message1;
-        });
-        titleObs.subscribe((title1: string) => {
-          title = title1;
-        });
-        if (message) {
-          const messageObj = this.messageService.info(message, title);
-          this.previousMessageId = messageObj.toastId;
-        }
+      } else if (!this.offlineButtonStatus && this.networkState.connection && this.networkState.connection !== initial) {
+        const messageObj = this.messageService.info(
+          'igo.geo.network.online.message',
+          'igo.geo.network.online.title');
+        this.previousMessageId = messageObj.toastId;
         this.offlineButtonState.connection = true;
         this.changeLayer();
       }

--- a/packages/geo/src/lib/print/shared/print.service.ts
+++ b/packages/geo/src/lib/print/shared/print.service.ts
@@ -668,14 +668,7 @@ export class PrintService {
           }
         } catch (err) {
           status = SubjectStatus.Error;
-          this.messageService.error(
-            this.languageService.translate.instant(
-              'igo.geo.printForm.corsErrorMessageBody'
-            ),
-            this.languageService.translate.instant(
-              'igo.geo.printForm.corsErrorMessageHeader'
-            )
-          );
+          this.messageService.error('igo.geo.printForm.corsErrorMessageBody','igo.geo.printForm.corsErrorMessageHeader');
         }
         this.renderMap(map, mapSize, extent);
         status$.next(status);
@@ -695,14 +688,7 @@ export class PrintService {
           }
         } catch (err) {
           status = SubjectStatus.Error;
-          this.messageService.error(
-            this.languageService.translate.instant(
-              'igo.geo.printForm.corsErrorMessageBody'
-            ),
-            this.languageService.translate.instant(
-              'igo.geo.printForm.corsErrorMessageHeader'
-            )
-          );
+          this.messageService.error('igo.geo.printForm.corsErrorMessageBody', 'igo.geo.printForm.corsErrorMessageHeader');
         }
         this.renderMap(map, mapSize, extent);
         status$.next(status);
@@ -1069,14 +1055,7 @@ export class PrintService {
         that.saveFileProcessing();
       }, blobFormat);
     } catch (err) {
-      this.messageService.error(
-        this.languageService.translate.instant(
-          'igo.geo.printForm.corsErrorMessageBody'
-        ),
-        this.languageService.translate.instant(
-          'igo.geo.printForm.corsErrorMessageHeader'
-        )
-      );
+      this.messageService.error('igo.geo.printForm.corsErrorMessageBody','igo.geo.printForm.corsErrorMessageHeader');
     }
   }
 
@@ -1105,14 +1084,7 @@ export class PrintService {
         }, blobFormat);
       }
     } catch (err) {
-      this.messageService.error(
-        this.languageService.translate.instant(
-          'igo.geo.printForm.corsErrorMessageBody'
-        ),
-        this.languageService.translate.instant(
-          'igo.geo.printForm.corsErrorMessageHeader'
-        )
-      );
+      this.messageService.error('igo.geo.printForm.corsErrorMessageBody','igo.geo.printForm.corsErrorMessageHeader');
     }
   }
 

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -422,10 +422,8 @@ export class QueryService {
       featureCount.test(url) &&
       ((wmsDatasource.params?.FEATURE_COUNT && this.featureCount > 1 && features.length === this.featureCount) ||
       (!wmsDatasource.params?.FEATURE_COUNT && features.length === this.defaultFeatureCount))) {
-      this.languageService.translate.get('igo.geo.query.featureCountMax', {value: layer.title}).subscribe(message => {
-        const messageObj = this.messageService.info(message);
-        this.previousMessageIds.push(messageObj.toastId);
-      });
+      const messageObj = this.messageService.info('igo.geo.query.featureCountMax', undefined, undefined, { value: layer.title });
+      this.previousMessageIds.push(messageObj.toastId);
     }
 
     return features.map((feature: Feature, index: number) => {

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -11,7 +11,7 @@ import {
   EntityTableColumnRenderer,
   EntityTableTemplate,
   EntityTableButton} from '@igo2/common';
-import { ConfigService, LanguageService, MessageService, StorageService } from '@igo2/core';
+import { ConfigService, MessageService, StorageService } from '@igo2/core';
 import { AuthInterceptor } from '@igo2/auth';
 import { catchError, map, skipWhile, take } from 'rxjs/operators';
 import { RelationOptions, SourceFieldsOptionsParams, WMSDataSource } from '../../datasource';
@@ -63,7 +63,6 @@ export class EditionWorkspaceService {
     private storageService: StorageService,
     private configService: ConfigService,
     private messageService: MessageService,
-    private languageService: LanguageService,
     private http: HttpClient,
     private dialog: MatDialog,
     private styleService: StyleService,
@@ -450,10 +449,7 @@ export class EditionWorkspaceService {
         workspace.deleteDrawings();
         workspace.entityStore.delete(feature);
 
-        const message = this.languageService.translate.instant(
-          'igo.geo.workspace.addSuccess'
-        );
-        this.messageService.success(message);
+        this.messageService.success('igo.geo.workspace.addSuccess');
 
         this.refreshMap(workspace.layer as VectorLayer, workspace.layer.map);
         this.adding$.next(false);
@@ -462,9 +458,6 @@ export class EditionWorkspaceService {
       error => {
         this.loading = false;
         error.error.caught = true;
-        const genericErrorMessage = this.languageService.translate.instant(
-          'igo.geo.workspace.addError'
-        );
         const messages = workspace.layer.dataSource.options.edition.messages;
         if (messages) {
           let text;
@@ -476,10 +469,10 @@ export class EditionWorkspaceService {
             }
           });
           if (!text) {
-            this.messageService.error(genericErrorMessage);
+            this.messageService.error('igo.geo.workspace.addError');
           }
         } else {
-          this.messageService.error(genericErrorMessage);
+          this.messageService.error('igo.geo.workspace.addError');
         }
       }
     );
@@ -490,10 +483,7 @@ export class EditionWorkspaceService {
     this.http.delete(`${url}`, {}).subscribe(
       () => {
         this.loading = false;
-        const message = this.languageService.translate.instant(
-          'igo.geo.workspace.deleteSuccess'
-        );
-        this.messageService.success(message);
+        this.messageService.success('igo.geo.workspace.deleteSuccess');
 
         this.refreshMap(workspace.layer as VectorLayer, workspace.layer.map);
         for (const relation of workspace.layer.options.sourceOptions.relations) {
@@ -507,9 +497,6 @@ export class EditionWorkspaceService {
       error => {
         this.loading = false;
         error.error.caught = true;
-          const genericErrorMessage = this.languageService.translate.instant(
-            'igo.geo.workspace.addError'
-          );
           const messages = workspace.layer.dataSource.options.edition.messages;
           if (messages) {
             let text;
@@ -521,10 +508,10 @@ export class EditionWorkspaceService {
               }
             });
             if (!text) {
-              this.messageService.error(genericErrorMessage);
+              this.messageService.error('igo.geo.workspace.addError');
             }
           } else {
-            this.messageService.error(genericErrorMessage);
+            this.messageService.error('igo.geo.workspace.addError');
           }
       }
     );
@@ -556,10 +543,7 @@ export class EditionWorkspaceService {
         this.loading = false;
         this.cancelEdit(workspace, feature, true);
 
-        const message = this.languageService.translate.instant(
-          'igo.geo.workspace.modifySuccess'
-        );
-        this.messageService.success(message);
+        this.messageService.success('igo.geo.workspace.modifySuccess');
 
         this.refreshMap(workspace.layer as VectorLayer, workspace.layer.map);
 
@@ -577,9 +561,6 @@ export class EditionWorkspaceService {
       error => {
         this.loading = false;
         error.error.caught = true;
-        const genericErrorMessage = this.languageService.translate.instant(
-          'igo.geo.workspace.addError'
-        );
         const messages = workspace.layer.dataSource.options.edition.messages;
         if (messages) {
           let text;
@@ -591,10 +572,10 @@ export class EditionWorkspaceService {
             }
           });
           if (!text) {
-            this.messageService.error(genericErrorMessage);
+            this.messageService.error('igo.geo.workspace.addError');
           }
         } else {
-          this.messageService.error(genericErrorMessage);
+          this.messageService.error('igo.geo.workspace.addError');
         }
       }
     );
@@ -678,8 +659,7 @@ export class EditionWorkspaceService {
   }
 
   validateFeature(feature, workspace: EditionWorkspace) {
-    const translate = this.languageService.translate;
-    let message ;
+    let message;
     let key;
     let valid = true;
     workspace.meta.tableTemplate.columns.forEach(column => {
@@ -690,38 +670,39 @@ export class EditionWorkspaceService {
             case 'mandatory': {
               if (column.validation[type] && (!feature.properties.hasOwnProperty(key) || !feature.properties[key])) {
                 valid = false;
-                  message = translate.instant('igo.geo.formValidation.mandatory',
-                  {
-                    column: column.title
-                  }
-                );
-                this.messageService.error(message);
+                this.messageService.error(
+                  'igo.geo.formValidation.mandatory',
+                  undefined,
+                  undefined,
+                  {column: column.title});
               }
               break;
             }
             case 'minValue': {
               if (feature.properties.hasOwnProperty(key) && feature.properties[key] && feature.properties[key] < column.validation[type]) {
                 valid = false;
-                message = translate.instant('igo.geo.formValidation.minValue',
+                this.messageService.error(
+                  'igo.geo.formValidation.minValue',
+                  undefined,
+                  undefined,
                   {
                     column: column.title,
                     value: column.validation[type]
-                  }
-                );
-                this.messageService.error(message);
+                  });
               }
               break;
             }
             case 'maxValue': {
               if (feature.properties.hasOwnProperty(key) && feature.properties[key] && feature.properties[key] > column.validation[type]) {
                 valid = false;
-                message = translate.instant('igo.geo.formValidation.maxValue',
+                this.messageService.error(
+                  'igo.geo.formValidation.maxValue',
+                  undefined,
+                  undefined,
                   {
                     column: column.title,
                     value: column.validation[type]
-                  }
-                );
-                this.messageService.error(message);
+                  });
               }
               break;
             }
@@ -731,13 +712,14 @@ export class EditionWorkspaceService {
                 feature.properties[key].length < column.validation[type])
               {
                 valid = false;
-                message = translate.instant('igo.geo.formValidation.minLength',
+                this.messageService.error(
+                  'igo.geo.formValidation.minLength',
+                  undefined,
+                  undefined,
                   {
                     column: column.title,
                     value: column.validation[type]
-                  }
-                );
-                this.messageService.error(message);
+                  });
               }
               break;
             }
@@ -747,13 +729,14 @@ export class EditionWorkspaceService {
                 feature.properties[key].length > column.validation[type])
               {
                 valid = false;
-                message = translate.instant('igo.geo.formValidation.maxLength',
+                this.messageService.error(
+                  'igo.geo.formValidation.maxLength',
+                  undefined,
+                  undefined,
                   {
                     column: column.title,
                     value: column.validation[type]
-                  }
-                );
-                this.messageService.error(message);
+                  });
               }
               break;
             }

--- a/packages/integration/src/lib/directions/directions-tool/directions-tool.component.ts
+++ b/packages/integration/src/lib/directions/directions-tool/directions-tool.component.ts
@@ -74,12 +74,9 @@ export class DirectionsToolComponent implements OnInit {
   ngOnInit(): void {
     const warningShown = this.storageService.get('direction.warning.shown') as boolean;
     if (!warningShown) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.integration.directions.warning.title'
-      );
-      const msg = translate.instant('igo.integration.directions.warning.message');
-      this.messageService.info(msg, title, { timeOut: 20000 });
+      this.messageService.info(
+        'igo.integration.directions.warning.message',
+        'igo.integration.directions.warning.title', { timeOut: 20000 });
       this.storageService.set('direction.warning.shown', true, StorageScope.SESSION);
     }
     this.contextState.context$.subscribe(c => {

--- a/packages/integration/src/lib/filter/spatial-filter-tool/spatial-filter-tool.component.ts
+++ b/packages/integration/src/lib/filter/spatial-filter-tool/spatial-filter-tool.component.ts
@@ -297,12 +297,8 @@ export class SpatialFilterToolComponent implements OnInit, OnDestroy {
 
               if (features.length >= 10000) {
                 this.messageService.alert(
-                  this.languageService.translate.instant(
-                    'igo.geo.spatialFilter.maxSizeAlert'
-                  ),
-                  this.languageService.translate.instant(
-                    'igo.geo.spatialFilter.warning'
-                  ),
+                  'igo.geo.spatialFilter.maxSizeAlert',
+                  'igo.geo.spatialFilter.warning',
                   { timeOut: 10000 }
                 );
               }
@@ -315,12 +311,8 @@ export class SpatialFilterToolComponent implements OnInit, OnDestroy {
       this.loading = false;
       if (zeroResults) {
         this.messageService.alert(
-          this.languageService.translate.instant(
-            'igo.geo.spatialFilter.zeroResults'
-          ),
-          this.languageService.translate.instant(
-            'igo.geo.spatialFilter.warning'
-          ),
+          'igo.geo.spatialFilter.zeroResults',
+          'igo.geo.spatialFilter.warning',
           { timeOut: 10000 }
         );
       }

--- a/packages/integration/src/lib/map/advanced-map-tool/advanced-coordinates/advanced-coordinates.component.ts
+++ b/packages/integration/src/lib/map/advanced-map-tool/advanced-coordinates/advanced-coordinates.component.ts
@@ -141,12 +141,9 @@ export class AdvancedCoordinatesComponent implements OnInit, OnDestroy {
   copyTextToClipboard(): void {
     const successful = Clipboard.copy(this.coordinates.toString());
     if (successful) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.integration.advanced-map-tool.advanced-coordinates.copyTitle'
-      );
-      const msg = translate.instant('igo.integration.advanced-map-tool.advanced-coordinates.copyMsg');
-      this.messageService.success(msg, title);
+      this.messageService.success(
+        'igo.integration.advanced-map-tool.advanced-coordinates.copyMsg',
+        'igo.integration.advanced-map-tool.advanced-coordinates.copyTitle');
     }
   }
 

--- a/packages/integration/src/lib/map/map-proximity-tool/map-proximity-tool.component.ts
+++ b/packages/integration/src/lib/map/map-proximity-tool/map-proximity-tool.component.ts
@@ -106,12 +106,7 @@ export class MapProximityToolComponent implements OnInit, OnDestroy {
 
     const successful = Clipboard.copy(this.mapProximityState.currentPositionCoordinate$?.value.toString());
     if (successful) {
-      const translate = this.languageService.translate;
-      const title = translate.instant(
-        'igo.integration.map-proximity-tool.copyTitle'
-      );
-      const msg = translate.instant('igo.integration.map-proximity-tool.copyMsg');
-      this.messageService.success(msg, title);
+      this.messageService.success('igo.integration.map-proximity-tool.copyMsg', 'igo.integration.map-proximity-tool.copyTitle');
     }
   }
 }


### PR DESCRIPTION
…e (message service)

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Message content was translated before being sent to message service. Although, message service is also doing a translation...  


**What is the new behavior?**
Remove pre-translation for message sent to message-service. This refactor allow messages to be translated live. 

Ex, a message with a undefined duration was not translated IF the browser's language is  changed. 
Now, if message-service get a translation key instead of a translated message, the message will be transated if the language is changed....

Plus, allow to remove a lot of language service from each component, this is a attempt to fix https://github.com/infra-geo-ouverte/igo2-lib/issues/1004

Related to :
https://github.com/infra-geo-ouverte/igo2-lib/issues/1004
https://github.com/infra-geo-ouverte/igo2-lib/issues/1110

@ameliebernier Major refactor need to be reviewed
@gignacnic Check this specific file (packages/geo/src/lib/map/shared/mapOffline.directive.ts) , I had to slightly change this part of the code.... 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
