### PR TITLE
fix(drawing guide): Fix a regression to the drawing guide that wasn't…

### DIFF
--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
@@ -6,7 +6,7 @@ import {
 import { UntypedFormControl } from '@angular/forms';
 import { IgoFormFieldComponent } from '@igo2/common';
 import type { Type } from 'ol/geom/Geometry';
-import * as OlStyle from 'ol/style';
+import { StyleLike as OlStyleLike } from 'ol/style/Style';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { IgoMap } from '../../map';
 import { GeoJSONGeometry } from '../shared/geometry.interfaces';
@@ -104,13 +104,13 @@ export class GeometryFormFieldComponent implements OnInit, OnDestroy {
   /**
    * Style for the draw control (applies while the geometry is being drawn)
    */
-  @Input() drawStyle: OlStyle.Style;
+  @Input() drawStyle: OlStyleLike;
 
   /**
    * Style for the overlay layer (applies once the geometry is added to the map)
    * If not specified, drawStyle applies
    */
-  @Input() overlayStyle: OlStyle.Style;
+  @Input() overlayStyle: OlStyleLike;
 
   constructor(private cdRef: ChangeDetectorRef) {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
This is a reoping of PR 1016.
A regression in the drawing guide in the geometry-input component assumes that we are drawing circles. It doesn't work with any other style.


**What is the new behavior?**
It works with other styles as it should. I'm not sure the demo provides a way to test that easily but I did test it.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
