### PR TITLE
feat(geo): add a error message on fail during data download

### DIFF
--- a/packages/geo/src/lib/offline/geoDB/configFileToGeoDB.service.ts
+++ b/packages/geo/src/lib/offline/geoDB/configFileToGeoDB.service.ts
@@ -1,9 +1,10 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { MessageService } from '@igo2/core';
 
 import { default as JSZip } from 'jszip';
+import { ActiveToast } from 'ngx-toastr';
 import { of, zip } from 'rxjs';
 import { catchError, concatMap } from 'rxjs/operators';
 
@@ -22,12 +23,12 @@ export class ConfigFileToGeoDBService {
   ) {}
 
   load(url: string) {
-    let downloadMessage;
+    let downloadMessage: ActiveToast<any>;
     this.http
       .get(url)
       .pipe(
-        catchError((error: any): any => {
-          console.log(`GeoData file ${url} could not be read`);
+        catchError((error: HttpErrorResponse) => {
+          this.messageService.error(`GeoData file ${url} could not be read`);
           error.error.caught = true;
           throw error;
         }),
@@ -69,6 +70,19 @@ export class ConfigFileToGeoDBService {
                               responseType = 'arraybuffer';
                             }
                             return this.http.get(url, { responseType }).pipe(
+                              catchError((error: HttpErrorResponse) => {
+                                this.messageService.remove(
+                                  downloadMessage.toastId
+                                );
+                                this.messageService.success(
+                                  'igo.geo.indexedDb.data-download-failed',
+                                  undefined,
+                                  { timeOut: 40000 }
+                                );
+
+                                error.error.caught = true;
+                                throw error;
+                              }),
                               concatMap((r) => {
                                 if (isZip) {
                                   const observables$ = [
@@ -145,7 +159,7 @@ export class ConfigFileToGeoDBService {
       .subscribe(() => {
         if (downloadMessage) {
           setTimeout(() => {
-            this.messageService.remove((downloadMessage as any).toastId);
+            this.messageService.remove(downloadMessage.toastId);
             this.messageService.success(
               'igo.geo.indexedDb.data-download-completed',
               undefined,

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -807,7 +807,8 @@
       },
       "indexedDb": {
         "data-download-start": "Downloading data. Please don't leave the current app.",
-        "data-download-completed": "Data download completed"
+        "data-download-completed": "Data download completed",
+        "data-download-failed": "Data download failed. Please contact your application manager."
       }
     }
   }

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -808,7 +808,8 @@
       },
       "indexedDb": {
         "data-download-start": "Téléchargement des données. Veuillez ne pas quitter.",
-        "data-download-completed": "Téléchargement des données terminées."
+        "data-download-completed": "Téléchargement des données terminées.",
+        "data-download-failed": "Échec du téléchargement des données pour utilisation hors ligne. Contacter le support de l'application"
       }
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Wrong url or path simply raise a console.log message OR throw an error.
+ 
On error, the "data download"  message stay indefinetly. 


**What is the new behavior?**
Raise message error + delete the Download start message.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
