### PR TITLE
feat(context): set map zoom level after importing context

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
         ],
         "unused-imports/no-unused-imports": "error",
         "no-multi-spaces": "error",
-        "eqeqeq": ["error", "always"],
+        "eqeqeq": ["error", "smart"],
         "semi": ["error", "always"],
         "no-trailing-spaces": "error",
         "no-multiple-empty-lines": "error",

--- a/packages/context/src/lib/context-import-export/context-import-export/context-import-export.component.ts
+++ b/packages/context/src/lib/context-import-export/context-import-export/context-import-export.component.ts
@@ -82,7 +82,8 @@ export class ContextImportExportComponent implements OnInit, OnDestroy {
     this.res = this.contextService.getContextFromLayers(
       this.map,
       contextOptions.layers,
-      contextOptions.name
+      contextOptions.name,
+      false
     );
     this.res.imported = true;
     this.contextExportService.export(this.res).pipe(take(1)).subscribe(

--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -506,7 +506,8 @@ export class ContextService {
   getContextFromLayers(
     igoMap: IgoMap,
     layers: Layer[],
-    name: string
+    name: string,
+    keepCurrentView? : boolean
   ): DetailedContext {
     const currentContext = this.context$.getValue();
     const view = igoMap.ol.getView();
@@ -523,7 +524,8 @@ export class ContextService {
         view: {
           center: center.getCoordinates(),
           zoom: view.getZoom(),
-          projection: proj
+          projection: proj,
+          keepCurrentView
         }
       },
       layers: [],

--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -210,23 +210,16 @@ export class IgoMap implements MapBase {
       this.viewController.clearStateHistory();
     }
 
-    const viewOptions = this.handleMapViewOptions(options);
+    const viewOptions: ViewOptions = { constrainResolution: true, ...options };
+    if (options.center) {
+      viewOptions.center = olproj.fromLonLat(options.center, this.projectionCode);
+    }
+
     this.ol.setView(new olView(viewOptions));
 
     if (options.maxLayerZoomExtent) {
       this.viewController.maxLayerZoomExtent = options.maxLayerZoomExtent;
     }
-  }
-
-  private handleMapViewOptions(options: MapViewOptions): ViewOptions {
-    const viewOptions: ViewOptions = { constrainResolution: true, ...options };
-
-    if (options.center) {
-      const projection = olproj.createProjection(options.projection, 'EPSG:3857');
-      viewOptions.center = olproj.fromLonLat(options.center, projection);
-    }
-
-    return viewOptions;
   }
 
   updateControls(value: MapControlsOptions) {

--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -222,6 +222,9 @@ export class IgoMap implements MapBase {
         const center = olproj.fromLonLat(options.center, projection);
         view.setCenter(center);
       }
+      if (options.zoom) {
+          view.setZoom(options.zoom)
+      }
     }
   }
 

--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -223,7 +223,7 @@ export class IgoMap implements MapBase {
         view.setCenter(center);
       }
       if (options.zoom) {
-          view.setZoom(options.zoom)
+          view.setZoom(options.zoom);
       }
     }
   }

--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -212,7 +212,7 @@ export class IgoMap implements MapBase {
 
     const viewOptions: ViewOptions = { constrainResolution: true, ...options };
     if (options.center) {
-      viewOptions.center = olproj.fromLonLat(options.center, this.projectionCode);
+      viewOptions.center = olproj.fromLonLat(options.center, options.projection);
     }
 
     this.ol.setView(new olView(viewOptions));

--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -1,5 +1,5 @@
 import olMap from 'ol/Map';
-import olView from 'ol/View';
+import olView, { ViewOptions } from 'ol/View';
 import olControlAttribution from 'ol/control/Attribution';
 import olControlScaleLine from 'ol/control/ScaleLine';
 import * as olproj from 'ol/proj';
@@ -185,14 +185,16 @@ export class IgoMap implements MapBase {
 
   updateView(options: MapViewOptions) {
     const currentView = this.ol.getView();
-    const viewOptions = Object.assign(
-      {
-        zoom: currentView.getZoom()
-      },
-      currentView.getProperties()
-    );
+    const viewOptions: MapViewOptions = {
+      ...currentView.getProperties(),
+      ...options
+    };
 
-    this.setView(Object.assign(viewOptions, options));
+    if (options.zoom && options.resolution == null) {
+      viewOptions.resolution = undefined;
+    }
+
+    this.setView(viewOptions);
     if (options.maxZoomOnExtent) {
       this.viewController.maxZoomOnExtent = options.maxZoomOnExtent;
     }
@@ -208,24 +210,23 @@ export class IgoMap implements MapBase {
       this.viewController.clearStateHistory();
     }
 
-    options = Object.assign({ constrainResolution: true }, options);
-    const view = new olView(options);
-    this.ol.setView(view);
+    const viewOptions = this.handleMapViewOptions(options);
+    this.ol.setView(new olView(viewOptions));
 
-    if (options) {
-      if (options.maxLayerZoomExtent) {
-        this.viewController.maxLayerZoomExtent = options.maxLayerZoomExtent;
-      }
-
-      if (options.center) {
-        const projection = view.getProjection().getCode();
-        const center = olproj.fromLonLat(options.center, projection);
-        view.setCenter(center);
-      }
-      if (options.zoom) {
-          view.setZoom(options.zoom);
-      }
+    if (options.maxLayerZoomExtent) {
+      this.viewController.maxLayerZoomExtent = options.maxLayerZoomExtent;
     }
+  }
+
+  private handleMapViewOptions(options: MapViewOptions): ViewOptions {
+    const viewOptions: ViewOptions = { constrainResolution: true, ...options };
+
+    if (options.center) {
+      const projection = olproj.createProjection(options.projection, 'EPSG:3857');
+      viewOptions.center = olproj.fromLonLat(options.center, projection);
+    }
+
+    return viewOptions;
   }
 
   updateControls(value: MapControlsOptions) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

this behavior related to [#981](https://github.com/infra-geo-ouverte/igo2/issues/981) in igo2

**What is the new behavior?**

Set map zoom level after importing context


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
