### PR TITLE
fix(geo): build with partial compilation mode

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,6 @@
+{
+  "excludeRegExp": [
+    "^.*geo/src/lib/map.*$",
+    "^.*geo/src/lib/layer.*$"
+  ]
+}

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-group.component.ts
@@ -13,7 +13,7 @@ import type { EntityStateManager } from '@igo2/common';
 
 import { BehaviorSubject } from 'rxjs';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   AddedChangeEmitter,
   AddedChangeGroupEmitter,

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.ts
@@ -15,7 +15,7 @@ import { first } from 'rxjs/operators';
 
 import { LayerService } from '../../layer/shared/layer.service';
 import { Layer, TooltipType } from '../../layer/shared/layers';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { MetadataLayerOptions } from '../../metadata/shared/metadata.interface';
 import { AddedChangeEmitter, CatalogItemLayer } from '../shared';
 

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
@@ -13,7 +13,7 @@ import { BehaviorSubject, zip } from 'rxjs';
 
 import { LayerService } from '../../layer/shared/layer.service';
 import { Layer } from '../../layer/shared/layers/layer';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   AddedChangeEmitter,
   AddedChangeGroupEmitter,

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
@@ -11,7 +11,7 @@ import { ConfigService, LanguageService } from '@igo2/core';
 
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import { TypeCapabilities } from '../../datasource';
+import { TypeCapabilities } from '../../datasource/shared/capabilities.interface';
 import { Catalog } from '../shared/catalog.abstract';
 
 @Component({

--- a/packages/geo/src/lib/catalog/catalog-library/catalog-library-item.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/catalog-library-item.component.ts
@@ -8,7 +8,7 @@ import {
 
 import { getEntityTitle } from '@igo2/common';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { Catalog } from '../shared/catalog.abstract';
 
 /**

--- a/packages/geo/src/lib/catalog/catalog-library/catalog-library.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/catalog-library.component.ts
@@ -17,8 +17,8 @@ import { Observable, Subscription } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Md5 } from 'ts-md5';
 
-import { CapabilitiesService } from '../../datasource';
-import { IgoMap } from '../../map/shared';
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
+import { IgoMap } from '../../map/shared/map';
 import { standardizeUrl } from '../../utils/id-generator';
 import { Catalog } from '../shared/catalog.abstract';
 import { AddCatalogDialogComponent } from './add-catalog-dialog.component';

--- a/packages/geo/src/lib/catalog/shared/catalog.abstract.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.abstract.ts
@@ -1,8 +1,8 @@
 import { Observable } from 'rxjs';
 
-import { TimeFilterOptions } from '../../filter/shared';
-import { TooltipType } from '../../layer/shared';
-import { QueryFormat, QueryHtmlTarget } from '../../query/shared';
+import { TimeFilterOptions } from '../../filter/shared/time-filter.interface';
+import { TooltipType } from '../../layer/shared/layers/layer.interface';
+import { QueryFormat, QueryHtmlTarget } from '../../query/shared/query.enums';
 import { TypeCatalogStrings } from './catalog.enum';
 import { CatalogItem, CatalogItemGroup, ICatalog } from './catalog.interface';
 

--- a/packages/geo/src/lib/catalog/shared/catalog.interface.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.interface.ts
@@ -1,7 +1,7 @@
 import { EntityState } from '@igo2/common';
 
-import { TooltipType } from '../../layer';
-import { QueryFormat } from '../../query';
+import { TooltipType } from '../../layer/shared/layers/layer.interface';
+import { QueryFormat } from '../../query/shared/query.enums';
 import { MetadataLayerOptions } from './../../metadata/shared/metadata.interface';
 import {
   CatalogItemType,

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -7,17 +7,17 @@ import { ObjectUtils, uuid } from '@igo2/utils';
 import { EMPTY, Observable, of, zip } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
 import {
   ArcGISRestDataSourceOptions,
-  CapabilitiesService,
   WMSDataSourceOptions,
   WMSDataSourceOptionsParams,
   WMTSDataSourceOptions
-} from '../../datasource';
+} from '../../datasource/shared/datasources';
 import { ImageLayerOptions, LayerOptions } from '../../layer/shared';
-import { getResolutionFromScale } from '../../map/shared';
-import { QueryFormat } from '../../query/shared';
-import { generateIdFromSourceOptions } from '../../utils';
+import { getResolutionFromScale } from '../../map/shared/map.utils';
+import { QueryFormat } from '../../query/shared/query.enums';
+import { generateIdFromSourceOptions } from '../../utils/id-generator';
 import { Catalog } from './catalog.abstract';
 import { CatalogItemType, TypeCatalog } from './catalog.enum';
 import {

--- a/packages/geo/src/lib/datasource/shared/capabilities.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.interface.ts
@@ -1,0 +1,9 @@
+export enum TypeCapabilities {
+  wms = 'wms',
+  wmts = 'wmts',
+  arcgisrest = 'esriJSON',
+  imagearcgisrest = 'esriJSON',
+  tilearcgisrest = 'esriJSON'
+}
+
+export type TypeCapabilitiesStrings = keyof typeof TypeCapabilities;

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -28,6 +28,10 @@ import {
 } from '../../query/shared/query.enums';
 import { EsriStyleGenerator } from '../../style/shared/datasource/esri-style-generator';
 import {
+  TypeCapabilities,
+  TypeCapabilitiesStrings
+} from './capabilities.interface';
+import {
   ArcGISRestDataSourceOptions,
   ArcGISRestImageDataSourceOptions,
   CartoDataSourceOptions,
@@ -35,16 +39,6 @@ import {
   WMSDataSourceOptions,
   WMTSDataSourceOptions
 } from './datasources';
-
-export enum TypeCapabilities {
-  wms = 'wms',
-  wmts = 'wmts',
-  arcgisrest = 'esriJSON',
-  imagearcgisrest = 'esriJSON',
-  tilearcgisrest = 'esriJSON'
-}
-
-export type TypeCapabilitiesStrings = keyof typeof TypeCapabilities;
 
 @Injectable({
   providedIn: 'root'

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
@@ -3,7 +3,7 @@ import olSource from 'ol/source/Source';
 import olSourceVector from 'ol/source/Vector';
 import type { ServerType } from 'ol/source/wms';
 
-import { TimeFilterOptions } from '../../../filter';
+import { TimeFilterOptions } from '../../../filter/shared/time-filter.interface';
 import { DataSourceOptions } from './datasource.interface';
 import { WFSDataSourceOptionsParams } from './wfs-datasource.interface';
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -4,13 +4,13 @@ import olSourceImageWMS from 'ol/source/ImageWMS';
 
 import { BehaviorSubject } from 'rxjs';
 
-import { TimeFilterOptions } from '../../../filter';
 import { OgcFilterWriter } from '../../../filter/shared/ogc-filter';
 import {
   OgcFilterDuringOptions,
   OgcFilterableDataSourceOptions,
   OgcFiltersOptions
 } from '../../../filter/shared/ogc-filter.interface';
+import { TimeFilterOptions } from '../../../filter/shared/time-filter.interface';
 import { LegendMapViewOptions } from '../../../layer/shared/layers/legend.interface';
 import { QueryHtmlTarget } from '../../../query/shared/query.enums';
 import { DataSource } from './datasource';

--- a/packages/geo/src/lib/datasource/shared/index.ts
+++ b/packages/geo/src/lib/datasource/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './datasources';
 export * from './datasource.service';
+export * from './capabilities.interface';
 export * from './capabilities.service';
 export * from './options';

--- a/packages/geo/src/lib/directions/shared/directions.service.ts
+++ b/packages/geo/src/lib/directions/shared/directions.service.ts
@@ -11,8 +11,9 @@ import { UserOptions } from 'jspdf-autotable';
 import moment from 'moment';
 import { Observable, Subject } from 'rxjs';
 
-import { IgoMap } from '../../map';
-import { PrintLegendPosition, PrintService } from '../../print';
+import { IgoMap } from '../../map/shared/map';
+import { PrintService } from '../../print/shared/print.service';
+import { PrintLegendPosition } from '../../print/shared/print.type';
 import { DirectionsSource } from '../directions-sources/directions-source';
 import { Direction, DirectionOptions } from '../shared/directions.interface';
 import { DirectionsSourceService } from './directions-source.service';

--- a/packages/geo/src/lib/download/shared/download.service.ts
+++ b/packages/geo/src/lib/download/shared/download.service.ts
@@ -10,7 +10,7 @@ import {
   OgcFilterWriter,
   OgcFilterableDataSourceOptions
 } from '../../filter/shared';
-import { Layer } from '../../layer/shared';
+import { Layer } from '../../layer/shared/layers/layer';
 
 @Injectable({
   providedIn: 'root'

--- a/packages/geo/src/lib/draw/shared/draw.interface.ts
+++ b/packages/geo/src/lib/draw/shared/draw.interface.ts
@@ -1,5 +1,5 @@
-import { FeatureStore } from '../../feature';
 import { Feature } from '../../feature/shared/feature.interfaces';
+import { FeatureStore } from '../../feature/shared/store';
 import { DrawControl } from '../../geometry/shared/controls/draw';
 import { IgoMap } from '../../map/shared/map';
 import {

--- a/packages/geo/src/lib/environment/environment.interface.ts
+++ b/packages/geo/src/lib/environment/environment.interface.ts
@@ -1,16 +1,14 @@
 import { DOMOptions, DepotOptions } from '@igo2/common';
 
-import { CatalogServiceOptions } from '../catalog';
-import { OptionsApiOptions } from '../datasource';
-import { DirectionsSourceOptions } from '../directions';
+import { CatalogServiceOptions } from '../catalog/shared/catalog.interface';
+import { OptionsApiOptions } from '../datasource/shared/options/options-api.interface';
+import { DirectionsSourceOptions } from '../directions/directions-sources/directions-source.interface';
 import { DrawOptions } from '../draw/shared/draw.interface';
-import { SpatialFilterOptions } from '../filter';
-import { ImportExportServiceOptions } from '../import-export';
-import {
-  GeolocationOptions,
-  HomeExtentButtonOptions,
-  Projection
-} from '../map';
+import { SpatialFilterOptions } from '../filter/shared/spatial-filter.interface';
+import { ImportExportServiceOptions } from '../import-export/shared/import.interface';
+import { HomeExtentButtonOptions } from '../map/home-extent-button/home-extent-button.interface';
+import { GeolocationOptions } from '../map/shared/controllers/geolocation.interface';
+import { Projection } from '../map/shared/projection.interfaces';
 import {
   SearchSourceOptions,
   StoredQueriesReverseSearchSourceOptions,

--- a/packages/geo/src/lib/feature/shared/feature-store.utils.ts
+++ b/packages/geo/src/lib/feature/shared/feature-store.utils.ts
@@ -1,4 +1,4 @@
-import { FeatureDataSource } from '../../datasource';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import { VectorLayer } from '../../layer/shared/layers/vector-layer';
 import { FeatureStore } from './store';
 

--- a/packages/geo/src/lib/feature/shared/feature.interfaces.ts
+++ b/packages/geo/src/lib/feature/shared/feature.interfaces.ts
@@ -12,9 +12,9 @@ import OlRenderFeature from 'ol/render/Feature';
 
 import { GeoJsonGeometryTypes } from 'geojson';
 
-import { SourceFieldsOptionsParams } from '../../datasource';
-import { VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { SourceFieldsOptionsParams } from '../../datasource/shared/datasources';
+import { VectorLayer } from '../../layer/shared/layers/vector-layer';
+import { IgoMap } from '../../map/shared/map';
 import { FeatureMotion } from './feature.enums';
 
 export interface Feature<P = { [key: string]: any }> {

--- a/packages/geo/src/lib/feature/shared/feature.utils.ts
+++ b/packages/geo/src/lib/feature/shared/feature.utils.ts
@@ -22,7 +22,8 @@ import OlRenderFeature from 'ol/render/Feature';
 import OlSource from 'ol/source/Source';
 import * as olstyle from 'ol/style';
 
-import { MapExtent, MapViewController } from '../../map/shared';
+import { MapViewController } from '../../map/shared/controllers/view';
+import { MapExtent } from '../../map/shared/map.interface';
 import { FEATURE, FeatureMotion } from './feature.enums';
 import { Feature, FeatureGeometry } from './feature.interfaces';
 

--- a/packages/geo/src/lib/feature/shared/store.ts
+++ b/packages/geo/src/lib/feature/shared/store.ts
@@ -6,7 +6,7 @@ import type { default as OlGeometry } from 'ol/geom/Geometry';
 
 import { Document } from 'flexsearch';
 
-import { FeatureDataSource } from '../../datasource';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import { VectorLayer } from '../../layer/shared';
 import { IgoMap, MapExtent } from '../../map/shared';
 import { FeatureMotion } from './feature.enums';

--- a/packages/geo/src/lib/feature/shared/strategies/geo-properties.ts
+++ b/packages/geo/src/lib/feature/shared/strategies/geo-properties.ts
@@ -6,8 +6,8 @@ import { Subscription, debounceTime, pairwise } from 'rxjs';
 import { CapabilitiesService } from '../../../datasource/shared/capabilities.service';
 import { Layer } from '../../../layer/shared/layers/layer';
 import { IgoMap } from '../../../map/shared/map';
-import { GeoServiceDefinition } from '../../../utils';
 import { generateIdFromSourceOptions } from '../../../utils/id-generator';
+import { GeoServiceDefinition } from '../../../utils/propertyTypeDetector/propertyTypeDetector.interface';
 import { PropertyTypeDetectorService } from '../../../utils/propertyTypeDetector/propertyTypeDetector.service';
 import {
   Feature,

--- a/packages/geo/src/lib/feature/shared/strategies/in-map-extent.ts
+++ b/packages/geo/src/lib/feature/shared/strategies/in-map-extent.ts
@@ -5,7 +5,7 @@ import * as olextent from 'ol/extent';
 import { Subscription } from 'rxjs';
 import { debounceTime, skipWhile } from 'rxjs/operators';
 
-import { MapExtent } from '../../../map';
+import { MapExtent } from '../../../map/shared/map.interface';
 import {
   Feature,
   FeatureStoreInMapExtentStrategyOptions

--- a/packages/geo/src/lib/feature/shared/strategies/selection.ts
+++ b/packages/geo/src/lib/feature/shared/strategies/selection.ts
@@ -11,7 +11,7 @@ import { DragBoxEvent as OlDragBoxEvent } from 'ol/interaction/DragBox';
 import { Subscription, combineLatest } from 'rxjs';
 import { debounceTime, map, skip } from 'rxjs/operators';
 
-import { FeatureDataSource } from '../../../datasource';
+import { FeatureDataSource } from '../../../datasource/shared/datasources';
 import { VectorLayer } from '../../../layer/shared/layers/vector-layer';
 import { IgoMap } from '../../../map/shared/map';
 import { ctrlKeyDown } from '../../../map/shared/map.utils';

--- a/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-button/ogc-filter-button.component.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 
 import { Layer } from '../../layer/shared/layers/layer';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   IgoOgcSelector,
   OgcFilterableDataSourceOptions

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
@@ -10,7 +10,7 @@ import {
   OgcFilterableDataSource,
   OgcFiltersOptions
 } from '../../filter/shared/ogc-filter.interface';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { WktService } from '../../wkt/shared/wkt.service';
 
 @Component({

--- a/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-selection/ogc-filter-selection.component.ts
@@ -28,7 +28,7 @@ import {
   OgcSelectorBundle,
   SelectorGroup
 } from '../../filter/shared/ogc-filter.interface';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { OgcFilterOperator } from '../shared/ogc-filter.enum';
 import { OGCFilterService } from '../shared/ogc-filter.service';
 

--- a/packages/geo/src/lib/filter/ogc-filterable-form/ogc-filterable-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-form/ogc-filterable-form.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { MAT_AUTOCOMPLETE_DEFAULT_OPTIONS } from '@angular/material/autocomplete';
 import { MAT_SELECT_CONFIG } from '@angular/material/select';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { OgcFilterableDataSource } from '../shared/ogc-filter.interface';
 
 @Component({

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -6,7 +6,7 @@ import { WFSDataSourceOptionsParams } from '../../datasource/shared/datasources/
 import { WMSDataSource } from '../../datasource/shared/datasources/wms-datasource';
 import { OgcFilterOperator } from '../../filter/shared/ogc-filter.enum';
 import { Layer } from '../../layer/shared/layers/layer';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { OgcFilterWriter } from '../shared/ogc-filter';
 import {
   OgcFilterableDataSource,

--- a/packages/geo/src/lib/filter/ogc-filterable-list/ogc-filterable-list.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-list/ogc-filterable-list.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { Layer } from '../../layer/shared/layers/layer';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 
 @Component({
   selector: 'igo-ogc-filterable-list',

--- a/packages/geo/src/lib/filter/shared/filterable-datasource.pipe.ts
+++ b/packages/geo/src/lib/filter/shared/filterable-datasource.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { TimeFilterableDataSource } from '../../datasource';
+import { TimeFilterableDataSource } from '../../datasource/shared/datasources/wms-datasource';
 import { Layer } from '../../layer/shared/layers/layer';
 import { OgcFilterableDataSource } from './ogc-filter.interface';
 

--- a/packages/geo/src/lib/filter/shared/spatial-filter.service.ts
+++ b/packages/geo/src/lib/filter/shared/spatial-filter.service.ts
@@ -6,7 +6,7 @@ import { ConfigService, LanguageService } from '@igo2/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { Feature } from '../../feature/shared';
+import { Feature } from '../../feature/shared/feature.interfaces';
 import {
   SpatialFilterItemType,
   SpatialFilterQueryType,

--- a/packages/geo/src/lib/filter/spatial-filter/spatial-filter-item/spatial-filter-item.component.ts
+++ b/packages/geo/src/lib/filter/spatial-filter/spatial-filter-item/spatial-filter-item.component.ts
@@ -35,7 +35,7 @@ import { FeatureDataSource } from '../../../datasource/shared';
 import { FeatureMotion, FeatureStoreSelectionStrategy } from '../../../feature';
 import { GeoJSONGeometry } from '../../../geometry/shared/geometry.interfaces';
 import { Layer, VectorLayer } from '../../../layer/shared';
-import { IgoMap } from '../../../map/shared';
+import { IgoMap } from '../../../map/shared/map';
 import { MeasureLengthUnit } from '../../../measure';
 import {
   SpatialFilterQueryType,

--- a/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-button/time-filter-button.component.ts
@@ -5,10 +5,10 @@ import {
   OnInit
 } from '@angular/core';
 
-import { TimeFilterableDataSourceOptions } from '../../datasource';
+import { TimeFilterableDataSourceOptions } from '../../datasource/shared/datasources/wms-datasource.interface';
 import { WMSDataSourceOptions } from '../../datasource/shared/datasources/wms-datasource.interface';
 import { Layer } from '../../layer/shared/layers/layer';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 
 @Component({
   selector: 'igo-time-filter-button',

--- a/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
+++ b/packages/geo/src/lib/filter/time-filter-item/time-filter-item.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import { TimeFilterableDataSource } from '../../datasource';
+import { TimeFilterableDataSource } from '../../datasource/shared/datasources/wms-datasource';
 import { Layer } from '../../layer/shared/layers/layer';
 import { TimeFilterService } from '../shared/time-filter.service';
 

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field-input.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field-input.component.ts
@@ -28,7 +28,7 @@ import { StyleLike as OlStyleLike } from 'ol/style/Style';
 
 import { Subscription } from 'rxjs';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   MeasureLengthUnit,
   formatMeasure,

--- a/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
+++ b/packages/geo/src/lib/geometry/geometry-form-field/geometry-form-field.component.ts
@@ -15,7 +15,7 @@ import { StyleLike as OlStyleLike } from 'ol/style/Style';
 
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { GeoJSONGeometry } from '../shared/geometry.interfaces';
 
 /**

--- a/packages/geo/src/lib/geometry/shared/geometry.interfaces.ts
+++ b/packages/geo/src/lib/geometry/shared/geometry.interfaces.ts
@@ -4,7 +4,7 @@ import type { Type } from 'ol/geom/Geometry';
 
 import { GeoJsonGeometryTypes } from 'geojson';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 
 export interface GeometryFormFieldInputs extends FormFieldInputs {
   map: IgoMap;

--- a/packages/geo/src/lib/import-export/export-button/export-button.component.ts
+++ b/packages/geo/src/lib/import-export/export-button/export-button.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { DataSourceOptions } from '../../datasource';
+import { DataSourceOptions } from '../../datasource/shared/datasources';
 import { VectorLayer } from '../../layer/shared';
 import { Layer } from '../../layer/shared/layers/layer';
 

--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.ts
@@ -17,7 +17,8 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { MetadataLayerOptions } from '../../metadata/shared/metadata.interface';
 import { layerIsQueryable } from '../../query/shared/query.utils';
-import { Layer, TooltipType } from '../shared/layers';
+import { Layer } from '../shared/layers/layer';
+import { TooltipType } from '../shared/layers/layer.interface';
 
 @Component({
   selector: 'igo-layer-item',

--- a/packages/geo/src/lib/layer/layer-legend-item/layer-legend-item.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend-item/layer-legend-item.component.ts
@@ -11,7 +11,8 @@ import { ConnectionState, NetworkService } from '@igo2/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { MetadataLayerOptions } from '../../metadata/shared/metadata.interface';
-import { Layer, TooltipType } from '../shared/layers';
+import { Layer } from '../shared/layers/layer';
+import { TooltipType } from '../shared/layers/layer.interface';
 
 @Component({
   selector: 'igo-layer-legend-item',

--- a/packages/geo/src/lib/layer/layer-legend-list/layer-legend-list.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend-list/layer-legend-list.component.ts
@@ -17,7 +17,7 @@ import {
 } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 
-import { Layer } from '../shared';
+import { Layer } from '../shared/layers/layer';
 
 @Component({
   selector: 'igo-layer-legend-list',

--- a/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
+++ b/packages/geo/src/lib/layer/layer-legend/layer-legend.component.ts
@@ -17,10 +17,11 @@ import { ConfigService, LanguageService } from '@igo2/core';
 import { BehaviorSubject, Observable, Subscription, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { WMSDataSource, WMSDataSourceOptions } from '../../datasource';
 import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
 import { Legend } from '../../datasource/shared/datasources/datasource.interface';
-import { Layer } from '../shared/layers';
+import { WMSDataSource } from '../../datasource/shared/datasources/wms-datasource';
+import { WMSDataSourceOptions } from '../../datasource/shared/datasources/wms-datasource.interface';
+import { Layer } from '../shared/layers/layer';
 import {
   ItemStyleOptions,
   LegendMapViewOptions

--- a/packages/geo/src/lib/layer/shared/layer.service.ts
+++ b/packages/geo/src/lib/layer/shared/layer.service.ts
@@ -14,6 +14,7 @@ import { stylefunction } from 'ol-mapbox-style';
 import { Observable, combineLatest, of } from 'rxjs';
 import { catchError, concatMap, map } from 'rxjs/operators';
 
+import { DataSourceService } from '../../datasource/shared/datasource.service';
 import {
   ArcGISRestDataSource,
   CartoDataSource,
@@ -29,8 +30,7 @@ import {
   WMTSDataSource,
   WebSocketDataSource,
   XYZDataSource
-} from '../../datasource';
-import { DataSourceService } from '../../datasource/shared/datasource.service';
+} from '../../datasource/shared/datasources';
 import { LayerDBService } from '../../offline/layerDB/layerDB.service';
 import { GeoNetworkService } from '../../offline/shared/geo-network.service';
 import { StyleService } from '../../style/style-service/style.service';

--- a/packages/geo/src/lib/layer/shared/layers/image-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/image-layer.ts
@@ -6,8 +6,8 @@ import olSourceImage from 'ol/source/Image';
 
 import { ImageArcGISRestDataSource } from '../../../datasource/shared/datasources/imagearcgisrest-datasource';
 import { WMSDataSource } from '../../../datasource/shared/datasources/wms-datasource';
-import { IgoMap } from '../../../map/shared';
-import { ImageWatcher } from '../../utils';
+import { IgoMap } from '../../../map/shared/map';
+import { ImageWatcher } from '../../utils/image-watcher';
 import { ImageLayerOptions } from './image-layer.interface';
 import { Layer } from './layer';
 

--- a/packages/geo/src/lib/layer/shared/layers/layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.ts
@@ -14,7 +14,8 @@ import {
 } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { DataSource, Legend } from '../../../datasource';
+import { DataSource } from '../../../datasource/shared/datasources/datasource';
+import { Legend } from '../../../datasource/shared/datasources/datasource.interface';
 import { MapBase } from '../../../map/shared/map.abstract';
 import { getResolutionFromScale } from '../../../map/shared/map.utils';
 import { GeoDBService } from '../../../offline/geoDB/geoDB.service';

--- a/packages/geo/src/lib/layer/shared/layers/tile-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/tile-layer.ts
@@ -11,8 +11,8 @@ import { TileArcGISRestDataSource } from '../../../datasource/shared/datasources
 import { TileDebugDataSource } from '../../../datasource/shared/datasources/tiledebug-datasource';
 import { WMTSDataSource } from '../../../datasource/shared/datasources/wmts-datasource';
 import { XYZDataSource } from '../../../datasource/shared/datasources/xyz-datasource';
-import { IgoMap } from '../../../map/shared';
-import { TileWatcher } from '../../utils';
+import { IgoMap } from '../../../map/shared/map';
+import { TileWatcher } from '../../utils/tile-watcher';
 import { Layer } from './layer';
 import { TileLayerOptions } from './tile-layer.interface';
 

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -43,16 +43,16 @@ import {
   OgcFiltersOptions
 } from '../../../filter/shared/ogc-filter.interface';
 import { IgoMap, MapExtent, getResolutionFromScale } from '../../../map/shared';
-import { LayerDBData } from '../../../offline';
 import { InsertSourceInsertDBEnum } from '../../../offline/geoDB/geoDB.enums';
 import { GeoDBService } from '../../../offline/geoDB/geoDB.service';
+import { LayerDBData } from '../../../offline/layerDB/layerDB.interface';
 import { LayerDBService } from '../../../offline/layerDB/layerDB.service';
 import {
   GeoNetworkService,
   SimpleGetOptions
 } from '../../../offline/shared/geo-network.service';
 import { olStyleToBasicIgoStyle } from '../../../style/shared/vector/conversion.utils';
-import { VectorWatcher } from '../../utils';
+import { VectorWatcher } from '../../utils/vector-watcher';
 import { Layer } from './layer';
 import { VectorLayerOptions } from './vector-layer.interface';
 

--- a/packages/geo/src/lib/layer/shared/layers/vectortile-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vectortile-layer.ts
@@ -6,8 +6,8 @@ import olLayerVectorTile from 'ol/layer/VectorTile';
 import olSourceVectorTile from 'ol/source/VectorTile';
 
 import { MVTDataSource } from '../../../datasource/shared/datasources/mvt-datasource';
-import { IgoMap } from '../../../map/shared';
-import { TileWatcher } from '../../utils';
+import { IgoMap } from '../../../map/shared/map';
+import { TileWatcher } from '../../utils/tile-watcher';
 import { Layer } from './layer';
 import { VectorTileLayerOptions } from './vectortile-layer.interface';
 

--- a/packages/geo/src/lib/layer/track-feature-button/track-feature-button.component.ts
+++ b/packages/geo/src/lib/layer/track-feature-button/track-feature-button.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit
 } from '@angular/core';
 
-import { VectorLayer } from '../shared/layers';
+import { VectorLayer } from '../shared/layers/vector-layer';
 import { VectorLayerOptions } from '../shared/layers/vector-layer.interface';
 
 @Component({

--- a/packages/geo/src/lib/map/baselayers-switcher/baselayers-switcher.component.ts
+++ b/packages/geo/src/lib/map/baselayers-switcher/baselayers-switcher.component.ts
@@ -5,7 +5,7 @@ import { Media, MediaService } from '@igo2/core';
 import { Subscription } from 'rxjs';
 
 import { Layer } from '../../layer/shared';
-import { IgoMap } from '../shared';
+import { IgoMap } from '../shared/map';
 import { baseLayersSwitcherSlideInOut } from './baselayers-switcher.animation';
 
 @Component({

--- a/packages/geo/src/lib/map/baselayers-switcher/mini-basemap.component.ts
+++ b/packages/geo/src/lib/map/baselayers-switcher/mini-basemap.component.ts
@@ -12,7 +12,7 @@ import OlView from 'ol/View';
 
 import { Layer, LayerOptions } from '../../layer/shared';
 import { LayerService } from '../../layer/shared/layer.service';
-import { IgoMap } from '../shared';
+import { IgoMap } from '../shared/map';
 
 @Component({
   selector: 'igo-mini-basemap',

--- a/packages/geo/src/lib/map/shared/linkedLayers.utils.ts
+++ b/packages/geo/src/lib/map/shared/linkedLayers.utils.ts
@@ -5,7 +5,7 @@ import { getUid } from 'ol/util';
 import {
   TimeFilterableDataSource,
   TimeFilterableDataSourceOptions
-} from '../../datasource';
+} from '../../datasource/shared/datasources';
 import { WMSDataSource } from '../../datasource/shared/datasources/wms-datasource';
 import { OgcFilterWriter } from '../../filter/shared/ogc-filter';
 import {

--- a/packages/geo/src/lib/map/shared/map.abstract.ts
+++ b/packages/geo/src/lib/map/shared/map.abstract.ts
@@ -8,16 +8,18 @@ import { Source } from 'ol/source';
 import { Map } from 'ol';
 import { BehaviorSubject, Subject } from 'rxjs';
 
-import { FeatureDataSource } from '../../datasource';
-import { Layer } from '../../layer';
-import { Overlay } from '../../overlay';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
+import { Layer } from '../../layer/shared/layers/layer';
+import { Overlay } from '../../overlay/shared/overlay';
+import {
+  MapGeolocationController,
+  MapViewController
+} from '../shared/controllers';
 import {
   MapControlsOptions,
   MapExtent,
-  MapGeolocationController,
-  MapViewController,
   MapViewOptions
-} from '../shared';
+} from '../shared/map.interface';
 
 export abstract class MapBase {
   ol: Map;

--- a/packages/geo/src/lib/measure/measurer/measurer.component.ts
+++ b/packages/geo/src/lib/measure/measurer/measurer.component.ts
@@ -27,7 +27,7 @@ import OlStyle from 'ol/style/Style';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { skip } from 'rxjs/operators';
 
-import { FeatureDataSource } from '../../datasource';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import {
   FEATURE,
   FeatureStore,
@@ -39,7 +39,7 @@ import {
 } from '../../feature';
 import { DrawControl, ModifyControl } from '../../geometry/shared';
 import { VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   MeasureAreaUnit,
   MeasureLengthUnit,

--- a/packages/geo/src/lib/measure/shared/measure.interfaces.ts
+++ b/packages/geo/src/lib/measure/shared/measure.interfaces.ts
@@ -1,5 +1,5 @@
-import { Feature } from '../../feature';
-import { IgoMap } from '../../map/shared';
+import { Feature } from '../../feature/shared/feature.interfaces';
+import { IgoMap } from '../../map/shared/map';
 
 export interface Measure {
   area?: number;

--- a/packages/geo/src/lib/metadata/shared/metadata.interface.ts
+++ b/packages/geo/src/lib/metadata/shared/metadata.interface.ts
@@ -1,4 +1,4 @@
-import { TypeCatalogStrings } from '../../catalog';
+import { TypeCatalogStrings } from '../../catalog/shared/catalog.enum';
 import { LayerOptions } from '../../layer/shared/layers/layer.interface';
 
 export interface MetadataOptions {

--- a/packages/geo/src/lib/overlay/shared/overlay.ts
+++ b/packages/geo/src/lib/overlay/shared/overlay.ts
@@ -1,7 +1,7 @@
 import OlFeature from 'ol/Feature';
 import type { default as OlGeometry } from 'ol/geom/Geometry';
 
-import { FeatureDataSource } from '../../datasource';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import {
   Feature,
   FeatureMotion,

--- a/packages/geo/src/lib/overlay/shared/overlay.utils.ts
+++ b/packages/geo/src/lib/overlay/shared/overlay.utils.ts
@@ -1,4 +1,4 @@
-import { FeatureDataSource } from '../../datasource';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import { VectorLayer } from '../../layer/shared/layers/vector-layer';
 import { createOverlayLayerStyle } from '../../style/shared/overlay/overlay-style.utils';
 

--- a/packages/geo/src/lib/query/shared/query.service.ts
+++ b/packages/geo/src/lib/query/shared/query.service.ts
@@ -22,7 +22,7 @@ import {
   TileArcGISRestDataSource,
   WMSDataSource,
   WMSDataSourceOptions
-} from '../../datasource';
+} from '../../datasource/shared/datasources';
 import { FEATURE } from '../../feature/shared/feature.enums';
 import {
   Feature,

--- a/packages/geo/src/lib/search/search-results/search-results-add-button.component.ts
+++ b/packages/geo/src/lib/search/search-results/search-results-add-button.component.ts
@@ -20,7 +20,8 @@ import Style from 'ol/style/Style';
 
 import { BehaviorSubject, Subscription, take } from 'rxjs';
 
-import { DataSourceService, FeatureDataSource } from '../../datasource';
+import { DataSourceService } from '../../datasource/shared/datasource.service';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import {
   Feature,
   FeatureMotion,

--- a/packages/geo/src/lib/search/search-results/search-results-item.component.ts
+++ b/packages/geo/src/lib/search/search-results/search-results-item.component.ts
@@ -15,7 +15,7 @@ import {
 import olFormatGeoJSON from 'ol/format/GeoJSON';
 
 import { FeatureMotion, moveToOlFeatures } from '../../feature';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { SearchResult } from '../shared/search.interfaces';
 
 /**

--- a/packages/geo/src/lib/search/search-results/search-results.component.ts
+++ b/packages/geo/src/lib/search/search-results/search-results.component.ts
@@ -22,7 +22,7 @@ import { ConfigService } from '@igo2/core';
 import { BehaviorSubject, EMPTY, Observable, Subscription, timer } from 'rxjs';
 import { debounce, map } from 'rxjs/operators';
 
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { Research, SearchResult } from '../shared/search.interfaces';
 import { SearchService } from '../shared/search.service';
 import { SearchSource } from '../shared/sources/source';

--- a/packages/geo/src/lib/search/shared/search.enums.ts
+++ b/packages/geo/src/lib/search/shared/search.enums.ts
@@ -1,4 +1,4 @@
-import { FEATURE } from '../../feature';
-import { LAYER } from '../../layer/shared';
+import { FEATURE } from '../../feature/shared/feature.enums';
+import { LAYER } from '../../layer/shared/layer.enums';
 
 export const SEARCH_TYPES = [FEATURE, LAYER];

--- a/packages/geo/src/lib/search/shared/search.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/search.interfaces.ts
@@ -1,8 +1,11 @@
 import { Observable } from 'rxjs';
 
 import { CommonVectorStyleOptions } from '../../style/shared/vector/vector-style.interface';
-import { ReverseSearchOptions, TextSearchOptions } from './sources';
 import { SearchSource } from './sources/source';
+import {
+  ReverseSearchOptions,
+  TextSearchOptions
+} from './sources/source.interfaces';
 
 export interface Research {
   request: Observable<SearchResult[]>;

--- a/packages/geo/src/lib/search/shared/search.service.ts
+++ b/packages/geo/src/lib/search/shared/search.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@angular/core';
 
 import { StorageService } from '@igo2/core';
 
-import { stringToLonLat } from '../../map/shared';
 import { MapService } from '../../map/shared/map.service';
+import { stringToLonLat } from '../../map/shared/map.utils';
 import { SearchSourceService } from './search-source.service';
 import { Research, ReverseSearch, TextSearch } from './search.interfaces';
 import {

--- a/packages/geo/src/lib/search/shared/sources/cadastre.ts
+++ b/packages/geo/src/lib/search/shared/sources/cadastre.ts
@@ -11,7 +11,11 @@ import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Cacheable } from 'ts-cacheable';
 
-import { FEATURE, Feature, FeatureGeometry } from '../../../feature';
+import { FEATURE } from '../../../feature/shared/feature.enums';
+import {
+  Feature,
+  FeatureGeometry
+} from '../../../feature/shared/feature.interfaces';
 import { SearchResult, TextSearch } from '../search.interfaces';
 import { computeTermSimilarity } from '../search.utils';
 import { SearchSource } from './source';

--- a/packages/geo/src/lib/search/shared/sources/coordinates.ts
+++ b/packages/geo/src/lib/search/shared/sources/coordinates.ts
@@ -10,15 +10,19 @@ import * as olproj from 'ol/proj';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { Cacheable } from 'ts-cacheable';
 
-import { FEATURE, Feature, FeatureGeometry } from '../../../feature';
+import { FEATURE } from '../../../feature/shared/feature.enums';
+import {
+  Feature,
+  FeatureGeometry
+} from '../../../feature/shared/feature.interfaces';
 import {
   convertDDToDMS,
   lonLatConversion,
   roundCoordTo
 } from '../../../map/shared/map.utils';
 import { Projection } from '../../../map/shared/projection.interfaces';
-import { OsmLinks } from '../../../utils';
 import { GoogleLinks } from '../../../utils/googleLinks';
+import { OsmLinks } from '../../../utils/osmLinks';
 import { ReverseSearch, SearchResult } from '../search.interfaces';
 import { SearchSource } from './source';
 import { ReverseSearchOptions, SearchSourceOptions } from './source.interfaces';

--- a/packages/geo/src/lib/search/shared/sources/icherche.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.interfaces.ts
@@ -1,4 +1,4 @@
-import { FeatureGeometry } from '../../../feature';
+import { FeatureGeometry } from '../../../feature/shared/feature.interfaces';
 
 export interface IChercheData {
   index: string;

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -14,7 +14,8 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Cacheable } from 'ts-cacheable';
 
-import { FEATURE, Feature } from '../../../feature';
+import { FEATURE } from '../../../feature/shared/feature.enums';
+import { Feature } from '../../../feature/shared/feature.interfaces';
 import { ReverseSearch, SearchResult, TextSearch } from '../search.interfaces';
 import { computeTermSimilarity } from '../search.utils';
 import { GoogleLinks } from './../../../utils/googleLinks';

--- a/packages/geo/src/lib/search/shared/sources/ilayer.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.ts
@@ -8,12 +8,15 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Cacheable } from 'ts-cacheable';
 
-import { LAYER } from '../../../layer';
+import { LAYER } from '../../../layer/shared/layer.enums';
 import { getResolutionFromScale } from '../../../map/shared/map.utils';
-import { QueryFormat, QueryableDataSourceOptions } from '../../../query';
+import { QueryableDataSourceOptions } from '../../../query/shared/query.interfaces';
 import { SearchResult, TextSearch } from '../search.interfaces';
 import { computeTermSimilarity } from '../search.utils';
-import { QueryHtmlTarget } from './../../../query/shared/query.enums';
+import {
+  QueryFormat,
+  QueryHtmlTarget
+} from './../../../query/shared/query.enums';
 import {
   ILayerData,
   ILayerDataSource,

--- a/packages/geo/src/lib/search/shared/sources/nominatim.ts
+++ b/packages/geo/src/lib/search/shared/sources/nominatim.ts
@@ -8,7 +8,11 @@ import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Cacheable } from 'ts-cacheable';
 
-import { FEATURE, Feature, FeatureGeometry } from '../../../feature';
+import { FEATURE } from '../../../feature/shared/feature.enums';
+import {
+  Feature,
+  FeatureGeometry
+} from '../../../feature/shared/feature.interfaces';
 import { SearchResult, TextSearch } from '../search.interfaces';
 import { computeTermSimilarity } from '../search.utils';
 import { NominatimData } from './nominatim.interfaces';

--- a/packages/geo/src/lib/search/shared/sources/source.ts
+++ b/packages/geo/src/lib/search/shared/sources/source.ts
@@ -2,7 +2,7 @@ import { Workspace } from '@igo2/common';
 import { StorageService } from '@igo2/core';
 import { ObjectUtils } from '@igo2/utils';
 
-import { FeatureStore } from '../../../feature';
+import { FeatureStore } from '../../../feature/shared/store';
 import {
   ISearchSourceParams,
   SearchSourceOptions,

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.interfaces.ts
@@ -1,4 +1,4 @@
-import { FeatureGeometry } from '../../../feature';
+import { FeatureGeometry } from '../../../feature/shared/feature.interfaces';
 import { SearchSourceOptions } from './source.interfaces';
 
 export interface StoredQueriesSearchSourceOptions extends SearchSourceOptions {

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -10,7 +10,8 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Cacheable } from 'ts-cacheable';
 
-import { FEATURE, Feature } from '../../../feature';
+import { FEATURE } from '../../../feature/shared/feature.enums';
+import { Feature } from '../../../feature/shared/feature.interfaces';
 import { ReverseSearch, SearchResult, TextSearch } from '../search.interfaces';
 import { computeTermSimilarity } from '../search.utils';
 import { SearchSource } from './source';

--- a/packages/geo/src/lib/search/shared/sources/workspace.ts
+++ b/packages/geo/src/lib/search/shared/sources/workspace.ts
@@ -6,7 +6,8 @@ import pointOnFeature from '@turf/point-on-feature';
 import { SimpleDocumentSearchResultSetUnit } from 'flexsearch';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 
-import { FEATURE, Feature } from '../../../feature';
+import { FEATURE } from '../../../feature/shared/feature.enums';
+import { Feature } from '../../../feature/shared/feature.interfaces';
 import { Layer } from '../../../layer/shared/layers/layer';
 import { GoogleLinks } from '../../../utils/googleLinks';
 import { SearchResult, TextSearch } from '../search.interfaces';

--- a/packages/geo/src/lib/utils/id-generator.ts
+++ b/packages/geo/src/lib/utils/id-generator.ts
@@ -2,7 +2,7 @@ import { uuid } from '@igo2/utils';
 
 import { Md5 } from 'ts-md5';
 
-import { WFSDataSourceOptions } from '../datasource';
+import { WFSDataSourceOptions } from '../datasource/shared/datasources';
 import { AnyDataSourceOptions } from '../datasource/shared/datasources/any-datasource.interface';
 import { DataSourceOptions } from '../datasource/shared/datasources/datasource.interface';
 import { WMSDataSourceOptions } from '../datasource/shared/datasources/wms-datasource.interface';

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -30,7 +30,7 @@ import {
   RelationOptions,
   SourceFieldsOptionsParams,
   WMSDataSource
-} from '../../datasource';
+} from '../../datasource/shared/datasources';
 import { FeatureDataSource } from '../../datasource/shared/datasources/feature-datasource';
 import { WFSDataSourceOptions } from '../../datasource/shared/datasources/wfs-datasource.interface';
 import {
@@ -41,16 +41,16 @@ import {
   FeatureStoreInMapResolutionStrategy,
   FeatureStoreLoadingLayerStrategy,
   FeatureStoreSelectionStrategy
-} from '../../feature';
+} from '../../feature/shared';
 import { OgcFilterableDataSourceOptions } from '../../filter/shared/ogc-filter.interface';
 import {
+  GeoWorkspaceOptions,
   ImageLayer,
   LayerService,
   LayersLinkProperties,
   LinkedProperties,
   VectorLayer
 } from '../../layer/shared';
-import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
 import { IgoMap, MapBase } from '../../map/shared';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { StyleService } from '../../style/style-service/style.service';

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.ts
@@ -15,11 +15,11 @@ import * as OlStyle from 'ol/style';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 
 import { FeatureDataSource, RelationOptions } from '../../datasource/shared';
-import { GeometryType, createInteractionStyle } from '../../draw';
-import { featureToOl } from '../../feature';
-import { DrawControl } from '../../geometry';
+import { GeometryType, createInteractionStyle } from '../../draw/shared';
+import { featureToOl } from '../../feature/shared';
+import { DrawControl } from '../../geometry/shared';
 import { ImageLayer, VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { ConfirmationPopupComponent } from '../confirmation-popup/confirmation-popup.component';
 
 export interface EditionWorkspaceOptions extends WorkspaceOptions {

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.service.ts
@@ -5,7 +5,8 @@ import { ConfigService, StorageService } from '@igo2/core';
 
 import { BehaviorSubject } from 'rxjs';
 
-import { CapabilitiesService, FeatureDataSource } from '../../datasource';
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import {
   FeatureMotion,
   FeatureStore,
@@ -15,15 +16,15 @@ import {
   FeatureStoreSearchIndexStrategy,
   FeatureStoreSelectionStrategy,
   GeoPropertiesStrategy
-} from '../../feature';
+} from '../../feature/shared';
 import { LayerService, VectorLayer } from '../../layer/shared';
 import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   FeatureCommonVectorStyleOptions,
-  OverlayStyleOptions
-} from '../../style';
-import { getCommonVectorSelectedStyle } from '../../style/shared/vector/commonVectorStyle';
+  OverlayStyleOptions,
+  getCommonVectorSelectedStyle
+} from '../../style/shared';
 import { PropertyTypeDetectorService } from '../../utils/propertyTypeDetector/propertyTypeDetector.service';
 import { FeatureWorkspace } from './feature-workspace';
 import {

--- a/packages/geo/src/lib/workspace/shared/feature-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/feature-workspace.ts
@@ -3,7 +3,7 @@ import { Workspace, WorkspaceOptions } from '@igo2/common';
 import { BehaviorSubject } from 'rxjs';
 
 import { VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 
 export interface FeatureWorkspaceOptions extends WorkspaceOptions {
   layer: VectorLayer;

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.service.ts
@@ -5,7 +5,8 @@ import { ConfigService, StorageService } from '@igo2/core';
 
 import { BehaviorSubject } from 'rxjs';
 
-import { CapabilitiesService, FeatureDataSource } from '../../datasource';
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
+import { FeatureDataSource } from '../../datasource/shared/datasources';
 import {
   FeatureMotion,
   FeatureStore,
@@ -14,15 +15,18 @@ import {
   FeatureStoreLoadingLayerStrategy,
   FeatureStoreSelectionStrategy,
   GeoPropertiesStrategy
-} from '../../feature';
-import { LayerService, VectorLayer } from '../../layer/shared';
-import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
-import { IgoMap } from '../../map/shared';
+} from '../../feature/shared';
+import {
+  GeoWorkspaceOptions,
+  LayerService,
+  VectorLayer
+} from '../../layer/shared';
+import { IgoMap } from '../../map/shared/map';
 import {
   FeatureCommonVectorStyleOptions,
-  OverlayStyleOptions
-} from '../../style';
-import { getCommonVectorSelectedStyle } from '../../style/shared/vector/commonVectorStyle';
+  OverlayStyleOptions,
+  getCommonVectorSelectedStyle
+} from '../../style/shared';
 import { PropertyTypeDetectorService } from '../../utils/propertyTypeDetector';
 import { WfsWorkspace } from './wfs-workspace';
 import {

--- a/packages/geo/src/lib/workspace/shared/wfs-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/wfs-workspace.ts
@@ -3,7 +3,7 @@ import { Workspace, WorkspaceOptions } from '@igo2/common';
 import { BehaviorSubject } from 'rxjs';
 
 import { VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 
 export interface WfsWorkspaceOptions extends WorkspaceOptions {
   layer: VectorLayer;

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -5,7 +5,8 @@ import { ConfigService, StorageService } from '@igo2/core';
 
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 
-import { CapabilitiesService, WMSDataSource } from '../../datasource';
+import { CapabilitiesService } from '../../datasource/shared/capabilities.service';
+import { WMSDataSource } from '../../datasource/shared/datasources';
 import { FeatureDataSource } from '../../datasource/shared/datasources/feature-datasource';
 import { WFSDataSourceOptions } from '../../datasource/shared/datasources/wfs-datasource.interface';
 import {
@@ -16,17 +17,17 @@ import {
   FeatureStoreLoadingLayerStrategy,
   FeatureStoreSelectionStrategy,
   GeoPropertiesStrategy
-} from '../../feature';
+} from '../../feature/shared';
 import { OgcFilterableDataSourceOptions } from '../../filter/shared/ogc-filter.interface';
 import {
+  GeoWorkspaceOptions,
   ImageLayer,
   LayerService,
   LayersLinkProperties,
   LinkedProperties,
   VectorLayer
 } from '../../layer/shared';
-import { GeoWorkspaceOptions } from '../../layer/shared/layers/layer.interface';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { getCommonVectorSelectedStyle } from '../../style/shared/vector/commonVectorStyle';
 import {

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.ts
@@ -1,7 +1,7 @@
 import { Workspace, WorkspaceOptions } from '@igo2/common';
 
 import { ImageLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 
 export interface WmsWorkspaceOptions extends WorkspaceOptions {
   layer: ImageLayer;

--- a/packages/geo/src/lib/workspace/shared/workspace.utils.ts
+++ b/packages/geo/src/lib/workspace/shared/workspace.utils.ts
@@ -22,7 +22,7 @@ import {
   SourceFieldsOptionsParams
 } from '../../datasource/shared/datasources/datasource.interface';
 import { Feature } from '../../feature/shared/feature.interfaces';
-import { LayerService, VectorLayer } from '../../layer';
+import { LayerService, VectorLayer } from '../../layer/shared';
 import { IgoMap } from '../../map/shared/map';
 import { generateIdFromSourceOptions } from '../../utils/id-generator';
 import { FeatureWorkspace } from './feature-workspace';

--- a/packages/geo/src/lib/workspace/workspace-selector/workspace-selector.directive.ts
+++ b/packages/geo/src/lib/workspace/workspace-selector/workspace-selector.directive.ts
@@ -20,11 +20,11 @@ import {
   FeatureDataSource,
   WFSDataSource,
   WMSDataSource
-} from '../../datasource';
+} from '../../datasource/shared/datasources';
 import { FeatureStoreInMapExtentStrategy } from '../../feature/shared/strategies/in-map-extent';
 import { OgcFilterableDataSourceOptions } from '../../filter/shared';
 import { ImageLayer, Layer, VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { EditionWorkspaceService } from '../shared/edition-workspace.service';
 import { FeatureWorkspaceService } from '../shared/feature-workspace.service';

--- a/packages/geo/src/lib/workspace/workspace-updator/workspace-updator.directive.ts
+++ b/packages/geo/src/lib/workspace/workspace-updator/workspace-updator.directive.ts
@@ -10,11 +10,11 @@ import {
   FeatureDataSource,
   WFSDataSource,
   WMSDataSource
-} from '../../datasource';
+} from '../../datasource/shared/datasources';
 import { FeatureStoreInMapExtentStrategy } from '../../feature/shared/strategies/in-map-extent';
 import { OgcFilterableDataSourceOptions } from '../../filter/shared';
 import { ImageLayer, Layer, VectorLayer } from '../../layer/shared';
-import { IgoMap } from '../../map/shared';
+import { IgoMap } from '../../map/shared/map';
 import { QueryableDataSourceOptions } from '../../query/shared/query.interfaces';
 import { EditionWorkspaceService } from '../shared/edition-workspace.service';
 import { FeatureWorkspaceService } from '../shared/feature-workspace.service';

--- a/packages/geo/tsconfig.lib.json
+++ b/packages/geo/tsconfig.lib.json
@@ -12,6 +12,6 @@
   },
   "exclude": ["src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
-    "compilationMode": "full"
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
- Fix barrel import to remove circular dependencies. These circular dependencies were silent, no errors, except that component declarations were not exported in the build for many components in these categories (Catalog/Filter/Layer/Map/Measure)
