### PR TITLE
Fix Advanced filter 'As' 

### DIFF
--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
@@ -168,11 +168,9 @@ export class OgcFilterFormComponent implements OnInit {
   }
 
   private _filterValues(value: string): string[] {
-    if (value.includes('*')) {
-      value = value.replaceAll('*', '\\*');
-    }
     const keywordRegex = new RegExp(
       value
+        .replace(/[.*+?^${}()|[\]\\]/g, '')
         .toString()
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, ''),

--- a/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filter-form/ogc-filter-form.component.ts
@@ -148,8 +148,8 @@ export class OgcFilterFormComponent implements OnInit {
       value && value.length > 0
         ? of(this._filterValues(value))
         : this.selectedField$.value
-        ? of(this.selectedField$.value.values)
-        : of([]);
+          ? of(this.selectedField$.value.values)
+          : of([]);
     if (value && value.length >= 1) {
       this.changeProperty(value, pos);
     }
@@ -168,6 +168,9 @@ export class OgcFilterFormComponent implements OnInit {
   }
 
   private _filterValues(value: string): string[] {
+    if (value.includes('*')) {
+      value = value.replaceAll('*', '\\*');
+    }
     const keywordRegex = new RegExp(
       value
         .toString()
@@ -343,14 +346,14 @@ export class OgcFilterFormComponent implements OnInit {
         return pos && pos === 1
           ? 'lowerBoundary'
           : pos && pos === 2
-          ? 'upperBoundary'
-          : undefined;
+            ? 'upperBoundary'
+            : undefined;
       case OgcFilterOperator.During:
         return pos && pos === 1
           ? 'begin'
           : pos && pos === 2
-          ? 'end'
-          : undefined;
+            ? 'end'
+            : undefined;
       default:
         return;
     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
The application cannot process filter with the special character '*'
It sends the following error message:
![image](https://github.com/infra-geo-ouverte/igo2-lib/assets/124627120/56fbf5f2-c16b-40f3-8248-ce1f905b263c)


**What is the new behavior?**
It can now filter with special character '*' as intended.

