### PR TITLE
fix(geo): fix home Extent Button Options

### DIFF
--- a/packages/geo/src/lib/map/home-extent-button/home-extent-button.component.ts
+++ b/packages/geo/src/lib/map/home-extent-button/home-extent-button.component.ts
@@ -36,11 +36,11 @@ export class HomeExtentButtonComponent {
       this.configService.getConfig('homeExtentButton');
 
     this.homeExtentButtonExtent =
-      this.extentOverride || homeExtentButtonOptions.homeExtButtonExtent;
+      this.extentOverride || homeExtentButtonOptions?.homeExtButtonExtent;
     this.homeExtentButtonCenter =
-      this.centerOverride || homeExtentButtonOptions.homeExtButtonCenter;
+      this.centerOverride || homeExtentButtonOptions?.homeExtButtonCenter;
     this.homeExtentButtonZoom =
-      this.zoomOverride || homeExtentButtonOptions.homeExtButtonZoom;
+      this.zoomOverride || homeExtentButtonOptions?.homeExtButtonZoom;
 
     // priority over extent if these 2 properties are defined;
     if (this.centerOverride && this.zoomOverride) {


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

this behavior related to #1391 

**What is the new behavior?**

fix  bug if homeExtentButton config is empty

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
