### PR TITLE
fix(geo): google map links were not interpreted on mobile

### DIFF
--- a/packages/geo/src/lib/utils/googleLinks.ts
+++ b/packages/geo/src/lib/utils/googleLinks.ts
@@ -1,14 +1,14 @@
 export class GoogleLinks {
   static getGoogleMapsCoordLink(lon, lat) {
-    return 'https://www.google.com/maps?q=' + lat + ',' + lon;
+    return `https://www.google.com/maps/search/?api=1&query=${lat}%2C${lon}`;
   }
 
   static getGoogleStreetViewLink(lon, lat) {
-    return 'https://www.google.com/maps?q=&layer=c&cbll=' + lat + ',' + lon;
+    return `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${lat}%2C${lon}`
   }
 
   static getGoogleMapsNameLink(name) {
     const encodedName = encodeURI(name);
-    return 'https://www.google.com/maps?q=' + encodedName;
+    return `https://www.google.com/maps/search/?api=1&query=${encodedName}`;
   }
 }

--- a/packages/geo/src/lib/utils/googleLinks.ts
+++ b/packages/geo/src/lib/utils/googleLinks.ts
@@ -4,7 +4,7 @@ export class GoogleLinks {
   }
 
   static getGoogleStreetViewLink(lon, lat) {
-    return `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${lat}%2C${lon}`
+    return `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${lat}%2C${lon}`;
   }
 
   static getGoogleMapsNameLink(name) {

--- a/packages/geo/src/lib/utils/osmLinks.ts
+++ b/packages/geo/src/lib/utils/osmLinks.ts
@@ -1,6 +1,5 @@
 export class OsmLinks {
   static getOpenStreetMapLink(lon, lat, zoom: number = 17) {
-    // return 'https://www.google.com/maps?q=' + lat + ',' + lon;
     return `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=${zoom}/${lat}/${lon}`;
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Current google map link were not interpreted on mobile. Google maps was opening but with no query 


**What is the new behavior?**
Fix around the new method from google map to open their apps. 
https://developers.google.com/maps/documentation/urls/get-started?hl=fr

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
