### PR TITLE
chore(*): refactor to set the configs files not dependent from any ht…

### DIFF
--- a/packages/core/src/lib/config/config.service.ts
+++ b/packages/core/src/lib/config/config.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, Injector } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { HttpBackend, HttpClient } from '@angular/common/http';
 import { throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -13,8 +13,11 @@ import { version } from './version';
 })
 export class ConfigService {
   private config: object = {};
+  private httpClient: HttpClient;
 
-  constructor(private injector: Injector) {}
+  constructor(handler: HttpBackend) {
+    this.httpClient = new HttpClient(handler);
+  }
 
   /**
    * Use to get the data found in config file
@@ -33,10 +36,9 @@ export class ConfigService {
       return true;
     }
 
-    const http = this.injector.get(HttpClient);
 
     return new Promise((resolve, _reject) => {
-      http
+      this.httpClient
         .get(options.path)
         .pipe(
           catchError((error: any): any => {

--- a/packages/core/src/lib/language/shared/language.loader.ts
+++ b/packages/core/src/lib/language/shared/language.loader.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpBackend, HttpClient } from '@angular/common/http';
 
 import { forkJoin, map } from 'rxjs';
 
@@ -9,15 +9,19 @@ import { ObjectUtils } from '@igo2/utils';
 import { ConfigService } from '../../config/config.service';
 
 export class LanguageLoader implements TranslateLoader {
+  private httpClient: HttpClient;
+
   constructor(
-    private http: HttpClient,
+    handler: HttpBackend,
     private prefix?: string | string[],
     private suffix: string = '.json',
     private config?: ConfigService
-  ) {}
+  ) {
+    this.httpClient = new HttpClient(handler);
+  }
 
   public getTranslation(lang: string): any {
-    const igoLocale$ = this.http.get(`locale/libs_locale/${lang}.json`);
+    const igoLocale$ = this.httpClient.get(`locale/libs_locale/${lang}.json`);
 
     if (this.config && !this.prefix) {
       const prefix = this.config.getConfig('language.prefix');
@@ -29,7 +33,7 @@ export class LanguageLoader implements TranslateLoader {
     }
 
     const appLocale$ = (this.prefix as string[]).map((prefix) =>
-      this.http.get(`${prefix}${lang}${this.suffix}`)
+      this.httpClient.get(`${prefix}${lang}${this.suffix}`)
     );
 
     const locale$ = forkJoin([igoLocale$, ...appLocale$]);

--- a/packages/core/src/lib/language/shared/language.provider.ts
+++ b/packages/core/src/lib/language/shared/language.provider.ts
@@ -1,11 +1,11 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpBackend } from '@angular/common/http';
 import { TranslateLoader } from '@ngx-translate/core';
 
 import { ConfigService } from '../../config/config.service';
 import { LanguageLoader } from './language.loader';
 
 export function defaultLanguageLoader(
-  http: HttpClient,
+  http: HttpBackend,
   config?: ConfigService
 ) {
   return new LanguageLoader(http, undefined, undefined, config);
@@ -15,7 +15,7 @@ export function provideLanguageLoader(loader?) {
   return {
     provide: TranslateLoader,
     useFactory: loader || defaultLanguageLoader,
-    deps: [HttpClient]
+    deps: [HttpBackend]
   };
 }
 
@@ -23,6 +23,6 @@ export function provideDefaultLanguageLoader(loader?) {
   return {
     provide: TranslateLoader,
     useFactory: loader || defaultLanguageLoader,
-    deps: [HttpClient, ConfigService]
+    deps: [HttpBackend, ConfigService]
   };
 }

--- a/packages/geo/src/lib/style/style-list/style-list.service.ts
+++ b/packages/geo/src/lib/style/style-list/style-list.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, Injector } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { HttpBackend, HttpClient } from '@angular/common/http';
 import { throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -12,8 +12,11 @@ import { StyleListOptions } from './style-list.interface';
 })
 export class StyleListService {
   private styleList: object = {};
+  private httpClient: HttpClient;
 
-  constructor(private injector: Injector) {}
+  constructor(handler: HttpBackend) {
+    this.httpClient = new HttpClient(handler);
+  }
 
   /**
    * Use to get the data found in styleList file
@@ -32,10 +35,8 @@ export class StyleListService {
       return true;
     }
 
-    const http = this.injector.get(HttpClient);
-
     return new Promise((resolve, _reject) => {
-      http
+      this.httpClient
         .get(options.path)
         .pipe(
           catchError((error: any): any => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Config file was dependent from Httpclient.
The fact is: Httpclient must instanciate Http_Interceptor .
But our AuthInterceptor was dependent from  our config files....

**What is the new behavior?**
Disconnect the config files dependency to Httpclient.
Use the HttpBackend handler to make calls. Then the http_interceptors do not intercept theses calls. 
https://github.com/angular/angular/issues/26845
https://stackoverflow.com/questions/46469349/how-to-make-an-angular-module-to-ignore-http-interceptor-added-in-a-core-module/49013534#49013534

I think this is a final solution to solve https://github.com/infra-geo-ouverte/igo2-lib/issues/1004
@cbourget, We will probably merge soon. But just to get you informed.

**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**
Config files/Translations files and style-list service files are no more intercepted by AuthInterceptor due to the usage of HttpBackend handler



**Other information**:
