### PR TITLE
fix(geo): adapt numbers with unit and solve show hide ditanse and area 

### DIFF
--- a/packages/geo/src/lib/measure/measurer/measurer.component.html
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.html
@@ -72,7 +72,7 @@
         activeMeasureType === measureType.Area
       "
       [measureType]="measureType.Length"
-      [measureUnit]="measureLengthUnit.Meters"
+      [measureUnit]="activeLengthUnit"
       [measure]="measure.length"
       [auto]="measureUnitsAuto"
       [placeholder]="
@@ -88,7 +88,7 @@
     <igo-measurer-item
       *ngIf="activeMeasureType === measureType.Area"
       [measureType]="measureType.Area"
-      [measureUnit]="measureAreaUnit.SquareMeters"
+      [measureUnit]="activeAreaUnit"
       [measure]="measure.area"
       [auto]="measureUnitsAuto"
       [placeholder]="'igo.geo.measure.area' | translate"

--- a/packages/geo/src/lib/measure/measurer/measurer.component.scss
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.scss
@@ -49,10 +49,9 @@ $slide-toggle-width: 60px;
     padding: 4px 8px;
     white-space: nowrap;
   }
-  .igo-map-tooltip-hidden {
-    display: none;
-  }
-  .igo-map-tooltip-measure-by-display {
-    display: none;
-  }
+}
+
+::ng-deep .igo-map-tooltip-hidden,
+.igo-map-tooltip-measure-by-display {
+  display: none;
 }

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -520,7 +520,6 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    */
   onLengthUnitChange(unit: MeasureLengthUnit) {
     this.activeLengthUnit = unit;
-    console.log('activeLengthUnit', this.activeLengthUnit);
     this.saveCurrentUnits();
     this.refreshTableAndTooltip();
   }

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -1,6 +1,8 @@
+import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -292,7 +294,8 @@ export class MeasurerComponent implements OnInit, OnDestroy {
   constructor(
     private languageService: LanguageService,
     private dialog: MatDialog,
-    private storageService: StorageService
+    private storageService: StorageService,
+    @Inject(DOCUMENT) private document: Document
   ) {
     this.tableTemplate = {
       selection: true,
@@ -439,6 +442,9 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    * @internal
    */
   checkDistanceAreaToggle() {
+    console.log('distanceToggle', this.storageService.get('distanceToggle'));
+    console.log('linesToggle', this.storageService.get('linesToggle'));
+    console.log('areasToggle', this.storageService.get('areasToggle'));
     if (this.storageService.get('distanceToggle') === false) {
       this.displayDistance = false;
     }
@@ -455,20 +461,18 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    * @internal
    */
   onDisplayDistance() {
+    const elements: HTMLCollectionOf<Element> =
+      this.document.getElementsByClassName(
+        'igo-map-tooltip-measure-polygone-segments'
+      );
     if (this.displayDistance) {
-      Array.from(
-        document.getElementsByClassName(
-          'igo-map-tooltip-measure-polygone-segments'
-        )
-      ).map((value: Element) =>
+      Array.from(elements).map((value: Element) =>
         value.classList.remove('igo-map-tooltip-hidden')
       );
     } else {
-      Array.from(
-        document.getElementsByClassName(
-          'igo-map-tooltip-measure-polygone-segments'
-        )
-      ).map((value: Element) => value.classList.add('igo-map-tooltip-hidden'));
+      Array.from(elements).map((value: Element) =>
+        value.classList.add('igo-map-tooltip-hidden')
+      );
     }
   }
 
@@ -477,16 +481,19 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    * @internal
    */
   onDisplayLines() {
-    if (this.displayLines) {
-      Array.from(
-        document.getElementsByClassName('igo-map-tooltip-measure-line-segments')
-      ).map((value: Element) =>
-        value.classList.remove('igo-map-tooltip-hidden')
+    const elements: HTMLCollectionOf<Element> =
+      this.document.getElementsByClassName(
+        'igo-map-tooltip-measure-line-segments'
       );
+
+    if (this.displayLines) {
+      Array.from(elements).map((value: Element) => {
+        value.classList.remove('igo-map-tooltip-hidden');
+      });
     } else {
-      Array.from(
-        document.getElementsByClassName('igo-map-tooltip-measure-line-segments')
-      ).map((value: Element) => value.classList.add('igo-map-tooltip-hidden'));
+      Array.from(elements).map((value: Element) => {
+        value.classList.add('igo-map-tooltip-hidden');
+      });
     }
   }
 
@@ -495,16 +502,17 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    * @internal
    */
   onDisplayAreas() {
+    const elements: HTMLCollectionOf<Element> =
+      this.document.getElementsByClassName('igo-map-tooltip-measure-area');
+
     if (this.displayAreas) {
-      Array.from(
-        document.getElementsByClassName('igo-map-tooltip-measure-area')
-      ).map((value: Element) =>
+      Array.from(elements).map((value: Element) =>
         value.classList.remove('igo-map-tooltip-hidden')
       );
     } else {
-      Array.from(
-        document.getElementsByClassName('igo-map-tooltip-measure-area')
-      ).map((value: Element) => value.classList.add('igo-map-tooltip-hidden'));
+      Array.from(elements).map((value: Element) =>
+        value.classList.add('igo-map-tooltip-hidden')
+      );
     }
   }
 
@@ -635,16 +643,15 @@ export class MeasurerComponent implements OnInit, OnDestroy {
     tryBindStoreLayer(store, layer);
     store.layer.visible = true;
     layer.visible$.subscribe((visible) => {
+      const elements: HTMLCollectionOf<Element> =
+        this.document.getElementsByClassName('igo-map-tooltip-measure');
+
       if (visible) {
-        Array.from(
-          document.getElementsByClassName('igo-map-tooltip-measure')
-        ).map((value: Element) =>
+        Array.from(elements).map((value: Element) =>
           value.classList.remove('igo-map-tooltip-measure-by-display')
         );
       } else {
-        Array.from(
-          document.getElementsByClassName('igo-map-tooltip-measure')
-        ).map((value: Element) =>
+        Array.from(elements).map((value: Element) =>
           value.classList.add('igo-map-tooltip-measure-by-display')
         );
       }
@@ -667,6 +674,8 @@ export class MeasurerComponent implements OnInit, OnDestroy {
         const olGeometry = localFeature.getGeometry() as any;
         this.updateMeasureOfOlGeometry(olGeometry, localFeature.get('measure'));
         this.onDisplayDistance();
+        this.onDisplayLines();
+        this.onDisplayAreas();
       }
     );
 

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -515,6 +515,7 @@ export class MeasurerComponent implements OnInit, OnDestroy {
   onLengthUnitChange(unit: MeasureLengthUnit) {
     this.activeLengthUnit = unit;
     this.table.refresh();
+    this.store.stateView.clear();
     this.updateTooltipsOfOlSource(this.store.source.ol);
     if (this.activeOlGeometry !== undefined) {
       this.updateTooltipsOfOlGeometry(this.activeOlGeometry);
@@ -528,6 +529,7 @@ export class MeasurerComponent implements OnInit, OnDestroy {
   onAreaUnitChange(unit: MeasureAreaUnit) {
     this.activeAreaUnit = unit;
     this.table.refresh();
+    this.store.stateView.clear();
     this.updateTooltipsOfOlSource(this.store.source.ol);
     if (this.activeOlGeometry !== undefined) {
       this.updateTooltipsOfOlGeometry(this.activeOlGeometry);

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -185,12 +185,12 @@ export class MeasurerComponent implements OnInit, OnDestroy {
   /**
    * Active mlength unit
    */
-  private activeLengthUnit: MeasureLengthUnit = MeasureLengthUnit.Meters;
+  public activeLengthUnit: MeasureLengthUnit = MeasureLengthUnit.Meters;
 
   /**
    * Active area unit
    */
-  private activeAreaUnit: MeasureAreaUnit = MeasureAreaUnit.SquareMeters;
+  public activeAreaUnit: MeasureAreaUnit = MeasureAreaUnit.SquareMeters;
 
   /**
    * Feature added listener key
@@ -352,6 +352,7 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    * @internal
    */
   ngOnInit() {
+    this.getSavedUnits();
     this.initStore();
     this.createDrawLineControl();
     this.createDrawPolygonControl();
@@ -519,6 +520,8 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    */
   onLengthUnitChange(unit: MeasureLengthUnit) {
     this.activeLengthUnit = unit;
+    console.log('activeLengthUnit', this.activeLengthUnit);
+    this.saveCurrentUnits();
     this.refreshTableAndTooltip();
   }
 
@@ -528,6 +531,7 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    */
   onAreaUnitChange(unit: MeasureAreaUnit) {
     this.activeAreaUnit = unit;
+    this.saveCurrentUnits();
     this.refreshTableAndTooltip();
   }
 
@@ -1176,5 +1180,28 @@ export class MeasurerComponent implements OnInit, OnDestroy {
     }
 
     return true;
+  }
+
+  private saveCurrentUnits() {
+    this.storageService.set(
+      'distanceUnit',
+      this.activeLengthUnit,
+      StorageScope.SESSION
+    );
+    this.storageService.set(
+      'areaUnit',
+      this.activeAreaUnit,
+      StorageScope.SESSION
+    );
+  }
+
+  private getSavedUnits() {
+    const distanceUnit = this.storageService.get(
+      'distanceUnit'
+    ) as MeasureLengthUnit;
+    const areaUnit = this.storageService.get('areaUnit') as MeasureAreaUnit;
+
+    this.activeLengthUnit = distanceUnit ? distanceUnit : this.activeLengthUnit;
+    this.activeAreaUnit = areaUnit ? areaUnit : this.activeAreaUnit;
   }
 }

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -442,9 +442,6 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    * @internal
    */
   checkDistanceAreaToggle() {
-    console.log('distanceToggle', this.storageService.get('distanceToggle'));
-    console.log('linesToggle', this.storageService.get('linesToggle'));
-    console.log('areasToggle', this.storageService.get('areasToggle'));
     if (this.storageService.get('distanceToggle') === false) {
       this.displayDistance = false;
     }

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -514,12 +514,7 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    */
   onLengthUnitChange(unit: MeasureLengthUnit) {
     this.activeLengthUnit = unit;
-    this.table.refresh();
-    this.store.stateView.clear();
-    this.updateTooltipsOfOlSource(this.store.source.ol);
-    if (this.activeOlGeometry !== undefined) {
-      this.updateTooltipsOfOlGeometry(this.activeOlGeometry);
-    }
+    this.refreshTableAndTooltip();
   }
 
   /**
@@ -528,8 +523,12 @@ export class MeasurerComponent implements OnInit, OnDestroy {
    */
   onAreaUnitChange(unit: MeasureAreaUnit) {
     this.activeAreaUnit = unit;
-    this.table.refresh();
+    this.refreshTableAndTooltip();
+  }
+
+  private refreshTableAndTooltip(): void {
     this.store.stateView.clear();
+
     this.updateTooltipsOfOlSource(this.store.source.ol);
     if (this.activeOlGeometry !== undefined) {
       this.updateTooltipsOfOlGeometry(this.activeOlGeometry);


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

this behavior related to #1499 and [#1096](https://github.com/infra-geo-ouverte/igo2/issues/1096)

**What is the new behavior?**
- adapt numbers with unit changes.
- solve show hide ligne ditanse and area surface.
- keep Length and area units after navigating to another tool.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
