### PR TITLE
fix: sass exports for themes and utils

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -29,7 +29,7 @@
     "./style": {
       "style": "./style/style.css"
     },
-    "./theming": {
+    "./theme": {
       "sass": "./src/common-theme.scss"
     },
     "./partial/*": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -25,7 +25,7 @@
     ".": {
       "import": "./src/public_api.ts"
     },
-    "./theming": {
+    "./theme": {
       "sass": "./src/context-theme.scss"
     }
   },

--- a/packages/core/ng-package.json
+++ b/packages/core/ng-package.json
@@ -10,8 +10,7 @@
     {
       "input": "src",
       "glob": "*.scss",
-      "output": "src",
-      "ignore": ["*.import.scss"]
+      "output": "src"
     },
     { "input": "src", "glob": "**/*.them*.scss", "output": "src" },
     { "input": "src/style", "glob": "**/*.scss", "output": "src/style" },

--- a/packages/core/ng-package.prod.json
+++ b/packages/core/ng-package.prod.json
@@ -9,8 +9,7 @@
     {
       "input": "src",
       "glob": "*.scss",
-      "output": "src",
-      "ignore": ["*.import.scss"]
+      "output": "src"
     },
     { "input": "src", "glob": "**/*.them*.scss", "output": "src" },
     { "input": "src/style", "glob": "**/*.scss", "output": "src/style" },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": {
       "import": "./src/public_api.ts",
-      "sass": "./index.scss"
+      "sass": "./src/index.scss"
     },
     "./style": {
       "style": "./style/style.css"
@@ -38,8 +38,11 @@
     "./partial/*": {
       "sass": "./src/style/partial/*.scss"
     },
-    "./theming": {
+    "./theme": {
       "sass": "./src/core-theme.scss"
+    },
+    "./theming/*": {
+      "sass": "./src/theming/*.scss"
     },
     "./prebuilt-themes/*": {
       "style": "./theming/prebuilt-themes/*.css"

--- a/packages/core/src/packages-prod.import.scss
+++ b/packages/core/src/packages-prod.import.scss
@@ -1,4 +1,0 @@
-@forward './core-theme' show core-component-themes;
-@forward '../common/common-theme' show common-component-themes;
-@forward '../context/context-theme' show context-component-themes;
-@forward '../geo/geo-theme' show geo-component-themes;

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -30,7 +30,7 @@
     "./style": {
       "sass": "./style/style.scss"
     },
-    "./theming": {
+    "./theme": {
       "sass": "./src/geo-theme.scss"
     }
   },

--- a/scripts/src/core/postbuild-core.ts
+++ b/scripts/src/core/postbuild-core.ts
@@ -4,7 +4,6 @@ import { performance } from 'perf_hooks';
 
 import { PackageName } from '../config/packages';
 import { resolveDist, resolvePackage } from '../config/paths';
-import { copyFile, pathExist } from '../utils/file-system.utils';
 import * as log from '../utils/log';
 import { getDuration } from '../utils/performance.utils';
 import { compileStyle } from '../utils/style.utils';
@@ -22,8 +21,6 @@ const baseCmdName = `Postbuild @igo2/${packageName}`;
   const startTime = performance.now();
   log.startMsg(baseCmdName);
 
-  await copyProdImportationFile();
-
   await prebuiltThemes();
 
   await compileBaseStyle();
@@ -38,29 +35,6 @@ const baseCmdName = `Postbuild @igo2/${packageName}`;
   const duration = getDuration(startTime);
   log.info(`${baseCmdName} excuted in ${duration}`);
 })();
-
-/**
- * We got two files for packages style importation. One for local development and one for production.
- * We need to provide the good file for production.
- */
-async function copyProdImportationFile(): Promise<void> {
-  const startTime = performance.now();
-
-  const importationFile = join(distPath, 'packages.import.scss');
-  const prodImport = join(srcPath, 'packages-prod.import.scss');
-
-  if (pathExist(importationFile)) {
-    return;
-  }
-
-  // Replace the theme-import file by theme-import.prod
-  await copyFile(prodImport, importationFile);
-
-  const duration = getDuration(startTime);
-  log.success(
-    `✔ Provide packages style importation for production in ${duration}`
-  );
-}
 
 async function compileBaseStyle(): Promise<void> {
   const startTime = performance.now();


### PR DESCRIPTION
Ajustement de path pour respecter la règle que tous les SASS devrait se retrouver dans le dossier `src` en mode distribution. Ce qui nous permet de rouler en local (symlink) comme en prod (distribution).

Breaking changes pour la nomenclature de l'export `theming` qui devient `theme`. Pour éviter les collisions lors de la résolutions de paths. Je passe le BREAKING CHANGES incognito vu qu'on doit être les seuls a utiliser les thèmes via les fichiers SASS.