### PR TITLE
feat(core): add a new method to handle deprecated configs

### DIFF
--- a/packages/core/src/lib/config/config-deprecated.ts
+++ b/packages/core/src/lib/config/config-deprecated.ts
@@ -2,7 +2,7 @@ import { DeprecatedOptions, AlternateConfigOptions } from './config.interface';
 
 export const CONFIG_DEPRECATED: { [key: string]: DeprecatedOptions } = {
   showMenuButton: {
-    alternativeKey: 'menu.button.show',
+    alternativeKey: 'menu.button.visible',
     mayBeRemoveIn: new Date('2024-06-06')
   },
   menuButtonReverseColor: {

--- a/packages/core/src/lib/config/config-deprecated.ts
+++ b/packages/core/src/lib/config/config-deprecated.ts
@@ -20,8 +20,7 @@ export const ALTERNATE_CONFIG_FROM_DEPRECATION = new Map<
     .map(([key, options]) => [
       options.alternativeKey,
       {
-        deprecatedKey: key,
-        mayBeRemoveIn: options.mayBeRemoveIn
+        deprecatedKey: key
       } satisfies AlternateConfigOptions
     ])
 );

--- a/packages/core/src/lib/config/config-deprecated.ts
+++ b/packages/core/src/lib/config/config-deprecated.ts
@@ -1,0 +1,27 @@
+import { DeprecatedOptions, AlternateConfigOptions } from './config.interface';
+
+export const CONFIG_DEPRECATED: { [key: string]: DeprecatedOptions } = {
+  showMenuButton: {
+    alternativeKey: 'menu.button.show',
+    mayBeRemoveIn: new Date('2024-06-06')
+  },
+  menuButtonReverseColor: {
+    alternativeKey: 'menu.button.useThemeColor',
+    mayBeRemoveIn: new Date('2024-06-06')
+  }
+};
+
+export const ALTERNATE_CONFIG_FROM_DEPRECATION = new Map<
+  string,
+  AlternateConfigOptions
+>(
+  Object.entries(CONFIG_DEPRECATED)
+    .filter(([_, options]) => options.alternativeKey)
+    .map(([key, options]) => [
+      options.alternativeKey,
+      {
+        deprecatedKey: key,
+        mayBeRemoveIn: options.mayBeRemoveIn
+      } satisfies AlternateConfigOptions
+    ])
+);

--- a/packages/core/src/lib/config/config.interface.ts
+++ b/packages/core/src/lib/config/config.interface.ts
@@ -2,8 +2,13 @@ export interface ConfigOptions {
   default?: { [key: string]: any };
   path?: string;
 }
-export interface DeprecatedConfig {
-  key: string;
-  deprecationDate?: Date;
+
+export interface DeprecatedOptions {
   alternativeKey?: string;
+  mayBeRemoveIn: Date;
+}
+
+export interface AlternateConfigOptions {
+  deprecatedKey: string;
+  mayBeRemoveIn?: Date;
 }

--- a/packages/core/src/lib/config/config.interface.ts
+++ b/packages/core/src/lib/config/config.interface.ts
@@ -2,3 +2,8 @@ export interface ConfigOptions {
   default?: { [key: string]: any };
   path?: string;
 }
+export interface DeprecatedConfig {
+  key: string;
+  deprecationDate?: Date;
+  alternativeKey?: string;
+}

--- a/packages/core/src/lib/config/config.interface.ts
+++ b/packages/core/src/lib/config/config.interface.ts
@@ -10,5 +10,4 @@ export interface DeprecatedOptions {
 
 export interface AlternateConfigOptions {
   deprecatedKey: string;
-  mayBeRemoveIn?: Date;
 }

--- a/packages/core/src/lib/config/config.service.ts
+++ b/packages/core/src/lib/config/config.service.ts
@@ -23,7 +23,7 @@ export class ConfigService {
     {
       key: 'menuButtonReverseColor',
       deprecationDate: new Date('2024-06-06'),
-      alternativeKey: 'menu.button.show'
+      alternativeKey: 'menu.button.useThemeColor'
     }
   ];
 

--- a/packages/core/src/lib/config/config.service.ts
+++ b/packages/core/src/lib/config/config.service.ts
@@ -33,7 +33,7 @@ export class ConfigService {
     const isDeprecated = this.configDeprecated.get(key);
     if (isDeprecated) {
       this.handleDeprecatedConfig(key);
-    } else if (value === undefined && !isDeprecated) {
+    } else if (value === undefined) {
       return this.handleDeprecationPossibility(key);
     }
 

--- a/packages/geo/src/lib/map/menu-button/menu-button.component.ts
+++ b/packages/geo/src/lib/map/menu-button/menu-button.component.ts
@@ -28,15 +28,7 @@ export class MenuButtonComponent {
     const configValue = this.configService.getConfig(
       'menu.button.useThemeColor'
     );
-    const configReverseColor = this.configService.getConfig(
-      'menuButtonReverseColor'
-    );
-    this.useThemeColor =
-      configValue !== undefined
-        ? configValue
-        : configReverseColor !== undefined
-        ? configReverseColor
-        : false;
+    this.useThemeColor = configValue !== undefined ? configValue : false;
   }
 
   getClassMenuButton() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The is no method to warn user ou super user of deprecated configs.


**What is the new behavior?**
Add a way to infor user, inside the console, as a warn or an error, based on a deprecation date.
If there is an alternate key, the key will be suggested. 
![image](https://github.com/infra-geo-ouverte/igo2-lib/assets/7397743/6ec1a3b0-7305-4a13-bb50-b61ab2e8f45c)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
