### PR TITLE
feat(linked-layers): Added new config for visibility in Base Layer Switcher

### DIFF
--- a/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
@@ -63,7 +63,8 @@ export interface GeoWorkspaceQueryOptions {
 
 export interface LayersLink {
   linkId: string;
-  showInMiniBaseMap?: boolean; // default value is true
+  /** Default value is true */
+  showInMiniBaseMap?: boolean;
   links?: LayersLinkProperties[];
 }
 export interface LayersLinkProperties {

--- a/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
@@ -63,7 +63,7 @@ export interface GeoWorkspaceQueryOptions {
 
 export interface LayersLink {
   linkId: string;
-  showInMiniBaseMap?: boolean;
+  showInMiniBaseMap?: boolean; // default value is true
   links?: LayersLinkProperties[];
 }
 export interface LayersLinkProperties {

--- a/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.interface.ts
@@ -63,6 +63,7 @@ export interface GeoWorkspaceQueryOptions {
 
 export interface LayersLink {
   linkId: string;
+  showInMiniBaseMap?: boolean;
   links?: LayersLinkProperties[];
 }
 export interface LayersLinkProperties {

--- a/packages/geo/src/lib/map/baselayers-switcher/mini-basemap.component.ts
+++ b/packages/geo/src/lib/map/baselayers-switcher/mini-basemap.component.ts
@@ -10,7 +10,12 @@ import {
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 
-import { Layer, LayerOptions, LayersLink, LayersLinkProperties } from '../../layer/shared';
+import {
+  Layer,
+  LayerOptions,
+  LayersLink,
+  LayersLinkProperties
+} from '../../layer/shared';
 import { LayerService } from '../../layer/shared/layer.service';
 import { IgoMap } from '../shared/map';
 
@@ -132,9 +137,8 @@ export class MiniBaseMapComponent implements AfterViewInit, OnDestroy {
               layerToApply.options,
               {
                 zIndex: 9000,
-                visible: layerToApply.options.linkedLayers?.showInMiniBaseMap !== undefined
-                ? layerToApply.options.linkedLayers.showInMiniBaseMap
-                : true,
+                visible:
+                  layerToApply.options.linkedLayers?.showInMiniBaseMap ?? true,
                 baseLayer: false
               } as LayerOptions
             );

--- a/packages/geo/src/lib/map/baselayers-switcher/mini-basemap.component.ts
+++ b/packages/geo/src/lib/map/baselayers-switcher/mini-basemap.component.ts
@@ -10,7 +10,7 @@ import {
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 
-import { Layer, LayerOptions } from '../../layer/shared';
+import { Layer, LayerOptions, LayersLink, LayersLinkProperties } from '../../layer/shared';
 import { LayerService } from '../../layer/shared/layer.service';
 import { IgoMap } from '../shared/map';
 
@@ -112,31 +112,29 @@ export class MiniBaseMapComponent implements AfterViewInit, OnDestroy {
     this.handleLinkedBaseLayer(layer);
   }
 
-  private handleLinkedBaseLayer(baselayer: Layer) {
-    const linkedLayers = baselayer.options.linkedLayers;
+  private handleLinkedBaseLayer(baselayer: Layer): void {
+    const linkedLayers: LayersLink = baselayer.options.linkedLayers;
     if (!linkedLayers) {
       return;
     }
-    const currentLinkedId = linkedLayers.linkId;
-    const currentLinks = linkedLayers.links;
-    const isParentLayer = currentLinks ? true : false;
-    if (
-      isParentLayer &&
-      currentLinkedId === baselayer.options.linkedLayers.linkId
-    ) {
+    const links: LayersLinkProperties[] = linkedLayers.links;
+    const isParentLayer: boolean = links ? true : false;
+    if (isParentLayer) {
       // search for child layers
-      currentLinks.map((link) => {
-        link.linkedIds.map((linkedId) => {
-          const layerToApply = this.map.layers.find(
-            (l) => l.options.linkedLayers?.linkId === linkedId
+      links.map((link: LayersLinkProperties) => {
+        link.linkedIds.map((linkedId: string) => {
+          const layerToApply: Layer = this.map.layers.find(
+            (layer: Layer) => layer.options.linkedLayers?.linkId === linkedId
           );
           if (layerToApply) {
-            const linkedLayerOptions: any = Object.assign(
+            const linkedLayerOptions: LayerOptions = Object.assign(
               Object.create(layerToApply.options),
               layerToApply.options,
               {
                 zIndex: 9000,
-                visible: true,
+                visible: layerToApply.options.linkedLayers?.showInMiniBaseMap !== undefined
+                ? layerToApply.options.linkedLayers.showInMiniBaseMap
+                : true,
                 baseLayer: false
               } as LayerOptions
             );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When a base layer shown in the mini-basemap/preview has linked layers, the linked layers are always shown/visible in the preview. This can lead to performance issues.


**What is the new behavior?**
The new config, showInMiniBaseMap, allows the user to decide if a linked layer should be visible in the preview of a base layer or not.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
