### PR TITLE
feat(feature-datasource): add a preload options on vector source

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
@@ -16,8 +16,14 @@ export interface FeatureDataSourceOptions extends DataSourceOptions {
   format?: olFormatFeature;
   url?: string;
   pathOffline?: string;
+  preload?: PreloadOptions;
   excludeAttribute?: Array<string>;
   excludeAttributeOffline?: Array<string>;
 
   ol?: olSourceVector<OlGeometry> | olSource;
+}
+
+export interface PreloadOptions {
+  bypassVisible?: boolean;
+  bypassResolution?: boolean;
 }

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -82,7 +82,7 @@ export class VectorLayer extends Layer {
           this.options.minResolution = 0;
           this.options.maxResolution = Infinity;
         }
-        if (so.preload.bypassVisible && !this.options.visible) {
+        if (so.preload.bypassVisible && !initialVisibleValue) {
           this.options.visible = true;
         }
       }

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -17,7 +17,7 @@ import { WebSocketDataSource } from '../../../datasource/shared/datasources/webs
 import { ClusterDataSource } from '../../../datasource/shared/datasources/cluster-datasource';
 
 import { VectorWatcher } from '../../utils';
-import { IgoMap, MapExtent } from '../../../map';
+import { IgoMap, MapExtent, getResolutionFromScale } from '../../../map';
 import { Layer } from './layer';
 import { VectorLayerOptions } from './vector-layer.interface';
 import { AuthInterceptor } from '@igo2/auth';
@@ -34,6 +34,7 @@ import { LayerDBService } from '../../../offline/layerDB/layerDB.service';
 import { LayerDBData } from '../../../offline';
 import BaseEvent from 'ol/events/Event';
 import { olStyleToBasicIgoStyle } from '../../../style/shared/vector/conversion.utils';
+import { FeatureDataSourceOptions } from '../../../datasource/shared/datasources/feature-datasource.interface';
 
 export class VectorLayer extends Layer {
   public dataSource:
@@ -69,6 +70,24 @@ export class VectorLayer extends Layer {
   }
 
   protected createOlLayer(): olLayerVector<olSourceVector<OlGeometry>> {
+    const initialOpacityValue = this.options.opacity || 1;
+    const initialVisibleValue = this.options.visible === true;
+    const initialMinResValue = this.options.minResolution || getResolutionFromScale(Number(this.options.minScaleDenom));
+    const initialMaxResValue = this.options.maxResolution || getResolutionFromScale(Number(this.options.maxScaleDenom));
+    const so = this.options.sourceOptions as FeatureDataSourceOptions;
+    if (this.dataSource instanceof FeatureDataSource) {
+      if (so?.preload?.bypassResolution || so?.preload?.bypassVisible) {
+        this.options.opacity = 0;
+        if (so.preload.bypassResolution && (this.options.minResolution || this.options.maxResolution)) {
+          this.options.minResolution = 0;
+          this.options.maxResolution = Infinity;
+        }
+        if (so.preload.bypassVisible && !this.options.visible) {
+          this.options.visible = true;
+        }
+      }
+    }
+
     const olOptions = Object.assign({}, this.options, {
       source: this.options.source.ol as olSourceVector<OlGeometry>
     });
@@ -90,6 +109,23 @@ export class VectorLayer extends Layer {
         this.dataSource.ol.on('changefeature', () => this.maintainFeaturesInIdb());
         this.dataSource.ol.on('clear', () => this.maintainFeaturesInIdb());
         this.dataSource.ol.on('removefeature', () => this.maintainFeaturesInIdb());
+      });
+    }
+
+    if (
+      this.dataSource instanceof FeatureDataSource &&
+      (so?.preload?.bypassResolution || so?.preload?.bypassVisible)) {
+      this.dataSource.ol.once('featuresloadend', () => {
+        if (initialOpacityValue) {
+          this.opacity = initialOpacityValue;
+        }
+        if (so.preload.bypassResolution) {
+          this.minResolution = initialMinResValue;
+          this.maxResolution = initialMaxResValue;
+        }
+        if (so.preload.bypassVisible) {
+          this.visible = initialVisibleValue;
+        }
       });
     }
 

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -71,7 +71,7 @@ export class VectorLayer extends Layer {
 
   protected createOlLayer(): olLayerVector<olSourceVector<OlGeometry>> {
     const initialOpacityValue = this.options.opacity || 1;
-    const initialVisibleValue = this.options.visible === true;
+    const initialVisibleValue = this.options.visible !== false;
     const initialMinResValue = this.options.minResolution || getResolutionFromScale(Number(this.options.minScaleDenom));
     const initialMaxResValue = this.options.maxResolution || getResolutionFromScale(Number(this.options.maxScaleDenom));
     const so = this.options.sourceOptions as FeatureDataSourceOptions;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Non visible layers or layers out off resolution range are not loaded until the layer become visible or in the resolution range. 


**What is the new behavior?**
Add a bypass to load vector data before the visibility OR the range state change.
This allow to enable search on non visible layers. 



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
