### PR TITLE
feat(map-proximity): keep radius distance into storage

### DIFF
--- a/packages/integration/src/lib/map/map-proximity-tool/map-proximity-tool.component.html
+++ b/packages/integration/src/lib/map/map-proximity-tool/map-proximity-tool.component.html
@@ -27,7 +27,7 @@
 
 <div class="radius-unit"> 
   
-  <mat-form-field appearance="outline" class="measure-field" floatLabel="always">
+  <mat-form-field appearance="outline" class="radius-field" floatLabel="always">
     <mat-label>{{'igo.integration.map-proximity-tool.radiusM' | translate}}</mat-label>
     <input type="number" pattern="[0-9]*" [(ngModel)]="maxDistance" matInput placeholder="{{'igo.integration.map-proximity-tool.radiusM' | translate}}">
     </mat-form-field>

--- a/packages/integration/src/lib/map/map-proximity-tool/map-proximity-tool.component.scss
+++ b/packages/integration/src/lib/map/map-proximity-tool/map-proximity-tool.component.scss
@@ -21,14 +21,13 @@ mat-form-field.igo-input-container { width: 60%; padding: 0px 15px; };
   width: 90%;
   margin-left: 2px;
   padding: 5px;
+  mat-form-field.radius-field {
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+  }
 }
 
-.radius-field {
-
-  display: flex;
-  flex-flow: column nowrap;
-  width: 60%;
-}
 .title-container {
   padding: 10px;
 }

--- a/packages/integration/src/lib/map/map-proximity.state.ts
+++ b/packages/integration/src/lib/map/map-proximity.state.ts
@@ -16,6 +16,7 @@ import olVectorSource from 'ol/source/Vector';
 import Geometry from 'ol/geom/Geometry';
 import olLineString from 'ol/geom/LineString';
 import * as olProj from 'ol/proj';
+import { StorageService } from '@igo2/core';
 /**
  * Service that holds the state of the direction module
  */
@@ -24,8 +25,11 @@ import * as olProj from 'ol/proj';
 })
 export class MapProximityState {
 
+  private defaultProximityRadiusValue: number = 30;
+
   public enabled$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  public proximityRadiusValue$: BehaviorSubject<number> = new BehaviorSubject<number>(30);
+  public proximityRadiusValue$: BehaviorSubject<number> = new BehaviorSubject<number>(
+    this.storageService.get('mapProximityRadius') as number || this.defaultProximityRadiusValue);
   public proximitylocationType$: BehaviorSubject<string> = new BehaviorSubject<string>('geolocation');
   public proximityFeatureStore: FeatureStore<Feature> = new FeatureStore<Feature>([], { map: this.mapState.map });
   private subs$$: Subscription[] = [];
@@ -35,7 +39,9 @@ export class MapProximityState {
     return this.mapState.map;
   }
 
-  constructor(private mapState: MapState) {
+  constructor(
+    private mapState: MapState,
+    private storageService: StorageService) {
 
     this.mapState.map.ol.once('rendercomplete', () => {
       this.subscribeProximityMonitor();
@@ -59,6 +65,7 @@ export class MapProximityState {
         const currentPos = this.map.geolocationController.position$.value;
         const locationType = bunch[1];
         const proximityRadiusValue = bunch[2];
+        this.storageService.set('mapProximityRadius', proximityRadiusValue || this.defaultProximityRadiusValue);
 
         if (!enabled) {
           return;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Map proximity radius was not kept into storage. Then, after reloading app, the user's radius is not applied anymore.


**What is the new behavior?**
Keep the user's radius for further usage.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
