### PR TITLE
fix(common): prevent form submit on password hide/show and auto hide password after 10sec of inactivity

### DIFF
--- a/packages/common/src/lib/form/form-field/form-field-text.component.html
+++ b/packages/common/src/lib/form/form-field/form-field-text.component.html
@@ -1,11 +1,12 @@
 <mat-form-field>
   <input
     matInput
-    (blur)="hide = true"
+    (blur)="delayedHide(0)"
     [type]="isPassword ? (hide ? 'password' : 'text') : 'text'"
     [required]="isPassword ? 'true' : required"
     [placeholder]="placeholder"
     [formControl]="formControl"
+    (change)="delayedHide()"
   />
   <mat-icon
     *ngIf="disableSwitch === true"
@@ -21,6 +22,7 @@
   </mat-icon>
 
   <button
+    type="button"
     *ngIf="isPassword"
     matSuffix
     mat-icon-button

--- a/packages/common/src/lib/form/form-field/form-field-text.component.ts
+++ b/packages/common/src/lib/form/form-field/form-field-text.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   Input,
   OnInit
@@ -26,6 +27,8 @@ import {
 export class FormFieldTextComponent implements OnInit {
   disabled$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   hide: boolean = true;
+  private lastTimeoutRequest: NodeJS.Timeout;
+
   /**
    * The field's form control
    */
@@ -58,6 +61,8 @@ export class FormFieldTextComponent implements OnInit {
     return formControlIsRequired(this.formControl);
   }
 
+  constructor(private cdRef: ChangeDetectorRef) {}
+
   ngOnInit() {
     this.disabled$.next(this.formControl.disabled);
   }
@@ -85,5 +90,17 @@ export class FormFieldTextComponent implements OnInit {
 
   togglePassword() {
     this.hide = !this.hide;
+    this.delayedHide();
+  }
+  delayedHide(delayMS: number = 10000) {
+    if (this.isPassword && !this.hide) {
+      if (this.lastTimeoutRequest) {
+        clearTimeout(this.lastTimeoutRequest);
+      }
+      this.lastTimeoutRequest = setTimeout(() => {
+        this.hide = true;
+        this.cdRef.detectChanges();
+      }, delayMS);
+    }
   }
 }

--- a/packages/common/src/lib/form/form-field/form-field-text.component.ts
+++ b/packages/common/src/lib/form/form-field/form-field-text.component.ts
@@ -27,7 +27,7 @@ import {
 export class FormFieldTextComponent implements OnInit {
   disabled$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   hide: boolean = true;
-  private lastTimeoutRequest: NodeJS.Timeout;
+  private lastTimeoutRequest;
 
   /**
    * The field's form control


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When clicking on password type form field, the form was submitted. 


**What is the new behavior?**
Prevent it. 
+
Autohide password based on a 10sec timeout.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
