### PR TITLE
feat(context): save layer opacity if export context

### DIFF
--- a/packages/context/src/lib/context-import-export/shared/context-import.utils.ts
+++ b/packages/context/src/lib/context-import-export/shared/context-import.utils.ts
@@ -187,34 +187,34 @@ export function addImportedFeaturesStyledToMap(
   let distance: number;
 
   if (
-    styleListService.getStyleList(extraFeatures.name.toString() + '.styleByAttribute')
+    styleListService.getStyleList(extraFeatures.name + '.styleByAttribute')
   ) {
     const styleByAttribute: StyleByAttribute = styleListService.getStyleList(
-      extraFeatures.name.toString() + '.styleByAttribute'
+      extraFeatures.name + '.styleByAttribute'
     );
 
     style = (feature, resolution) => {
       return styleService.createStyleByAttribute(feature, styleByAttribute, resolution);
     };
   } else if (
-    styleListService.getStyleList(extraFeatures.name.toString() + '.clusterStyle')
+    styleListService.getStyleList(extraFeatures.name + '.clusterStyle')
   ) {
     const clusterParam: ClusterParam = styleListService.getStyleList(
-      extraFeatures.name.toString() + '.clusterParam'
+      extraFeatures.name + '.clusterParam'
     );
     distance = styleListService.getStyleList(
-      extraFeatures.name.toString() + '.distance'
+      extraFeatures.name + '.distance'
     );
 
     style = (feature, resolution) => {
       const baseStyle = styleService.createStyle(
-        styleListService.getStyleList(extraFeatures.name.toString() + '.clusterStyle'), feature, resolution
+        styleListService.getStyleList(extraFeatures.name + '.clusterStyle'), feature, resolution
       );
       return styleService.createClusterStyle(feature, resolution, clusterParam, baseStyle);
     };
-  } else if (styleListService.getStyleList(extraFeatures.name.toString() + '.style')) {
+  } else if (styleListService.getStyleList(extraFeatures.name + '.style')) {
     style = (feature, resolution) => styleService.createStyle(
-      styleListService.getStyleList(extraFeatures.name.toString() + '.style'), feature, resolution
+      styleListService.getStyleList(extraFeatures.name + '.style'), feature, resolution
     );
   } else {
     style = (feature, resolution) => styleService.createStyle(
@@ -223,7 +223,7 @@ export function addImportedFeaturesStyledToMap(
   }
   let source;
   const olFeatures = collectFeaturesFromExtraFeatures(extraFeatures);
-  if (styleListService.getStyleList(extraFeatures.name.toString() + '.clusterStyle')) {
+  if (styleListService.getStyleList(extraFeatures.name + '.clusterStyle')) {
     const sourceOptions: ClusterDataSourceOptions &
       QueryableDataSourceOptions = {
       distance,

--- a/packages/context/src/lib/context-manager/shared/context.interface.ts
+++ b/packages/context/src/lib/context-manager/shared/context.interface.ts
@@ -3,6 +3,7 @@ import { Tool } from '@igo2/common';
 import { MapViewOptions, LayerOptions, MapScaleLineOptions, MapAttributionOptions, MapExtent } from '@igo2/geo';
 
 import { TypePermission } from './context.enum';
+import { FeatureCollection } from 'geojson';
 
 export interface Context {
   id?: string;
@@ -23,6 +24,7 @@ export interface ContextsList {
   public?: Context[];
 }
 
+export type ExtraFeatures = FeatureCollection & {name: string; opacity: number; visible: boolean;}
 export interface DetailedContext extends Context {
   base?: string;
   map?: ContextMap;
@@ -32,7 +34,7 @@ export interface DetailedContext extends Context {
   message?: Message;
   messages?: Message[];
   removeLayersOnContextChange?: boolean;
-  extraFeatures?: any[];
+  extraFeatures?: ExtraFeatures[];
 }
 
 export interface ContextMapView extends MapViewOptions {

--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -40,8 +40,11 @@ import {
   DetailedContext,
   ContextMapView,
   ContextPermission,
-  ContextProfils
+  ContextProfils,
+  ExtraFeatures
 } from './context.interface';
+import { Geometry } from 'ol/geom';
+import { Feature } from 'ol';
 
 @Injectable({
   providedIn: 'root'
@@ -513,7 +516,7 @@ export class ContextService {
       'EPSG:4326'
     );
 
-    const context = {
+    const context: DetailedContext = {
       uri: name,
       title: name,
       map: {
@@ -577,38 +580,16 @@ export class ContextService {
         if (!(layer.ol.getSource() instanceof olVectorSource)) {
           const catalogLayer = layer.options;
           catalogLayer.zIndex = layer.zIndex;
+          catalogLayer.visible = layer.visible,
+          catalogLayer.opacity = layer.opacity;
           delete catalogLayer.source;
           context.layers.push(catalogLayer);
         } else {
-          let features;
-          const writer = new GeoJSON();
-          if (layer.ol.getSource() instanceof Cluster) {
-            const clusterSource = layer.ol.getSource() as Cluster;
-            let olFeatures = clusterSource.getFeatures();
-            olFeatures = (olFeatures as any).flatMap((cluster: any) => cluster.get('features'));
-            const cleanedOlFeatures = this.exportService.generateFeature(olFeatures, 'GeoJSON', '_featureStore');
-            features = writer.writeFeatures(
-              cleanedOlFeatures,
-              {
-                dataProjection: 'EPSG:4326',
-                featureProjection: 'EPSG:3857'
-              }
-            );
-          } else {
-            const source = layer.ol.getSource() as olVectorSource;
-            const olFeatures = source.getFeatures();
-            const cleanedOlFeatures = this.exportService.generateFeature(olFeatures, 'GeoJSON', '_featureStore');
-            features = writer.writeFeatures(
-              cleanedOlFeatures,
-              {
-                dataProjection: 'EPSG:4326',
-                featureProjection: 'EPSG:3857'
-              }
-            );
-          }
-          features = JSON.parse(features);
-          features.name = layer.options.title;
-          context.extraFeatures.push(features);
+          const extraFeatures = this.getExtraFeatures(layer);
+          extraFeatures.name = layer.options.title;
+          extraFeatures.opacity = layer.opacity;
+          extraFeatures.visible = layer.visible;
+          context.extraFeatures.push(extraFeatures);
         }
       }
     });
@@ -617,6 +598,28 @@ export class ContextService {
     context.tools = this.tools;
 
     return context;
+  }
+
+  private getExtraFeatures(layer: Layer): ExtraFeatures {
+    const writer = new GeoJSON();
+    let olFeatures: Feature<Geometry>[];
+    if (layer.ol.getSource() instanceof Cluster) {
+      const clusterSource = layer.ol.getSource() as Cluster;
+      olFeatures = clusterSource.getFeatures();
+      olFeatures = (olFeatures as any).flatMap((cluster: any) => cluster.get('features'));
+    } else {
+      const source = layer.ol.getSource() as olVectorSource;
+      olFeatures = source.getFeatures();
+    }
+    const cleanedOlFeatures = this.exportService.generateFeature(olFeatures, 'GeoJSON', '_featureStore');
+    const features = writer.writeFeatures(
+      cleanedOlFeatures,
+      {
+        dataProjection: 'EPSG:4326',
+        featureProjection: 'EPSG:3857'
+      }
+    );
+    return JSON.parse(features);
   }
 
   setTools(tools: Tool[]) {

--- a/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
+++ b/packages/context/src/lib/context-manager/shared/layer-context.directive.ts
@@ -21,7 +21,6 @@ import {
   addImportedFeaturesToMap,
   addImportedFeaturesStyledToMap
 } from '../../context-import-export/shared/context-import.utils';
-import GeoJSON from 'ol/format/GeoJSON';
 
 @Directive({
   selector: '[igoLayerContext]'
@@ -95,13 +94,6 @@ export class LayerContextDirective implements OnInit, OnDestroy {
 
         if (context.extraFeatures) {
           context.extraFeatures.forEach((featureCollection) => {
-            const format = new GeoJSON();
-            const title = featureCollection.name;
-            featureCollection = JSON.stringify(featureCollection);
-            featureCollection = format.readFeatures(featureCollection, {
-              dataProjection: 'EPSG:4326',
-              featureProjection: 'EPSG:3857'
-            });
             const importExportOptions = this.configService.getConfig('importExport');
             const importWithStyle =importExportOptions?.importWithStyle || this.configService.getConfig('importWithStyle');
             if (this.configService.getConfig('importWithStyle')) {
@@ -114,12 +106,12 @@ export class LayerContextDirective implements OnInit, OnDestroy {
               `);
             }
             if (!importWithStyle) {
-              addImportedFeaturesToMap(featureCollection, this.map, title);
+              addImportedFeaturesToMap(featureCollection, this.map);
             } else {
+              console.log('importWithStyle', importWithStyle);
               addImportedFeaturesStyledToMap(
                 featureCollection,
                 this.map,
-                title,
                 this.styleListService,
                 this.styleService
               );


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

this behavior related to [#979](https://github.com/infra-geo-ouverte/igo2/issues/979) in igo2

**What is the new behavior?**

Save layer opacity if export contexts
Solve some logical bugs for import and export contexts

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**

