### PR TITLE
fix(geo): eliminate 300 ppp resolution from mobile devices

### DIFF
--- a/packages/geo/src/lib/print/print-form/print-form.component.html
+++ b/packages/geo/src/lib/print/print-form/print-form.component.html
@@ -190,10 +190,7 @@
         formControlName="resolution"
         placeholder="{{ 'igo.geo.printForm.resolution' | translate }}"
       >
-        <mat-option
-          *ngFor="let resolution of targetResolutions"
-          [value]="resolution"
-        >
+        <mat-option *ngFor="let resolution of resolutions" [value]="resolution">
           {{ resolution }}
         </mat-option>
       </mat-select>

--- a/packages/geo/src/lib/print/print-form/print-form.component.html
+++ b/packages/geo/src/lib/print/print-form/print-form.component.html
@@ -191,10 +191,10 @@
         placeholder="{{ 'igo.geo.printForm.resolution' | translate }}"
       >
         <mat-option
-          *ngFor="let resolution of resolutions | keyvalue"
-          [value]="resolution.key"
+          *ngFor="let resolution of targetResolutions"
+          [value]="resolution"
         >
-          {{ resolution.value }}
+          {{ resolution }}
         </mat-option>
       </mat-select>
     </mat-form-field>

--- a/packages/geo/src/lib/print/print-form/print-form.component.ts
+++ b/packages/geo/src/lib/print/print-form/print-form.component.ts
@@ -30,7 +30,7 @@ export class PrintFormComponent implements OnInit {
   public outputFormats = PrintOutputFormat;
   public paperFormats = PrintPaperFormat;
   public orientations = PrintOrientation;
-  public resolutions = PrintResolution;
+  public resolutions: Array<string> = Object.keys(PrintResolution);
   public imageFormats = PrintSaveImageFormat;
   public legendPositions = PrintLegendPosition;
   public isPrintService = true;
@@ -203,7 +203,7 @@ export class PrintFormComponent implements OnInit {
   @Output() submit: EventEmitter<PrintOptions> = new EventEmitter();
 
   maxLength: number = 180;
-  targetResolutions: Array<string> = Object.keys(this.resolutions);
+
   constructor(
     private formBuilder: UntypedFormBuilder,
     private mediaService: MediaService
@@ -231,8 +231,8 @@ export class PrintFormComponent implements OnInit {
   ngOnInit() {
     this.doZipFileField.setValue(false);
     if (this.mediaService.isMobile()) {
-      this.targetResolutions = this.targetResolutions.filter(
-        (resolution) => resolution !== this.resolutions['300']
+      this.resolutions = this.resolutions.filter(
+        (resolution) => resolution !== PrintResolution['300']
       );
     }
   }

--- a/packages/geo/src/lib/print/print-form/print-form.component.ts
+++ b/packages/geo/src/lib/print/print-form/print-form.component.ts
@@ -6,6 +6,8 @@ import {
   Validators
 } from '@angular/forms';
 
+import { MediaService } from '@igo2/core';
+
 import { BehaviorSubject } from 'rxjs';
 
 import { PrintOptions } from '../shared/print.interface';
@@ -201,8 +203,11 @@ export class PrintFormComponent implements OnInit {
   @Output() submit: EventEmitter<PrintOptions> = new EventEmitter();
 
   maxLength: number = 180;
-
-  constructor(private formBuilder: UntypedFormBuilder) {
+  targetResolutions: Array<string> = Object.keys(this.resolutions);
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private mediaService: MediaService
+  ) {
     this.form = this.formBuilder.group({
       title: ['', [Validators.minLength(0), Validators.maxLength(130)]],
       subtitle: ['', [Validators.minLength(0), Validators.maxLength(120)]],
@@ -225,6 +230,11 @@ export class PrintFormComponent implements OnInit {
 
   ngOnInit() {
     this.doZipFileField.setValue(false);
+    if (this.mediaService.isMobile()) {
+      this.targetResolutions = this.targetResolutions.filter(
+        (resolution) => resolution !== this.resolutions['300']
+      );
+    }
   }
 
   handleFormSubmit(data: PrintOptions, isValid: boolean) {

--- a/packages/geo/src/lib/print/print-form/print-form.component.ts
+++ b/packages/geo/src/lib/print/print-form/print-form.component.ts
@@ -30,7 +30,7 @@ export class PrintFormComponent implements OnInit {
   public outputFormats = PrintOutputFormat;
   public paperFormats = PrintPaperFormat;
   public orientations = PrintOrientation;
-  public resolutions: Array<string> = Object.keys(PrintResolution);
+  public resolutions = [...PrintResolution];
   public imageFormats = PrintSaveImageFormat;
   public legendPositions = PrintLegendPosition;
   public isPrintService = true;
@@ -82,7 +82,7 @@ export class PrintFormComponent implements OnInit {
     return this.resolutionField.value;
   }
   set resolution(value: PrintResolution) {
-    this.resolutionField.setValue(value || PrintResolution['96'], {
+    this.resolutionField.setValue(value || ('96' satisfies PrintResolution), {
       onlySelf: true
     });
   }
@@ -232,7 +232,7 @@ export class PrintFormComponent implements OnInit {
     this.doZipFileField.setValue(false);
     if (this.mediaService.isMobile()) {
       this.resolutions = this.resolutions.filter(
-        (resolution) => resolution !== PrintResolution['300']
+        (resolution) => resolution !== '300'
       );
     }
   }

--- a/packages/geo/src/lib/print/shared/print.type.ts
+++ b/packages/geo/src/lib/print/shared/print.type.ts
@@ -19,7 +19,7 @@ export type PrintPaperFormat = keyof typeof PrintPaperFormat;
 export const PrintOrientation = strEnum(['landscape', 'portrait']);
 export type PrintOrientation = keyof typeof PrintOrientation;
 
-export const PrintResolution = strEnum(['72', '96', '150']); // For now, we remove the 300 dpi because there is too much instability on iOS and slow device.
+export const PrintResolution = strEnum(['72', '96', '150', '300']);
 export type PrintResolution = keyof typeof PrintResolution;
 
 export const PrintSaveImageFormat = strEnum([

--- a/packages/geo/src/lib/print/shared/print.type.ts
+++ b/packages/geo/src/lib/print/shared/print.type.ts
@@ -19,8 +19,8 @@ export type PrintPaperFormat = keyof typeof PrintPaperFormat;
 export const PrintOrientation = strEnum(['landscape', 'portrait']);
 export type PrintOrientation = keyof typeof PrintOrientation;
 
-export const PrintResolution = strEnum(['72', '96', '150', '300']);
-export type PrintResolution = keyof typeof PrintResolution;
+export const PrintResolution = ['72', '96', '150', '300'] as const;
+export type PrintResolution = (typeof PrintResolution)[number];
 
 export const PrintSaveImageFormat = strEnum([
   'Bmp',


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

this behavior related to [#1085](https://github.com/infra-geo-ouverte/igo2/issues/1085) on igo2

**What is the new behavior?**

with mobile devices max print resolution 150 ppp.
with Pc devices max print resolution 300 ppp.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
