### PR TITLE
fix(geo): initial rotation is not supplied to viewcontroller

### DIFF
--- a/packages/geo/src/lib/map/shared/map.ts
+++ b/packages/geo/src/lib/map/shared/map.ts
@@ -225,6 +225,9 @@ export class IgoMap implements MapBase {
         options.projection
       );
     }
+    if (viewOptions?.rotation) {
+      this.viewController.rotation$.next(viewOptions.rotation);
+    }
 
     this.ol.setView(new olView(viewOptions));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The rotation button is disabled despite the effective rotation. 
![image](https://github.com/infra-geo-ouverte/igo2-lib/assets/7397743/5cfeb364-66e7-4039-8a1d-411d9417959e)




**What is the new behavior?**
Set the rotation on view definition.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
