### PR TITLE
fix(geo): garantine no comma in the beginning and end of search term

### DIFF
--- a/packages/geo/src/lib/search/shared/sources/cadastre.ts
+++ b/packages/geo/src/lib/search/shared/sources/cadastre.ts
@@ -65,9 +65,10 @@ export class CadastreSearchSource extends SearchSource implements TextSearch {
     term: string | undefined,
     options?: TextSearchOptions
   ): Observable<SearchResult<Feature>[]> {
+    term = term.replace(/ /g, '');
+    term = term.replace(/,+/g, ',');
     term = term.endsWith(',') ? term.slice(0, -1) : term;
     term = term.startsWith(',') ? term.substr(1) : term;
-    term = term.replace(/ /g, '');
 
     const params = this.computeSearchRequestParams(term, options || {});
     if (!params.get('numero') || !params.get('numero').match(/^[0-9,]+$/g)) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

this behavior related to #1597 

**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
