### PR TITLE
feat(directions): added possibility to toggle between two routing sources

### DIFF
--- a/packages/geo/src/lib/directions/directions-sources/directions-source.interface.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.interface.ts
@@ -6,11 +6,9 @@ export interface DirectionsSourceOptions extends BaseDirectionsSourceOptions {
 export type OsrmDirectionsSourceOptions = BaseDirectionsSourceOptions;
 
 interface BaseDirectionsSourceOptions {
-  distance?: number;
   enabled?: boolean;
-  limit?: number;
-  logo?: string;
-  reverseUrl?: string;
-  type?: string;
+  name?: string;
+  type?: 'public' | 'private';
   url?: string;
+  userVerifUrl?: string;
 }

--- a/packages/geo/src/lib/directions/directions-sources/directions-source.provider.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.provider.ts
@@ -3,19 +3,36 @@ import { HttpClient } from '@angular/common/http';
 import { ConfigService } from '@igo2/core';
 
 import { DirectionsSource } from './directions-source';
-import { OsrmDirectionsSource } from './osrm-directions-source';
+import { OsrmPrivateDirectionsSource } from './osrm-private-directions-source';
+import { OsrmPublicDirectionsSource } from './osrm-public-directions-source';
 
-export function osrmDirectionsSourcesFactory(
+export function osrmPublicDirectionsSourcesFactory(
   http: HttpClient,
   config: ConfigService
 ) {
-  return new OsrmDirectionsSource(http, config);
+  return new OsrmPublicDirectionsSource(http, config);
 }
 
-export function provideOsrmDirectionsSource() {
+export function providePublicOsrmDirectionsSource() {
   return {
     provide: DirectionsSource,
-    useFactory: osrmDirectionsSourcesFactory,
+    useFactory: osrmPublicDirectionsSourcesFactory,
+    multi: true,
+    deps: [HttpClient, ConfigService]
+  };
+}
+
+export function osrmPrivateDirectionsSourcesFactory(
+  http: HttpClient,
+  config: ConfigService
+) {
+  return new OsrmPrivateDirectionsSource(http, config);
+}
+
+export function providePrivateOsrmDirectionsSource() {
+  return {
+    provide: DirectionsSource,
+    useFactory: osrmPrivateDirectionsSourcesFactory,
     multi: true,
     deps: [HttpClient, ConfigService]
   };

--- a/packages/geo/src/lib/directions/directions-sources/directions-source.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.ts
@@ -4,6 +4,8 @@ import { Direction, DirectionOptions } from '../shared/directions.interface';
 
 export abstract class DirectionsSource {
   abstract enabled: boolean;
+  abstract type: string;
+  abstract userVerifUrl: string;
   abstract getName(): string;
   abstract route(
     coordinates: [number, number][],

--- a/packages/geo/src/lib/directions/directions-sources/index.ts
+++ b/packages/geo/src/lib/directions/directions-sources/index.ts
@@ -1,4 +1,5 @@
 export * from './directions-source';
 export * from './directions-source.interface';
-export * from './osrm-directions-source';
+export * from './osrm-public-directions-source';
+export * from './osrm-private-directions-source';
 export * from './directions-source.provider';

--- a/packages/geo/src/lib/directions/directions-sources/osrm-private-directions-source.ts
+++ b/packages/geo/src/lib/directions/directions-sources/osrm-private-directions-source.ts
@@ -14,36 +14,81 @@ import {
 } from '../shared/directions.enum';
 import { Direction, DirectionOptions } from '../shared/directions.interface';
 import { DirectionsSource } from './directions-source';
-import { OsrmDirectionsSourceOptions } from './directions-source.interface';
+import { DirectionsSourceOptions, OsrmDirectionsSourceOptions } from './directions-source.interface';
+import { Position } from 'geojson';
 
 @Injectable()
-export class OsrmDirectionsSource extends DirectionsSource {
+export class OsrmPrivateDirectionsSource extends DirectionsSource {
+  get options(): OsrmDirectionsSourceOptions {
+    return this._options;
+  }
+
+  set options(value: OsrmDirectionsSourceOptions) {
+    this._options = value;
+  }
+
   get enabled(): boolean {
-    return this.options.enabled !== false;
+    return this._options.enabled;
   }
+
   set enabled(value: boolean) {
-    this.options.enabled = value;
+    this._options.enabled = value;
   }
-  static _name = 'OSRM Québec';
-  private directionsUrl =
-    'https://geoegl.msp.gouv.qc.ca/services/itineraire/route/v1/driving/';
-  private options: OsrmDirectionsSourceOptions;
+
+  get name(): string {
+    return this._options.name;
+  }
+
+  set name(value: string) {
+    this._options.name = value;
+  }
+
+  get url(): string {
+    return this._options.url;
+  }
+
+  set url(value: string) {
+    this._options.url = value;
+  }
+
+  get userVerifUrl(): string {
+    return this._options.userVerifUrl;
+  }
+
+  set userVerifUrl(value: string) {
+    this._options.userVerifUrl = value;
+  }
+
+  get type(): 'public' | 'private' {
+    return this._options.type;
+  }
+
+  set type(value: 'public' | 'private') {
+    this._options.type = value;
+  }
+
+  private _options: OsrmDirectionsSourceOptions;
 
   constructor(
-    private http: HttpClient,
-    private config: ConfigService
+    private _http: HttpClient,
+    private _config: ConfigService
   ) {
     super();
-    this.options = this.config.getConfig('directionsSources.osrm') || {};
-    this.directionsUrl = this.options.url || this.directionsUrl;
+    const directionsSources: DirectionsSourceOptions[] = this._config.getConfig('directionsSources');
+    this.options = directionsSources?.find(dS => dS.osrm.type === 'private')?.osrm || {};
+    this.name = this.name ? this.name : undefined;
+    this.url = this.url ? this.url : undefined;
+    this.userVerifUrl = this.userVerifUrl ? this.userVerifUrl : undefined;
+    this.type = this.type ? this.type : undefined;
+    this.enabled = false;
   }
 
   getName(): string {
-    return OsrmDirectionsSource._name;
+    return this.name;
   }
 
   route(
-    coordinates: [number, number][],
+    coordinates: Position[],
     directionsOptions: DirectionOptions = {}
   ): Observable<Direction[]> {
     const directionsParams = this.getRouteParams(directionsOptions);
@@ -55,11 +100,11 @@ export class OsrmDirectionsSource extends DirectionsSource {
     cacheHasher: customCacheHasher
   })
   private getRoute(
-    coordinates: [number, number][],
+    coordinates: Position[],
     params: HttpParams
   ): Observable<Direction[]> {
-    return this.http
-      .get<JSON[]>(this.directionsUrl + coordinates.join(';'), {
+    return this._http
+      .get<JSON[]>(this.url + coordinates.join(';'), {
         params
       })
       .pipe(map((res) => this.extractRoutesData(res)));
@@ -118,7 +163,7 @@ export class OsrmDirectionsSource extends DirectionsSource {
     return {
       id: uuid(),
       title: roadNetworkRoute.legs[0].summary,
-      source: OsrmDirectionsSource._name,
+      source: this.name,
       sourceType: SourceDirectionsType.Route,
       order: 1,
       format: DirectionsFormat.GeoJSON,

--- a/packages/geo/src/lib/directions/directions-sources/osrm-public-directions-source.ts
+++ b/packages/geo/src/lib/directions/directions-sources/osrm-public-directions-source.ts
@@ -1,0 +1,182 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { ConfigService } from '@igo2/core';
+import { customCacheHasher, uuid } from '@igo2/utils';
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Cacheable } from 'ts-cacheable';
+
+import {
+  DirectionsFormat,
+  SourceDirectionsType
+} from '../shared/directions.enum';
+import { Direction, DirectionOptions } from '../shared/directions.interface';
+import { DirectionsSource } from './directions-source';
+import { DirectionsSourceOptions, OsrmDirectionsSourceOptions } from './directions-source.interface';
+import { Position } from 'geojson';
+
+@Injectable()
+export class OsrmPublicDirectionsSource extends DirectionsSource {
+  get options(): OsrmDirectionsSourceOptions {
+    return this._options;
+  }
+
+  set options(value: OsrmDirectionsSourceOptions) {
+    this._options = value;
+  }
+
+  get enabled(): boolean {
+    return this._options.enabled;
+  }
+
+  set enabled(value: boolean) {
+    this._options.enabled = value;
+  }
+
+  get name(): string {
+    return this._options.name;
+  }
+
+  set name(value: string) {
+    this._options.name = value;
+  }
+
+  get url(): string {
+    return this._options.url;
+  }
+
+  set url(value: string) {
+    this._options.url = value;
+  }
+
+  get userVerifUrl(): string {
+    return this._options.userVerifUrl;
+  }
+
+  set userVerifUrl(value: string) {
+    this._options.userVerifUrl = value;
+  }
+
+  get type(): 'public' | 'private' {
+    return this._options.type;
+  }
+
+  set type(value: 'public' | 'private') {
+    this._options.type = value;
+  }
+
+  private _options: OsrmDirectionsSourceOptions;
+
+  constructor(
+    private _http: HttpClient,
+    private _config: ConfigService
+  ) {
+    super();
+    const directionsSources: DirectionsSourceOptions[] = this._config.getConfig('directionsSources');
+    this.options = directionsSources?.find(dS => dS.osrm.type === 'public')?.osrm || {};
+    this.name = this.name ? this.name : 'OSRM Québec (Public)';
+    this.url = this.url ? this.url : '/apis/itineraire/route/v1/driving/';
+    this.userVerifUrl = undefined;
+    this.type = this.type ? this.type : 'public';
+    this.enabled = true;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  route(
+    coordinates: Position[],
+    directionsOptions: DirectionOptions = {}
+  ): Observable<Direction[]> {
+    const directionsParams = this.getRouteParams(directionsOptions);
+    return this.getRoute(coordinates, directionsParams);
+  }
+
+  @Cacheable({
+    maxCacheCount: 20,
+    cacheHasher: customCacheHasher
+  })
+  private getRoute(
+    coordinates: Position[],
+    params: HttpParams
+  ): Observable<Direction[]> {
+    return this._http
+      .get<JSON[]>(this.url + coordinates.join(';'), {
+        params
+      })
+      .pipe(map((res) => this.extractRoutesData(res)));
+  }
+
+  private extractRoutesData(response): Direction[] {
+    const routeResponse = [];
+    response.routes.forEach((route) => {
+      routeResponse.push(this.formatRoute(route, response.waypoints));
+    });
+    return routeResponse;
+  }
+
+  private getRouteParams(directionsOptions: DirectionOptions = {}): HttpParams {
+    directionsOptions.alternatives =
+      directionsOptions.alternatives !== undefined
+        ? directionsOptions.alternatives
+        : true;
+    directionsOptions.steps =
+      directionsOptions.steps !== undefined ? directionsOptions.steps : true;
+    directionsOptions.geometries =
+      directionsOptions.geometries !== undefined
+        ? directionsOptions.geometries
+        : 'geojson';
+    directionsOptions.overview =
+      directionsOptions.overview !== undefined
+        ? directionsOptions.overview
+        : false;
+    directionsOptions.continue_straight =
+      directionsOptions.continue_straight !== undefined
+        ? directionsOptions.continue_straight
+        : false;
+
+    return new HttpParams({
+      fromObject: {
+        alternatives: directionsOptions.alternatives ? 'true' : 'false',
+        overview: directionsOptions.overview ? 'simplified' : 'full',
+        steps: directionsOptions.steps ? 'true' : 'false',
+        geometries: directionsOptions.geometries
+          ? directionsOptions.geometries
+          : 'geojson',
+        continue_straight: directionsOptions.continue_straight
+          ? 'true'
+          : 'false'
+      }
+    });
+  }
+
+  private formatRoute(roadNetworkRoute: any, waypoints: any): Direction {
+    const stepsUI = [];
+    roadNetworkRoute.legs.forEach((leg) => {
+      leg.steps.forEach((step) => {
+        stepsUI.push(step);
+      });
+    });
+    return {
+      id: uuid(),
+      title: roadNetworkRoute.legs[0].summary,
+      source: this.name,
+      sourceType: SourceDirectionsType.Route,
+      order: 1,
+      format: DirectionsFormat.GeoJSON,
+      icon: 'directions',
+      projection: 'EPSG:4326',
+      waypoints,
+      distance: roadNetworkRoute.distance,
+      duration: roadNetworkRoute.duration,
+      geometry: roadNetworkRoute.geometry,
+      legs: roadNetworkRoute.legs,
+      steps: stepsUI,
+      weight: roadNetworkRoute.weight,
+      weight_name: roadNetworkRoute.weight_name
+    };
+  }
+}

--- a/packages/geo/src/lib/directions/directions.component.html
+++ b/packages/geo/src/lib/directions/directions.component.html
@@ -6,6 +6,13 @@
   >
     {{ 'igo.geo.directionsForm.toggleActive' | translate }}
   </mat-slide-toggle>
+  <mat-slide-toggle *ngIf="toggleTypeAvailable && twoSourcesAvailable"
+    [checked]="currentSourceIsPrivate"
+    [labelPosition]="'before'"
+    (change)="onToggleModeControl($event.checked)"
+  >
+  {{ 'igo.geo.directionsForm.toggleType' | translate }}
+  </mat-slide-toggle>
 </div>
 
 <igo-directions-buttons

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -6,9 +6,10 @@ import {
   OnInit
 } from '@angular/core';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-
+import { CommonModule } from '@angular/common';
 import { EntityStoreWatcher } from '@igo2/common';
-import { LanguageService } from '@igo2/core';
+import { LanguageService, MessageService } from '@igo2/core';
+import { AuthService } from '@igo2/auth';
 import { ChangeUtils, ObjectUtils } from '@igo2/utils';
 
 import Collection from 'ol/Collection';
@@ -38,6 +39,7 @@ import {
   Stop
 } from './shared/directions.interface';
 import { DirectionsService } from './shared/directions.service';
+import { DirectionsSourceService } from './shared/directions-source.service';
 import {
   addDirectionToRoutesFeatureStore,
   addStopToStopsFeatureStore,
@@ -53,6 +55,7 @@ import {
   StopsFeatureStore,
   StopsStore
 } from './shared/store';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'igo-directions',
@@ -60,6 +63,7 @@ import {
   styleUrls: ['./directions.component.scss'],
   standalone: true,
   imports: [
+    CommonModule,
     MatSlideToggleModule,
     DirectionsButtonsComponent,
     DirectionsInputsComponent,
@@ -71,6 +75,8 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   private watcher: EntityStoreWatcher<Stop>;
 
   public projection: string = 'EPSG:4326';
+  public toggleTypeAvailable: boolean = false;
+  public twoSourcesAvailable: boolean = false;
 
   private zoomRoute$$: Subscription;
   private storeEmpty$$: Subscription;
@@ -86,6 +92,7 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   public previousStops: Stop[] = [];
 
   private searchs$$: Subscription[] = [];
+  private authenticated$$: Subscription;
 
   @Input() contextUri: string;
   @Input() stopsStore: StopsStore;
@@ -111,13 +118,33 @@ export class DirectionsComponent implements OnInit, OnDestroy {
 
   constructor(
     private cdRef: ChangeDetectorRef,
+    private http: HttpClient,
     private languageService: LanguageService,
     private directionsService: DirectionsService,
+    private directionsSourceService: DirectionsSourceService,
     private searchService: SearchService,
-    private queryService: QueryService
+    private queryService: QueryService,
+    private authService: AuthService,
+    private messageService: MessageService
   ) {}
 
   ngOnInit(): void {
+    this.authenticated$$ = this.authService.authenticate$.subscribe((auth: boolean) => {
+      if (auth) {
+        const userVerifUrl: string = this.directionsSourceService.sources.find(source => source.type === 'private')?.userVerifUrl;
+        this.http.get(userVerifUrl).subscribe((user: any) => {
+          this.toggleTypeAvailable = user.hasOsrmPrivateAccess;
+        });
+      }
+    });
+    for (const source of this.directionsSourceService.sources) {
+      if (source.getName()) {
+        this.twoSourcesAvailable = true;
+      } else {
+        this.twoSourcesAvailable = false;
+        break;
+      }
+    }
     this.queryService.queryEnabled = false;
     this.initEntityStores();
     setTimeout(() => {
@@ -134,7 +161,12 @@ export class DirectionsComponent implements OnInit, OnDestroy {
     this.storeChange$$.unsubscribe();
     this.routesQueries$$.map((u) => u.unsubscribe());
     this.zoomRoute$$.unsubscribe();
+    this.authenticated$$.unsubscribe();
     this.freezeStores();
+  }
+
+  get currentSourceIsPrivate() {
+    return this.directionsSourceService.sources.find(source => source.type === 'private')?.enabled;
   }
 
   private freezeStores() {
@@ -465,5 +497,19 @@ export class DirectionsComponent implements OnInit, OnDestroy {
         ? ol.addInteraction(interaction)
         : ol.removeInteraction(interaction)
     );
+  }
+
+  onToggleModeControl(isActive: boolean) {
+    this.directionsSourceService.sources.map(source => source.enabled = false);
+    if (isActive) {
+      this.directionsSourceService.sources.find(source => source.type === 'private').enabled = true;
+      this.messageService
+        .alert(this.languageService.translate
+        .instant('igo.geo.directionsForm.forestRoadsWarning.text'), this.languageService.translate
+        .instant('igo.geo.directionsForm.forestRoadsWarning.title'));
+    } else {
+      this.directionsSourceService.sources.find(source => source.type === 'public').enabled = true;
+    }
+    this.getRoutes();
   }
 }

--- a/packages/geo/src/lib/directions/shared/directions.utils.ts
+++ b/packages/geo/src/lib/directions/shared/directions.utils.ts
@@ -432,6 +432,7 @@ export function formatInstruction(
   languageService: LanguageService,
   lastStep = false
 ) {
+  route = route ? route : 'Voie';
   const translate = languageService.translate;
   let directive;
   let image = 'forward';

--- a/packages/geo/src/lib/environment/environment.interface.ts
+++ b/packages/geo/src/lib/environment/environment.interface.ts
@@ -26,7 +26,7 @@ export interface EnvironmentOptions {
     defaultContextUri?: string;
   };
   depot?: DepotOptions;
-  directionsSources?: DirectionsSourceOptions;
+  directionsSources?: DirectionsSourceOptions[];
   dom?: DOMOptions[];
   drawingTool?: DrawOptions;
   edition?: unknown;

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -378,7 +378,12 @@
           "copyMsgLink": "Link for directions copied to clipboard",
           "copyTitle": "Directions"
         },
-        "toggleActive": "Activate direction control"
+        "toggleActive": "Activate direction control",
+        "toggleType": "Include forest roads",
+        "forestRoadsWarning": {
+          "title": "Warning",
+          "text": "Some forest roads may be impassable or not suitable for vehicles."
+        }
       },
       "directions": {
         "uturn": "u-turn",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -378,7 +378,12 @@
           "copyMsgLink": "Le lien de l'itinéraire est copié dans le presse-papier",
           "copyTitle": "Itinéraire"
         },
-        "toggleActive": "Activer le contrôle d'itinéraire"
+        "toggleActive": "Activer le contrôle d'itinéraire",
+        "toggleType": "Inclure les chemins forestiers",
+        "forestRoadsWarning": {
+          "title": "Avertissement",
+          "text": "Certains chemins forestiers peuvent être impraticables ou non carrossables."
+        }
       },
       "directions": {
         "uturn": "demi-tour",

--- a/projects/demo/proxy.conf.json
+++ b/projects/demo/proxy.conf.json
@@ -14,6 +14,11 @@
     "secure": false,
     "changeOrigin": true
   },
+  "/services/": {
+    "target": "https://geoegl.msp.gouv.qc.ca",
+    "secure": false,
+    "changeOrigin": true
+  },
   "/swtq": {
     "target": "https://ws.mapserver.transports.gouv.qc.ca",
     "changeOrigin": true,

--- a/projects/demo/src/app/geo/directions/directions.component.ts
+++ b/projects/demo/src/app/geo/directions/directions.component.ts
@@ -5,7 +5,6 @@ import {
   IgoDirectionsModule,
   IgoMap,
   IgoSearchModule,
-  LayerOptions,
   LayerService,
   MAP_DIRECTIVES,
   MapService,
@@ -14,7 +13,8 @@ import {
   StepFeatureStore,
   StopsFeatureStore,
   StopsStore,
-  TileLayer
+  TileLayer,
+  TileLayerOptions
 } from '@igo2/geo';
 
 import { Subject } from 'rxjs';
@@ -70,13 +70,15 @@ export class AppDirectionsComponent {
     this.mapService.setMap(this.map);
     this.layerService
       .createAsyncLayer({
-        title: 'OSM',
+        title: 'Quebec Base Map',
         baseLayer: true,
         visible: true,
         sourceOptions: {
-          type: 'osm'
+          type: 'xyz',
+          url: '/carto/tms/1.0.0/carte_gouv_qc_public@EPSG_3857/{z}/{x}/{-y}.png',
+          crossOrigin: 'anonymous'
         }
-      } satisfies LayerOptions)
+      } satisfies TileLayerOptions)
       .subscribe((layer: TileLayer) => this.map.addLayer(layer));
   }
 }

--- a/projects/demo/src/environments/environment.prod.ts
+++ b/projects/demo/src/environments/environment.prod.ts
@@ -4,6 +4,23 @@ import { EnvironmentOptions } from '@igo2/integration';
 export const environment: EnvironmentOptions = {
   production: true,
   igo: {
+    directionsSources: [
+      {
+        osrm: {
+          name: 'OSRM Québec (Public)',
+          type: 'public',
+          url: '/apis/itineraire/route/v1/driving/'
+        }
+      },
+      {
+        osrm: {
+          name: 'OSRM Québec (Partenaires)',
+          type: 'private',
+          url: '/apis/itineraire/route/v1/forestier/',
+          userVerifUrl: '/apis/igo2/user/igo'
+        }
+      }
+    ],
     projections: [
       {
         code: 'EPSG:32198',

--- a/projects/demo/src/environments/environment.ts
+++ b/projects/demo/src/environments/environment.ts
@@ -4,6 +4,23 @@ import { EnvironmentOptions } from '@igo2/integration';
 export const environment: EnvironmentOptions = {
   production: false,
   igo: {
+    directionsSources: [
+      {
+        osrm: {
+          name: 'OSRM Québec (Public)',
+          type: 'public',
+          url: '/apis/itineraire/route/v1/driving/'
+        }
+      },
+      {
+        osrm: {
+          name: 'OSRM Québec (Partenaires)',
+          type: 'private',
+          url: '/apis/itineraire/route/v1/forestier/',
+          userVerifUrl: '/apis/igo2/user/igo'
+        }
+      }
+    ],
     importWithStyle: true,
     projections: [
       {

--- a/projects/demo/src/main.ts
+++ b/projects/demo/src/main.ts
@@ -36,7 +36,8 @@ import {
   IgoDirectionsModule,
   IgoGeoWorkspaceModule,
   provideIChercheSearchSource,
-  provideOsrmDirectionsSource,
+  providePublicOsrmDirectionsSource,
+  providePrivateOsrmDirectionsSource,
   provideWorkspaceSearchSource
 } from '@igo2/geo';
 
@@ -88,7 +89,8 @@ bootstrapApplication(AppComponent, {
     },
     { provide: MAT_TOOLTIP_DEFAULT_OPTIONS, useValue: defaultTooltipOptions },
     provideAnimations(),
-    provideOsrmDirectionsSource(),
+    providePublicOsrmDirectionsSource(),
+    providePrivateOsrmDirectionsSource(),
     provideIChercheSearchSource(),
     provideWorkspaceSearchSource()
   ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
At the moment, only one routing source can be used in the Directions tool.


**What is the new behavior?**
Two sources can now be used. In order to see the toggle to switch between the two, you need:
- To be authenticated and authorized to use the second routing source.
- Two routing sources that must be provided in the configs.

When the user activates the second/private source a message warns the user.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
