### PR TITLE
fix(geo): export map and legend in the same file zip

### DIFF
--- a/packages/geo/src/lib/print/print/print.component.ts
+++ b/packages/geo/src/lib/print/print/print.component.ts
@@ -109,15 +109,13 @@ export class PrintComponent {
         nbFileToProcess++;
       }
 
+      if (data.legendPosition === 'newpage') {
+        nbFileToProcess++;
+      }
+
       this.printService.defineNbFileToProcess(nbFileToProcess);
 
       const resolution = +data.resolution;
-
-      let nbRequests = data.showLegend ? 2 : 1;
-
-      if (data.legendPosition === 'newpage') {
-        nbRequests++;
-      }
 
       this.printService
         .downloadMapImage(
@@ -134,24 +132,7 @@ export class PrintComponent {
         )
         .pipe(take(1))
         .subscribe(() => {
-          nbRequests--;
-          if(data.legendPosition === 'newpage') {
-            this.printService.getLayersLegendImage(
-              this.map,
-              data.imageFormat,
-              data.doZipFile,
-              resolution
-            ).then(() => {
-              nbRequests--;
-              if (!nbRequests) {
-                this.disabled$.next(false);
-              }
-            });
-          } else {
-            if (!nbRequests) {
-              this.disabled$.next(false);
-            }
-          }
+          this.disabled$.next(false);
         });
     }
   }

--- a/packages/geo/src/lib/print/shared/print.service.ts
+++ b/packages/geo/src/lib/print/shared/print.service.ts
@@ -879,6 +879,13 @@ export class PrintService {
             legendPosition,
             format
           );
+        } else if(legendPosition === 'newpage') {
+          await this.getLayersLegendImage(
+            map,
+            format,
+            doZipFile,
+            resolution
+          );
         }
       }
 

--- a/packages/geo/src/lib/print/shared/print.service.ts
+++ b/packages/geo/src/lib/print/shared/print.service.ts
@@ -879,7 +879,7 @@ export class PrintService {
             legendPosition,
             format
           );
-        } else if(legendPosition === 'newpage') {
+        } else if (legendPosition === 'newpage') {
           await this.getLayersLegendImage(
             map,
             format,


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

This update relate to the issue [913](https://github.com/infra-geo-ouverte/igo2/issues/913) in igo2.

**What is the new behavior?**

fix the bug export map and legend  in the same zip file and code improvement