### PR TITLE
Fix import context with style (drawing layer)

### DIFF
--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -29,7 +29,7 @@ import {
 } from '@igo2/core';
 
 import { AuthService } from '@igo2/auth';
-import type { IgoMap, Layer, LayerOptions } from '@igo2/geo';
+import type { IgoMap, Layer, LayerOptions, VectorLayerOptions, VectorTileLayerOptions } from '@igo2/geo';
 import { ExportService } from '@igo2/geo';
 
 import { TypePermission } from './context.enum';
@@ -549,10 +549,11 @@ export class ContextService {
           return source && layer.id === source.id && !contextLayer.baseLayer;
         });
       if (layerFound) {
-        let layerStyle = layerFound[`style`];
-        if (layerFound[`igoStyle`][`styleByAttribute`]) {
+        let layerFoundAs = layerFound as VectorLayerOptions | VectorTileLayerOptions;
+        let layerStyle = layerFoundAs.style;
+        if (layerFoundAs.igoStyle?.styleByAttribute) {
           layerStyle = undefined;
-        } else if (layerFound[`igoStyle`][`clusterBaseStyle`]) {
+        } else if (layerFoundAs.igoStyle?.clusterBaseStyle) {
           layerStyle = undefined;
           delete layerFound.sourceOptions[`source`];
           delete layerFound.sourceOptions[`format`];
@@ -562,8 +563,8 @@ export class ContextService {
           title: layer.options.title,
           zIndex: layer.zIndex,
           igoStyle: {
-            styleByAttribute: layerFound[`igoStyle`][`styleByAttribute`],
-            clusterBaseStyle: layerFound[`igoStyle`][`clusterBaseStyle`],
+            styleByAttribute: layerFoundAs.igoStyle?.styleByAttribute,
+            clusterBaseStyle: layerFoundAs.igoStyle?.clusterBaseStyle,
           },
           style: layerStyle,
           clusterParam: layerFound[`clusterParam`],

--- a/packages/geo/src/lib/import-export/shared/export.service.ts
+++ b/packages/geo/src/lib/import-export/shared/export.service.ts
@@ -53,7 +53,7 @@ export class ExportService {
     projectionIn = 'EPSG:4326',
     projectionOut = 'EPSG:4326'
   ): Observable<void> {
-    const exportOlFeatures = this.generateFeature(olFeatures, format);
+    const exportOlFeatures = this.generateFeature(olFeatures, format,'_featureStore');
 
     return this.exportAsync(exportOlFeatures, format, title, encoding, projectionIn, projectionOut);
   }

--- a/packages/geo/src/lib/layer/shared/layers/vectortile-layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vectortile-layer.interface.ts
@@ -7,7 +7,7 @@ import { MVTDataSource } from '../../../datasource/shared/datasources/mvt-dataso
 
 import { MVTDataSourceOptions } from '../../../datasource/shared/datasources/mvt-datasource.interface';
 
-import { IgoStyleBase } from '../../../style/shared/vector/vector-style.interface';
+import { IgoStyle } from '../../../style/shared/vector/vector-style.interface';
 import RenderFeature from 'ol/render/Feature';
 import Feature from 'ol/Feature';
 
@@ -19,5 +19,5 @@ export interface VectorTileLayerOptions extends LayerOptions {
     | MVTDataSourceOptions;
   ol?: olLayerVectorTile;
   declutter?: boolean;
-  igoStyle?: IgoStyleBase;
+  igoStyle?: IgoStyle;
 }

--- a/packages/geo/src/lib/style/style-service/draw-style.service.ts
+++ b/packages/geo/src/lib/style/style-service/draw-style.service.ts
@@ -110,14 +110,44 @@ export class DrawStyleService {
     if (geom instanceof OlPoint) {
       labelsAreOffset = !labelsAreOffset;
     }
+    const textToShow = labelsAreShown ? feature.get('draw') : '';
+    feature.set('_mapTitle', textToShow);
+    const textIgoStyleObject = {
+      text: textToShow,
+      stroke: {
+        color: "white",
+        width: 0.75
+      },
+      fill: { color: "black" },
+      font: fontSizeAndStyle,
+      overflow: true,
+      offsetX: offsetX,
+      offsetY: offsetY
+    };
+
+    let igoStyleObject;
 
     // if feature is a circle
     if (feature.get('rad')) {
       const coordinates = transform(feature.getGeometry().flatCoordinates, proj, 'EPSG:4326');
+      const radius = feature.get('rad') / Math.cos((Math.PI / 180) * coordinates[1]) / resolution;
+      igoStyleObject = {
+        text: textIgoStyleObject,
+        circle: {
+          radius,
+          stroke: {
+              color: strokeColor ? strokeColor : this.strokeColor,
+              width: this.strokeWidth
+          },
+          fill: {
+            color: fillColor
+        },
+      }};
+      feature.set('_style', igoStyleObject);
 
       style = new OlStyle.Style({
         text: new OlStyle.Text({
-          text: labelsAreShown ? feature.get('draw') : '',
+          text: textToShow,
           stroke: new OlStyle.Stroke({
             color: 'white',
             width: 0.75
@@ -133,7 +163,7 @@ export class DrawStyleService {
         }),
 
         image: new OlStyle.Circle({
-          radius: feature.get('rad') / Math.cos((Math.PI / 180) * coordinates[1]) / resolution,
+          radius,
           stroke: new OlStyle.Stroke({
             color: strokeColor ? strokeColor : this.strokeColor,
             width: this.strokeWidth
@@ -148,6 +178,22 @@ export class DrawStyleService {
       // if feature is an icon
     } else if (icon) {
       this.offsetY = -26;
+      textIgoStyleObject.offsetY = this.offsetY;
+      const igoStyleObject = {
+        text: textIgoStyleObject,
+        stroke:{
+          color: strokeColor,
+          width: this.strokeWidth
+        },
+        fill:{
+          color: fillColor
+        },
+        icon: {
+          src: icon
+        }
+      };
+      feature.set('_style', igoStyleObject);
+
       style = new OlStyle.Style({
         text: new OlStyle.Text({
           text: labelsAreShown ? feature.get('draw') : '',
@@ -182,6 +228,30 @@ export class DrawStyleService {
       // if feature is a point, a linestring or a polygon
     } else {
       this.offsetY = labelsAreOffset ? -15 : 0;
+
+      textIgoStyleObject.offsetY = this.offsetY;
+      const igoStyleObject = {
+        text: textIgoStyleObject,
+        stroke:{
+          color: strokeColor,
+          width: this.strokeWidth
+        },
+        fill:{
+          color: fillColor
+        },
+        circle: {
+          radius: 5,
+          stroke: {
+              color: strokeColor,
+              width: this.strokeWidth
+          },
+          fill: {
+            color: fillColor
+        },
+      }
+      };
+      feature.set('_style', igoStyleObject);
+
       style = new OlStyle.Style({
         text: new OlStyle.Text({
           text: labelsAreShown ? feature.get('draw') : '',

--- a/packages/geo/src/lib/style/style-service/style.service.ts
+++ b/packages/geo/src/lib/style/style-service/style.service.ts
@@ -74,13 +74,16 @@ export class StyleService {
         labelMinResolution = labelMinResolutionFromScale || minResolution;
         labelMaxResolution = labelMaxResolutionFromScale || maxResolution;
       }
-      if (feature && resolution >= labelMinResolution && resolution <= labelMaxResolution) {
-        if (feature && options.text.attribute) {
-          parsedStyle.getText().setText(this.getLabel(feature, options.text.attribute));
+      if (options.text?.minScaleDenom || options.text?.maxScaleDenom || options.text?.minResolution || options.text?.maxResolution) {
+        if (feature && resolution >= labelMinResolution && resolution <= labelMaxResolution) {
+          if (feature && options.text.attribute) {
+            parsedStyle.getText().setText(this.getLabel(feature, options.text.attribute));
+          }
+        } else {
+          parsedStyle.setText();
         }
-      } else {
-        parsedStyle.setText();
       }
+
     }
     return parsedStyle;
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
this behavior related to https://github.com/infra-geo-ouverte/igo2-lib/issues/1337


**What is the new behavior?**
1- Store the feature style as an igoStyleObject within _style property. 
2- Store the label inside the _mapTitle property.

Overall, this PR propose to use existing mecanism to handle styles during import (context or data). This is a "temporary" fix. I think we need to create a new layer type or extend the vector type, to handle internal layer types (draw, directions, measures) to be handled easily, on export/import. 

Furthermore, the style handling will be changed shortly by using the geostyler library. 


**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
