### PR TITLE
fix(search): Make it optional to have a workspace source

### DIFF
--- a/packages/integration/src/lib/search/search.state.ts
+++ b/packages/integration/src/lib/search/search.state.ts
@@ -129,7 +129,9 @@ export class SearchState {
           fw instanceof FeatureWorkspace &&
           fw.layer.options.workspace.searchIndexEnabled
       );
-      this.searchSourceService.setWorkspaces(wksSource, searchableWks);
+      if (wksSource) {
+        this.searchSourceService.setWorkspaces(wksSource, searchableWks);
+      }
     });
     this.monitorLayerDeletion();
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
If there is no workspace search source, the search state fails to instantiate itself and an error is thrown upon loading the app.


**What is the new behavior?**
The workspace source is optional and the search state doesn't fail if there is none.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
