### PR TITLE
Corriger le parseInt qui ajuste normalement les attributs en integer

### DIFF
--- a/packages/common/src/lib/entity/entity-table/entity-table.component.ts
+++ b/packages/common/src/lib/entity/entity-table/entity-table.component.ts
@@ -360,7 +360,8 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
         const domain = column.domainValues as any;
         if (!domain?.features) {
           column.domainValues?.forEach(option => {
-            if (typeof formControlValue === 'string' && typeof option.id === 'number' && /^\d+$/.test(formControlValue)) {
+            if (typeof formControlValue === 'string' && typeof option.id === 'number' && /^\d+$/.test(formControlValue) &&
+            (formControlValue.length > 1 && formControlValue.charAt(0) !== '0')) {
               formControlValue = parseInt(formControlValue);
             }
             if (option.value === formControlValue || option.id === formControlValue) {
@@ -713,7 +714,8 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
         } else {
           if (!domain?.features) {
             column.domainValues.forEach(option => {
-              if (typeof value === 'string' && typeof option.id === 'number' && /^\d+$/.test(value)) {
+              if (typeof value === 'string' && typeof option.id === 'number' && /^\d+$/.test(value) &&
+                (value.length > 1 && value.charAt(0) !== '0')) {
                 value = parseInt(value);
               }
               if (option.value === value || option.id === value) {
@@ -731,7 +733,8 @@ export class EntityTableComponent implements OnInit, OnChanges, OnDestroy {
       } else {
         if (!domain?.features) {
           column.domainValues.forEach(option => {
-            if (typeof value === 'string' && typeof option.id === 'number' && /^\d+$/.test(value)) {
+            if (typeof value === 'string' && typeof option.id === 'number' && /^\d+$/.test(value) &&
+              (value.length > 1 && value.charAt(0) !== '0')) {
               value = parseInt(value);
             }
             if (option.value === value || option.id === value) {


### PR DESCRIPTION
Corriger le parseInt qui ajuste normalement les attributs en integer mais qui affecte négativement les string qui débute avec un zéro

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

Problème avec les string contenant des numériques et débutant avec un "0"

**What is the new behavior?**

Retrait de la conversion numérique du string débutant avec un zéro

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
