### PR TITLE
feat(direction): add a toogle to control user interaction with map

### DIFF
--- a/packages/geo/src/lib/directions/directions.component.html
+++ b/packages/geo/src/lib/directions/directions.component.html
@@ -1,4 +1,4 @@
-<div class="directions-options mat-typography">
+<div class="directions-options">
   <mat-slide-toggle
     [checked]="directionControlIsActive"
     [labelPosition]="'before'"

--- a/packages/geo/src/lib/directions/directions.component.html
+++ b/packages/geo/src/lib/directions/directions.component.html
@@ -1,3 +1,13 @@
+<div class="directions-options mat-typography">
+  <mat-slide-toggle
+    [checked]="directionControlIsActive"
+    [labelPosition]="'before'"
+    (change)="onToggleDirectionsControl($event.checked)"
+  >
+    {{ 'igo.geo.directionsForm.toggleActive' | translate }}
+  </mat-slide-toggle>
+</div>
+
 <igo-directions-buttons
   [stepFeatureStore]="stepFeatureStore"
   [contextUri]="contextUri"

--- a/packages/geo/src/lib/directions/directions.component.scss
+++ b/packages/geo/src/lib/directions/directions.component.scss
@@ -1,0 +1,17 @@
+$slide-toggle-width: 60px;
+
+.directions-options {
+  mat-slide-toggle {
+    width: 100%;
+    padding: 10px;
+
+    ::ng-deep .mdc-form-field {
+      width: 100%;
+    }
+
+    ::ng-deep .mdc-label {
+      margin-left: 0;
+      width: calc(100% - #{$slide-toggle-width});
+    }
+  }
+}

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -84,6 +84,14 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   @Input() coordRoundedDecimals: number = 6;
   @Input() zoomToActiveRoute$: Subject<void> = new Subject();
 
+  /**
+   * Wheter one of the direction control is active
+   * @internal
+   */
+  get directionControlIsActive(): boolean {
+    return !this.queryService.queryEnabled;
+  }
+
   constructor(
     private cdRef: ChangeDetectorRef,
     private languageService: LanguageService,
@@ -434,5 +442,20 @@ export class DirectionsComponent implements OnInit, OnDestroy {
       this.projection,
       this.languageService
     );
+  }
+
+  onToggleDirectionsControl(toggle: boolean) {
+    this.queryService.queryEnabled = !toggle;
+    if (toggle) {
+      [this.selectedRoute, this.translateStop, this.selectStopInteraction].map(
+        (interaction) =>
+          this.routesFeatureStore.layer.map.ol.addInteraction(interaction)
+      );
+    } else {
+      [this.selectedRoute, this.translateStop, this.selectStopInteraction].map(
+        (interaction) =>
+          this.routesFeatureStore.layer.map.ol.removeInteraction(interaction)
+      );
+    }
   }
 }

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -444,11 +444,11 @@ export class DirectionsComponent implements OnInit, OnDestroy {
     );
   }
 
-  onToggleDirectionsControl(toggle: boolean) {
-    this.queryService.queryEnabled = !toggle;
+  onToggleDirectionsControl(isActive: boolean) {
+    this.queryService.queryEnabled = !isActive;
     const ol = this.routesFeatureStore.layer.map.ol;
     this.interactions.map((interaction) =>
-      toggle
+      isActive
         ? ol.addInteraction(interaction)
         : ol.removeInteraction(interaction)
     );

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -92,7 +92,7 @@ export class DirectionsComponent implements OnInit, OnDestroy {
     return !this.queryService.queryEnabled;
   }
 
-  get interactions(): any[] {
+  get interactions(): olInteraction.Interaction[] {
     return [this.selectStopInteraction, this.translateStop, this.selectedRoute];
   }
 

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -446,14 +446,11 @@ export class DirectionsComponent implements OnInit, OnDestroy {
 
   onToggleDirectionsControl(toggle: boolean) {
     this.queryService.queryEnabled = !toggle;
-    if (toggle) {
-      this.interactions.map((interaction) =>
-        this.routesFeatureStore.layer.map.ol.addInteraction(interaction)
-      );
-    } else {
-      this.interactions.map((interaction) =>
-        this.routesFeatureStore.layer.map.ol.removeInteraction(interaction)
-      );
-    }
+    const ol = this.routesFeatureStore.layer.map.ol;
+    this.interactions.map((interaction) =>
+      toggle
+        ? ol.addInteraction(interaction)
+        : ol.removeInteraction(interaction)
+    );
   }
 }

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -92,6 +92,10 @@ export class DirectionsComponent implements OnInit, OnDestroy {
     return !this.queryService.queryEnabled;
   }
 
+  get interactions(): any[] {
+    return [this.selectStopInteraction, this.translateStop, this.selectedRoute];
+  }
+
   constructor(
     private cdRef: ChangeDetectorRef,
     private languageService: LanguageService,
@@ -121,11 +125,9 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   }
 
   private freezeStores() {
-    this.stopsFeatureStore.layer.map.ol.removeInteraction(
-      this.selectStopInteraction
+    this.interactions.map((interaction) =>
+      this.routesFeatureStore.layer.map.ol.removeInteraction(interaction)
     );
-    this.stopsFeatureStore.layer.map.ol.removeInteraction(this.translateStop);
-    this.routesFeatureStore.layer.map.ol.removeInteraction(this.selectedRoute);
     this.stopsFeatureStore.deactivateStrategyOfType(
       FeatureStoreLoadingStrategy
     );
@@ -209,11 +211,9 @@ export class DirectionsComponent implements OnInit, OnDestroy {
       }
     });
 
-    this.stopsFeatureStore.layer.map.ol.addInteraction(
-      this.selectStopInteraction
+    this.interactions.map((interaction) =>
+      this.routesFeatureStore.layer.map.ol.addInteraction(interaction)
     );
-    this.stopsFeatureStore.layer.map.ol.addInteraction(this.translateStop);
-    this.routesFeatureStore.layer.map.ol.addInteraction(this.selectedRoute);
   }
 
   onStopInputHasFocusChange(stopInputHasFocus: boolean) {
@@ -447,14 +447,12 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   onToggleDirectionsControl(toggle: boolean) {
     this.queryService.queryEnabled = !toggle;
     if (toggle) {
-      [this.selectedRoute, this.translateStop, this.selectStopInteraction].map(
-        (interaction) =>
-          this.routesFeatureStore.layer.map.ol.addInteraction(interaction)
+      this.interactions.map((interaction) =>
+        this.routesFeatureStore.layer.map.ol.addInteraction(interaction)
       );
     } else {
-      [this.selectedRoute, this.translateStop, this.selectStopInteraction].map(
-        (interaction) =>
-          this.routesFeatureStore.layer.map.ol.removeInteraction(interaction)
+      this.interactions.map((interaction) =>
+        this.routesFeatureStore.layer.map.ol.removeInteraction(interaction)
       );
     }
   }

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -66,7 +66,7 @@ export class DirectionsComponent implements OnInit, OnDestroy {
 
   private selectStopInteraction: olInteraction.Select;
   private translateStop: olInteraction.Translate;
-  private selectedRoute;
+  private selectedRoute: olInteraction.Select;
   private focusOnStop: boolean = false;
   private isTranslating: boolean = false;
 

--- a/packages/geo/src/lib/directions/directions.module.ts
+++ b/packages/geo/src/lib/directions/directions.module.ts
@@ -21,6 +21,7 @@ import { DirectionsInputsComponent } from './directions-inputs/directions-inputs
 import { DirectionsComponent } from './directions.component';
 import { DirectionsButtonsComponent } from './directions-buttons/directions-buttons.component';
 import { DirectionsResultsComponent } from './directions-results/directions-results.component';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @NgModule({
   imports: [
@@ -36,6 +37,7 @@ import { DirectionsResultsComponent } from './directions-results/directions-resu
     MatInputModule,
     MatOptionModule,
     MatSelectModule,
+    MatSlideToggleModule,
     MatTooltipModule,
     MatAutocompleteModule,
     IgoLanguageModule

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -376,7 +376,8 @@
           "copyMsg": "Directions copied to clipboard",
           "copyMsgLink": "Link for directions copied to clipboard",
           "copyTitle": "Directions"
-        }
+        },
+        "toggleActive": "Activate direction control"
       },
       "directions": {
         "uturn": "u-turn",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -376,7 +376,8 @@
           "copyMsg": "Itinéraire copié dans le presse-papier",
           "copyMsgLink": "Le lien de l'itinéraire est copié dans le presse-papier",
           "copyTitle": "Itinéraire"
-        }
+        },
+        "toggleActive": "Activer le contrôle d'itinéraire"
       },
       "directions": {
         "uturn": "demi-tour",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
There is no method to disable map's interaction from the user.

**What is the new behavior?**
Add a toogle to allow the user to enable/disable the map interaction.

This is useful if the user wants to query the map, not add a intermediate point.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
