### PR TITLE
feat(geo): add a sub level to arcgisrest  catalogs

### DIFF
--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -6,7 +6,6 @@ import { ObjectUtils, uuid } from '@igo2/utils';
 
 import { EMPTY, Observable, of, zip } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Md5 } from 'ts-md5';
 
 import {
   ArcGISRestCapabilitiesLayer,
@@ -839,7 +838,6 @@ export class CatalogService {
             ? propertiesToForce.title
             : layer.name,
           externalProvider: catalog.externalProvider,
-          address: catalog.id,
           options: {
             sourceOptions,
             minResolution: getResolutionFromScale(layer.maxScale),
@@ -857,11 +855,10 @@ export class CatalogService {
 
     const groupedItems: CatalogItemLayer[] = groups
       .map((group) => {
-        const md5 = Md5.hashStr(group.name);
         return {
           options: undefined,
-          address: `catalog.group.${md5}`,
-          id: `catalog.group.${md5}`,
+          address: `catalog.group.${group.name}`,
+          id: `catalog.group.${group.name}`,
           type: CatalogItemType.Group,
           externalProvider: catalog.externalProvider,
           sortDirection: catalog.sortDirection,

--- a/packages/geo/src/lib/datasource/shared/capabilities.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.interface.ts
@@ -7,3 +7,21 @@ export enum TypeCapabilities {
 }
 
 export type TypeCapabilitiesStrings = keyof typeof TypeCapabilities;
+
+export interface ArcGISRestCapabilitiesLayer {
+  id: number;
+  name: string;
+  parentLayerId: number;
+  defaultVisibility?: boolean;
+  subLayerIds: number[];
+  minScale: number;
+  maxScale: number;
+  type: ArcGISRestCapabilitiesLayerTypes;
+  geometryType?: string;
+}
+
+export enum ArcGISRestCapabilitiesLayerTypes {
+  FeatureLayer = 'Feature Layer',
+  RasterLayer = 'Raster Layer',
+  GroupLayer = 'Group Layer'
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Arcgisrest catalog are a simple list of layers.



**What is the new behavior?**
Add a group layer logic to show groups and nested layers within.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
