### PR TITLE
refactor(core): sentry monitoring update to v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1026,9 +1026,6 @@
       "version": "17.3.9",
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-17.3.9.tgz",
       "integrity": "sha512-7KFThQMTwEj/yj/Sk2NvdsCpBf46wV121UvmDYIaUl8AQcnrD94W+BJHkPSw1WgPL4yLquySg6D6GGHQcL2dQQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3740,6 +3737,28 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -7540,203 +7559,204 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.114.0.tgz",
-      "integrity": "sha512-kUiLRUDZuh10QE9JbSVVLgqxFoD9eDPOzT0MmzlPuas8JlTmJuV4FtSANNcqctd5mBuLt2ebNXH0MhRMwyae4A==",
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.26.0.tgz",
+      "integrity": "sha512-O2Tj+WK33/ZVp5STnz6ZL0OO+/Idk2KqsH0ITQkQmyZ2z0kdzWOeqK7s7q3/My6rB1GfPcyqPcBBv4dVv92FYQ==",
       "peer": true,
       "dependencies": {
-        "@sentry/core": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0"
+        "@sentry/core": "8.26.0",
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.114.0.tgz",
-      "integrity": "sha512-6rTiqmKi/FYtesdM2TM2U+rh6BytdPjLP65KTUodtxohJ+r/3m+termj2o4BhIYPE1YYOZNmbZfwebkuQPmWeg==",
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.26.0.tgz",
+      "integrity": "sha512-g/tVmTZD4GNbLFf++hKJfBpcCAtduFEMLnbfa9iT/QEZjlmP+EzY+GsH9bafM5VsNe8DiOUp+kJKWtShzlVdBA==",
       "peer": true,
       "dependencies": {
-        "@sentry/core": "7.114.0",
-        "@sentry/replay": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0"
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/types": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.26.0.tgz",
+      "integrity": "sha512-zKmh6SWsJh630rpt7a9vP4Cm4m1C2gDTUqUiH565CajCL/4cePpNWYrNwalSqsOSL7B9OrczA1+n6a6XvND+ng==",
       "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.114.0.tgz",
-      "integrity": "sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==",
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/utils": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.26.0.tgz",
+      "integrity": "sha512-xvlPU9Hd2BlyT+FhWHGNwnxWqdVRk2AHnDtVcW4Ma0Ri5EwS+uy4Jeik5UkSv8C5RVb9VlxFmS8LN3I1MPJsLw==",
       "peer": true,
       "dependencies": {
-        "@sentry/core": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0"
+        "@sentry/types": "8.26.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/angular-ivy": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/angular-ivy/-/angular-ivy-7.114.0.tgz",
-      "integrity": "sha512-fgiyB2N6UzXwGL7rMHLTqeLIm3ZCxHKRqcQP5P/2DTnJAsyxgx0e4CYZV236IgpPFl1JndCXMYSD/aJQPH6h7Q==",
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.26.0.tgz",
+      "integrity": "sha512-JDY7W2bswlp5c3483lKP4kcb75fHNwGNfwD8x8FsY9xMjv7nxeXjLpR5cCEk1XqPq2+n6w4j7mJOXhEXGiUIKg==",
       "peer": true,
       "dependencies": {
-        "@sentry/browser": "7.114.0",
-        "@sentry/core": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0",
+        "@sentry-internal/browser-utils": "8.26.0",
+        "@sentry/core": "8.26.0",
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.26.0.tgz",
+      "integrity": "sha512-g/tVmTZD4GNbLFf++hKJfBpcCAtduFEMLnbfa9iT/QEZjlmP+EzY+GsH9bafM5VsNe8DiOUp+kJKWtShzlVdBA==",
+      "peer": true,
+      "dependencies": {
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/types": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.26.0.tgz",
+      "integrity": "sha512-zKmh6SWsJh630rpt7a9vP4Cm4m1C2gDTUqUiH565CajCL/4cePpNWYrNwalSqsOSL7B9OrczA1+n6a6XvND+ng==",
+      "peer": true,
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/utils": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.26.0.tgz",
+      "integrity": "sha512-xvlPU9Hd2BlyT+FhWHGNwnxWqdVRk2AHnDtVcW4Ma0Ri5EwS+uy4Jeik5UkSv8C5RVb9VlxFmS8LN3I1MPJsLw==",
+      "peer": true,
+      "dependencies": {
+        "@sentry/types": "8.26.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/angular": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-8.26.0.tgz",
+      "integrity": "sha512-9YolcJMdEzS6hbImal3jrAbzGZGM7DpmfSOfzt1Cs4bYTD9gCxKRkLyUgiNRIlrIBO7CkdpMrCSY+nEohvCw7A==",
+      "peer": true,
+      "dependencies": {
+        "@sentry/browser": "8.26.0",
+        "@sentry/core": "8.26.0",
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0",
         "tslib": "^2.4.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
       },
       "peerDependencies": {
-        "@angular/common": ">= 12.x <= 17.x",
-        "@angular/core": ">= 12.x <= 17.x",
-        "@angular/router": ">= 12.x <= 17.x",
+        "@angular/common": ">= 14.x <= 18.x",
+        "@angular/core": ">= 14.x <= 18.x",
+        "@angular/router": ">= 14.x <= 18.x",
         "rxjs": "^6.5.5 || ^7.x"
       }
     },
-    "node_modules/@sentry/angular-ivy/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.114.0.tgz",
-      "integrity": "sha512-ijJ0vOEY6U9JJADVYGkUbLrAbpGSQgA4zV+KW3tcsBLX9M1jaWq4BV1PWHdzDPPDhy4OgfOjIfaMb5BSPn1U+g==",
+    "node_modules/@sentry/angular/node_modules/@sentry-internal/feedback": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.26.0.tgz",
+      "integrity": "sha512-hQtw1gg8n6ERK1UH47F7ZI1zOsbhu0J2VX+TrnkpaQR2FgxDW1oe9Ja6oCV4CQKuR4w+1ZI/Kj4imSt0K33kEw==",
       "peer": true,
       "dependencies": {
-        "@sentry-internal/feedback": "7.114.0",
-        "@sentry-internal/replay-canvas": "7.114.0",
-        "@sentry-internal/tracing": "7.114.0",
-        "@sentry/core": "7.114.0",
-        "@sentry/integrations": "7.114.0",
-        "@sentry/replay": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0"
+        "@sentry/core": "8.26.0",
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/browser/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.114.0.tgz",
-      "integrity": "sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==",
+    "node_modules/@sentry/angular/node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.26.0.tgz",
+      "integrity": "sha512-2CFQW6f9aJHIo/DqmqYa9PaYoLn1o36ywc0h8oyGrD4oPCbrnE5F++PmTdc71GBODu41HBn/yoCTLmxOD+UjpA==",
       "peer": true,
       "dependencies": {
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0"
+        "@sentry-internal/replay": "8.26.0",
+        "@sentry/core": "8.26.0",
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.114.0.tgz",
-      "integrity": "sha512-BJIBWXGKeIH0ifd7goxOS29fBA8BkEgVVCahs6xIOXBjX1IRS6PmX0zYx/GP23nQTfhJiubv2XPzoYOlZZmDxg==",
+    "node_modules/@sentry/angular/node_modules/@sentry/browser": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.26.0.tgz",
+      "integrity": "sha512-e5s6eKlwLZWzTwQcBwqyAGZMMuQROW9Z677VzwkSyREWAIkKjfH2VBxHATnNGc0IVkNHjD7iH3ixo3C0rLKM3w==",
       "peer": true,
       "dependencies": {
-        "@sentry/core": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0",
-        "localforage": "^1.8.1"
+        "@sentry-internal/browser-utils": "8.26.0",
+        "@sentry-internal/feedback": "8.26.0",
+        "@sentry-internal/replay": "8.26.0",
+        "@sentry-internal/replay-canvas": "8.26.0",
+        "@sentry/core": "8.26.0",
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/integrations/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/replay": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.114.0.tgz",
-      "integrity": "sha512-UvEajoLIX9n2poeW3R4Ybz7D0FgCGXoFr/x/33rdUEMIdTypknxjJWxg6fJngIduzwrlrvWpvP8QiZXczYQy2Q==",
+    "node_modules/@sentry/angular/node_modules/@sentry/core": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.26.0.tgz",
+      "integrity": "sha512-g/tVmTZD4GNbLFf++hKJfBpcCAtduFEMLnbfa9iT/QEZjlmP+EzY+GsH9bafM5VsNe8DiOUp+kJKWtShzlVdBA==",
       "peer": true,
       "dependencies": {
-        "@sentry-internal/tracing": "7.114.0",
-        "@sentry/core": "7.114.0",
-        "@sentry/types": "7.114.0",
-        "@sentry/utils": "7.114.0"
+        "@sentry/types": "8.26.0",
+        "@sentry/utils": "8.26.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/replay/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
+    "node_modules/@sentry/angular/node_modules/@sentry/types": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.26.0.tgz",
+      "integrity": "sha512-zKmh6SWsJh630rpt7a9vP4Cm4m1C2gDTUqUiH565CajCL/4cePpNWYrNwalSqsOSL7B9OrczA1+n6a6XvND+ng==",
       "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/angular/node_modules/@sentry/utils": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.26.0.tgz",
+      "integrity": "sha512-xvlPU9Hd2BlyT+FhWHGNwnxWqdVRk2AHnDtVcW4Ma0Ri5EwS+uy4Jeik5UkSv8C5RVb9VlxFmS8LN3I1MPJsLw==",
+      "peer": true,
+      "dependencies": {
+        "@sentry/types": "8.26.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/types": {
@@ -7744,27 +7764,6 @@
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.115.0.tgz",
       "integrity": "sha512-KbhDS0DX+lk9VFCCR4AwPdiU9KUAH+vI+5HBLlgCNMY7KRGxRLnpXi3VyGi80iRdt2gi8sg2ncsVhc+SunBx7w==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.114.0.tgz",
-      "integrity": "sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==",
-      "peer": true,
-      "dependencies": {
-        "@sentry/types": "7.114.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils/node_modules/@sentry/types": {
-      "version": "7.114.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
-      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8263,6 +8262,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -8638,6 +8661,15 @@
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.3.6.tgz",
       "integrity": "sha512-3N0FpQTeiWjm+Oo1WUYWguUS7E6JLceiGTriFrG8k5PU7zRLJCzLcWURU3wjMbZGS//a2/LgjsnO3QxIlwxt9g==",
       "dev": true
+    },
+    "node_modules/@types/jasminewd2": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.13.tgz",
+      "integrity": "sha512-aJ3wj8tXMpBrzQ5ghIaqMisD8C3FIrcO6sDKHqFbuqAsI7yOxj0fA7MrRCPLZHIVUjERIwsMmGn/vB0UQ9u0Hg==",
+      "dev": true,
+      "dependencies": {
+        "@types/jasmine": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -9477,6 +9509,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -9772,6 +9816,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -11920,6 +11970,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -11980,6 +12039,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/critters": {
       "version": "0.0.22",
@@ -13238,6 +13303,15 @@
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
       "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -15989,6 +16063,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -16041,6 +16124,18 @@
         "obuf": "^1.0.0",
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/html-entities": {
@@ -16223,6 +16318,115 @@
         }
       }
     },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/http-server/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/http-server/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/http-server/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
@@ -16351,6 +16555,10 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/igo": {
+      "resolved": "projects/igo2",
+      "link": true
     },
     "node_modules/image-size": {
       "version": "0.5.5",
@@ -18439,24 +18647,6 @@
         "node": ">= 12.13.0"
       }
     },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "peer": true,
-      "dependencies": {
-        "lie": "3.1.1"
-      }
-    },
-    "node_modules/localforage/node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "peer": true,
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -18940,6 +19130,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/make-fetch-happen": {
       "version": "13.0.1",
@@ -23184,6 +23380,15 @@
         "opencollective-postinstall": "index.js"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -24018,6 +24223,38 @@
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
       "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
       "dev": true
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -25815,6 +26052,12 @@
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -27949,6 +28192,49 @@
         "code-block-writer": "^13.0.1"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -28768,6 +29054,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -28891,6 +29189,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -28935,6 +29239,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -29835,6 +30145,30 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -30241,6 +30575,15 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -30389,7 +30732,7 @@
         "@igo2/utils": "*",
         "@ngx-translate/core": "^15.0.0",
         "@ngx-translate/http-loader": "^8.0.0",
-        "@sentry/angular-ivy": "^7.87.0",
+        "@sentry/angular": "^8.26.0",
         "ngx-indexed-db": "^11.0.2",
         "ngx-toastr": "^18.0.0",
         "rxjs": "^7.8.0"
@@ -30486,7 +30829,6 @@
     "projects/igo2": {
       "name": "igo",
       "version": "17.0.0-next.0",
-      "extraneous": true,
       "license": "LiLiQ-R",
       "dependencies": {
         "@angular/animations": "^17.0.7",
@@ -30555,6 +30897,206 @@
       },
       "engines": {
         "node": ">=18.13.0"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.100.tgz",
+      "integrity": "sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.3.100",
+        "@swc/core-darwin-x64": "1.3.100",
+        "@swc/core-linux-arm64-gnu": "1.3.100",
+        "@swc/core-linux-arm64-musl": "1.3.100",
+        "@swc/core-linux-x64-gnu": "1.3.100",
+        "@swc/core-linux-x64-musl": "1.3.100",
+        "@swc/core-win32-arm64-msvc": "1.3.100",
+        "@swc/core-win32-ia32-msvc": "1.3.100",
+        "@swc/core-win32-x64-msvc": "1.3.100"
+      },
+      "peerDependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.100.tgz",
+      "integrity": "sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-darwin-x64": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.100.tgz",
+      "integrity": "sha512-KF/MXrnH1nakm1wbt4XV8FS7kvqD9TGmVxeJ0U4bbvxXMvzeYUurzg3AJUTXYmXDhH/VXOYJE5N5RkwZZPs5iA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.100.tgz",
+      "integrity": "sha512-p8hikNnAEJrw5vHCtKiFT4hdlQxk1V7vqPmvUDgL/qe2menQDK/i12tbz7/3BEQ4UqUPnvwpmVn2d19RdEMNxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.100.tgz",
+      "integrity": "sha512-BWx/0EeY89WC4q3AaIaBSGfQxkYxIlS3mX19dwy2FWJs/O+fMvF9oLk/CyJPOZzbp+1DjGeeoGFuDYpiNO91JA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.100.tgz",
+      "integrity": "sha512-XUdGu3dxAkjsahLYnm8WijPfKebo+jHgHphDxaW0ovI6sTdmEGFDew7QzKZRlbYL2jRkUuuKuDGvD6lO5frmhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.100.tgz",
+      "integrity": "sha512-PhoXKf+f0OaNW/GCuXjJ0/KfK9EJX7z2gko+7nVnEA0p3aaPtbP6cq1Ubbl6CMoPL+Ci3gZ7nYumDqXNc3CtLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.100.tgz",
+      "integrity": "sha512-PwLADZN6F9cXn4Jw52FeP/MCLVHm8vwouZZSOoOScDtihjY495SSjdPnlosMaRSR4wJQssGwiD/4MbpgQPqbAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.100.tgz",
+      "integrity": "sha512-0f6nicKSLlDKlyPRl2JEmkpBV4aeDfRQg6n8mPqgL7bliZIcDahG0ej+HxgNjZfS3e0yjDxsNRa6sAqWU2Z60A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.100.tgz",
+      "integrity": "sha512-b7J0rPoMkRTa3XyUGt8PwCaIBuYWsL2DqbirrQKRESzgCvif5iNpqaM6kjIjI/5y5q1Ycv564CB51YDpiS8EtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "projects/igo2/node_modules/@swc/wasm": {
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.3.100.tgz",
+      "integrity": "sha512-rCi5+dUBta1jgrT5xGeAIY8yeJ/o/8PSFmcpsTVe2I2aSXkcHX2c1G1/tS86O65rMlwEiBmGvm1txEMG89me6Q==",
+      "dev": true
+    },
+    "projects/igo2/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/packages/core/monitoring/src/sentry/sentry.interface.ts
+++ b/packages/core/monitoring/src/sentry/sentry.interface.ts
@@ -1,4 +1,4 @@
-import { BrowserOptions, ErrorHandlerOptions } from '@sentry/angular-ivy';
+import { BrowserOptions, ErrorHandlerOptions } from '@sentry/angular';
 
 import { MonitoringOptions } from '../shared/monitoring.interface';
 
@@ -6,5 +6,4 @@ export type SentryMonitoringOptions = BrowserOptions &
   MonitoringOptions & {
     provider: 'sentry';
     errorHandlerOptions?: ErrorHandlerOptions;
-    enableReplay?: boolean;
   };

--- a/packages/core/monitoring/src/sentry/sentry.provider.spec.ts
+++ b/packages/core/monitoring/src/sentry/sentry.provider.spec.ts
@@ -1,7 +1,7 @@
 import { APP_INITIALIZER, ErrorHandler, FactoryProvider } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { TraceService } from '@sentry/angular-ivy';
+import { TraceService } from '@sentry/angular';
 
 import { MOCK_SENTRY_OPTIONS } from '../__mocks__/monitoring-mock';
 import { SentryMonitoringOptions } from './sentry.interface';
@@ -35,7 +35,7 @@ describe('Provide Sentry monitoring', () => {
   });
 
   it('should provide TraceService if tracing is enabled', () => {
-    options.enableTracing = true;
+    options.tracesSampleRate = 1;
     const providers = provideSentryMonitoring(options);
     const traceServiceProvider = providers.find(
       (p) => p.provide === TraceService
@@ -45,7 +45,7 @@ describe('Provide Sentry monitoring', () => {
   });
 
   it('should provide APP_INITIALIZER to instantiate TraceService if tracing is enabled', () => {
-    options.enableTracing = true;
+    options.tracesSampleRate = 1;
     const providers = provideSentryMonitoring(options);
     const appInitializerProvider = providers.find(
       (p) => p.provide === APP_INITIALIZER
@@ -57,7 +57,8 @@ describe('Provide Sentry monitoring', () => {
   });
 
   it('should not provide TraceService if tracing is not enabled', () => {
-    options.enableTracing = false;
+    options.tracesSampleRate = undefined;
+    options.tracesSampler = undefined;
     const providers = provideSentryMonitoring(options);
     const tracingProviders = providers.filter(
       (p) =>

--- a/packages/core/monitoring/src/sentry/sentry.provider.ts
+++ b/packages/core/monitoring/src/sentry/sentry.provider.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { TraceService } from '@sentry/angular-ivy';
+import { TraceService } from '@sentry/angular';
 
 import { createSentryErrorHandler, initSentry } from './sentry';
 import { SentryMonitoringOptions } from './sentry.interface';

--- a/packages/core/monitoring/src/sentry/sentry.spec.ts
+++ b/packages/core/monitoring/src/sentry/sentry.spec.ts
@@ -1,4 +1,4 @@
-import { BrowserTracing, Replay, getCurrentHub } from '@sentry/angular-ivy';
+import { getClient } from '@sentry/angular';
 
 import { MOCK_SENTRY_OPTIONS } from '../__mocks__/monitoring-mock';
 import { createSentryErrorHandler, initSentry } from './sentry';
@@ -20,17 +20,22 @@ describe('Sentry', () => {
 
   describe('initSentry', () => {
     it('should initialize Sentry with default options', () => {
-      initSentry(options);
-      const client = getCurrentHub().getClient();
+      initSentry(options, true);
+      const client = getClient();
       expect(client).toBeDefined();
     });
 
     it('should initialize Sentry integration with tracing and replay enabled', () => {
-      options = { ...options, enableTracing: true, enableReplay: true };
-      initSentry(options);
-      const client = getCurrentHub().getClient();
-      const replay = client.getIntegration(Replay);
-      const tracing = client.getIntegration(BrowserTracing as any);
+      options = {
+        ...options,
+        tracesSampleRate: 1,
+        replaysSessionSampleRate: 1
+      };
+      initSentry(options, true);
+      const client = getClient();
+      console.log(client);
+      const replay = client.getIntegrationByName('Replay');
+      const tracing = client.getIntegrationByName('BrowserTracing');
       expect(replay).toBeDefined();
       expect(tracing).toBeDefined();
     });

--- a/packages/core/monitoring/src/sentry/sentry.ts
+++ b/packages/core/monitoring/src/sentry/sentry.ts
@@ -1,16 +1,15 @@
 import {
   BrowserOptions,
-  BrowserTracing,
-  Replay,
   SentryErrorHandler,
+  browserTracingIntegration,
   createErrorHandler,
-  getCurrentHub,
+  getClient,
   init,
-  instrumentAngularRouting
-} from '@sentry/angular-ivy';
+  replayIntegration
+} from '@sentry/angular';
 
 import { SentryMonitoringOptions } from './sentry.interface';
-import { isTracingEnabled } from './sentry.utils';
+import { isReplayEnabled, isTracingEnabled } from './sentry.utils';
 
 export const createSentryErrorHandler = (
   options: SentryMonitoringOptions
@@ -21,23 +20,21 @@ export const createSentryErrorHandler = (
   });
 };
 
-export const initSentry = (options: SentryMonitoringOptions): void => {
-  const client = getCurrentHub().getClient();
-  if (client) {
+export const initSentry = (
+  options: SentryMonitoringOptions,
+  force?: boolean
+): void => {
+  const client = getClient();
+  console.log('init sentry: ', client);
+  if (!force && client) {
     return;
   }
 
-  const tracingEnabled = isTracingEnabled(options);
   const baseConfig: BrowserOptions = {
-    dsn: options.dsn,
-    environment: options.environment,
-    release: options.release,
+    ...options,
     integrations: [
-      tracingEnabled &&
-        new BrowserTracing({
-          routingInstrumentation: instrumentAngularRouting
-        }),
-      options.enableReplay && new Replay()
+      isTracingEnabled(options) && browserTracingIntegration(),
+      isReplayEnabled(options) && replayIntegration()
     ].filter(Boolean)
   };
 

--- a/packages/core/monitoring/src/sentry/sentry.utils.spec.ts
+++ b/packages/core/monitoring/src/sentry/sentry.utils.spec.ts
@@ -10,13 +10,6 @@ const getOptions = (
 });
 
 describe('isTracingEnabled', () => {
-  it('should return true if enableTracing is true', () => {
-    const options: SentryMonitoringOptions = getOptions({
-      enableTracing: true
-    });
-    expect(isTracingEnabled(options)).toBe(true);
-  });
-
   it('should return true if tracesSampleRate is set', () => {
     const options: SentryMonitoringOptions = getOptions({
       tracesSampleRate: 0.5

--- a/packages/core/monitoring/src/sentry/sentry.utils.ts
+++ b/packages/core/monitoring/src/sentry/sentry.utils.ts
@@ -1,13 +1,14 @@
 import { BaseUser } from '@igo2/core/user';
 
-import { setUser } from '@sentry/angular-ivy';
+import { setUser } from '@sentry/angular';
 
 import { SentryMonitoringOptions } from './sentry.interface';
 
 export const isTracingEnabled = (options: SentryMonitoringOptions): boolean =>
-  options.enableTracing ||
-  !!options.tracesSampleRate ||
-  !!options.tracesSampler;
+  !!options.tracesSampleRate || !!options.tracesSampler;
+
+export const isReplayEnabled = (options: SentryMonitoringOptions): boolean =>
+  !!options.replaysSessionSampleRate || !!options.replaysOnErrorSampleRate;
 
 export const identifySentryUser = (user: BaseUser | null): void => {
   setUser(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "lint": "ng lint core",
     "lint.fix": "ng lint core --fix",
     "test": "ng test core --watch=false",
+    "test.watch": "ng test core",
     "watch": "ng build core --watch && npm run postbuild"
   },
   "exports": {
@@ -106,7 +107,7 @@
     "@angular/platform-browser": "^17.0.6",
     "@angular/router": "^17.0.6",
     "@igo2/utils": "*",
-    "@sentry/angular-ivy": "^7.87.0",
+    "@sentry/angular": "^8.26.0",
     "ngx-indexed-db": "^11.0.2",
     "ngx-toastr": "^18.0.0",
     "@ngx-translate/core": "^15.0.0",


### PR DESCRIPTION
- BREAKING CHANGE: Sentry enableReplay options is removed in favor of replaysSessionSampleRate. Samething for enableTracing replaced by tracesSampleRate. See the Sentry doc for more details