### PR TITLE
fix(geo): add saveable options for layers and datasources

### DIFF
--- a/packages/context/src/lib/context-manager/shared/context.interface.ts
+++ b/packages/context/src/lib/context-manager/shared/context.interface.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@igo2/common/tool';
 import { Message } from '@igo2/core/message';
 import {
+  AnyDataSourceOptions,
   LayerOptions,
   MapAttributionOptions,
   MapExtent,
@@ -97,4 +98,14 @@ export interface ContextProfils {
   name: string;
   title: string;
   childs?: ContextProfils[];
+}
+
+export interface IContextLayer {
+  id?: string;
+  layerId?: number;
+  contextId?: number;
+  layerOptions?:
+    | LayerOptions
+    | Pick<LayerOptions, 'title' | 'zIndex' | 'visible' | 'security'>;
+  sourceOptions?: AnyDataSourceOptions;
 }

--- a/packages/context/src/lib/context-manager/shared/context.service.ts
+++ b/packages/context/src/lib/context-manager/shared/context.service.ts
@@ -45,7 +45,8 @@ import {
   ContextServiceOptions,
   ContextsList,
   DetailedContext,
-  ExtraFeatures
+  ExtraFeatures,
+  IContextLayer
 } from './context.interface';
 
 @Injectable({
@@ -481,24 +482,11 @@ export class ContextService {
         .sort((a, b) => a.zIndex - b.zIndex);
     }
 
-    let i = 0;
     for (const layer of layers) {
-      const layerOptions: AnyLayerOptions = {
-        title: layer.options.title,
-        zIndex: ++i,
-        visible: layer.visible,
-        security: layer.options.security,
-        opacity: layer.opacity
-      };
-      const opts = {
+      const opts: IContextLayer = {
         id: layer.options.id ? String(layer.options.id) : undefined,
-        layerOptions,
-        sourceOptions: {
-          type: layer.dataSource.options.type,
-          params: layer.dataSource.options.params,
-          url: layer.dataSource.options.url,
-          queryable: layer.queryable
-        }
+        layerOptions: layer.saveableOptions,
+        sourceOptions: layer.dataSource.saveableOptions
       };
       if (opts.sourceOptions.type) {
         context.layers.push(opts);

--- a/packages/geo/src/lib/datasource/shared/datasources/arcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/arcgisrest-datasource.ts
@@ -10,6 +10,15 @@ export class ArcGISRestDataSource extends DataSource {
   declare public ol: olSourceVector;
   declare public options: ArcGISRestDataSourceOptions;
 
+  get saveableOptions(): Partial<ArcGISRestDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params,
+      url: this.options.url
+    };
+  }
+
   protected createOlSource(): olSourceVector {
     const esrijsonFormat = new olFormatEsriJSON();
     return new olSourceVector({

--- a/packages/geo/src/lib/datasource/shared/datasources/carto-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/carto-datasource.interface.ts
@@ -1,5 +1,3 @@
-import olSourceCarto from 'ol/source/CartoDB';
-
 import { DataSourceOptions } from './datasource.interface';
 
 export interface CartoDataSourceOptions extends DataSourceOptions {
@@ -13,6 +11,4 @@ export interface CartoDataSourceOptions extends DataSourceOptions {
   projection?: string;
   config?: any;
   map?: string;
-
-  ol?: olSourceCarto;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/carto-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/carto-datasource.ts
@@ -29,6 +29,14 @@ export class CartoDataSource extends DataSource {
       : QueryHtmlTarget.BLANK;
   }
 
+  get saveableOptions(): Partial<CartoDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params
+    };
+  }
+
   protected createOlSource(): olSourceCarto {
     const crossOrigin = this.options.crossOrigin
       ? this.options.crossOrigin

--- a/packages/geo/src/lib/datasource/shared/datasources/cluster-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/cluster-datasource.interface.ts
@@ -3,10 +3,8 @@ import olSourceVector from 'ol/source/Vector';
 import { FeatureDataSourceOptions } from './feature-datasource.interface';
 
 export interface ClusterDataSourceOptions extends FeatureDataSourceOptions {
-  // type?: 'cluster';
   distance?: number;
   source?: olSourceVector;
-  ol?: olSourceVector;
   pathOffline?: string;
   excludeAttribute?: string[];
   excludeAttributeOffline?: string[];

--- a/packages/geo/src/lib/datasource/shared/datasources/cluster-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/cluster-datasource.ts
@@ -9,6 +9,14 @@ export class ClusterDataSource extends FeatureDataSource {
   declare public options: ClusterDataSourceOptions;
   declare public ol: olSourceCluster;
 
+  get saveableOptions(): Partial<ClusterDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params
+    };
+  }
+
   protected createOlSource(): olSourceCluster {
     this.options.format = this.getSourceFormatFromOptions(this.options);
     this.options.source = super.createOlSource();

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -1,5 +1,4 @@
 import type { Type } from 'ol/geom/Geometry';
-import olSource from 'ol/source/Source';
 
 import { Encoders, Preset, Tokenizer } from 'flexsearch';
 
@@ -25,8 +24,8 @@ export interface DataSourceOptions {
   optionsFromCapabilities?: boolean;
   optionsFromApi?: boolean;
   _layerOptionsFromSource?: Record<string, string>;
+  url?: string;
   id?: string;
-  ol?: olSource;
   minZoom?: number;
   maxZoom?: number;
   minDate?: string;

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
@@ -12,6 +12,13 @@ export abstract class DataSource {
   public ol: olSource | olVectorSource | olClusterSource;
   private legend: Legend[];
 
+  get saveableOptions(): Partial<DataSourceOptions> {
+    return {
+      type: this.options.type,
+      url: this.options.url
+    };
+  }
+
   constructor(
     public options: DataSourceOptions = {},
     protected dataService?: DataService

--- a/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.interface.ts
@@ -1,12 +1,9 @@
 import olFeature from 'ol/Feature';
 import olFormatFeature from 'ol/format/Feature';
-import olSource from 'ol/source/Source';
-import olSourceVector from 'ol/source/Vector';
 
 import { DataSourceOptions } from './datasource.interface';
 
 export interface FeatureDataSourceOptions extends DataSourceOptions {
-  // type?: 'vector' | 'wfs';
   formatType?: string;
   formatOptions?: any;
 
@@ -18,8 +15,6 @@ export interface FeatureDataSourceOptions extends DataSourceOptions {
   preload?: PreloadOptions;
   excludeAttribute?: string[];
   excludeAttributeOffline?: string[];
-
-  ol?: olSourceVector | olSource;
 }
 
 export interface PreloadOptions {

--- a/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.ts
@@ -7,6 +7,15 @@ import { FeatureDataSourceOptions } from './feature-datasource.interface';
 export class FeatureDataSource extends DataSource {
   declare public options: FeatureDataSourceOptions;
   declare public ol: olSourceVector;
+
+  get saveableOptions(): Partial<FeatureDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params
+    };
+  }
+
   protected createOlSource(): olSourceVector {
     const sourceOptions = {
       format: this.getSourceFormatFromOptions(this.options)

--- a/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.interface.ts
@@ -1,5 +1,4 @@
 import olAttribution from 'ol/control/Attribution';
-import ImageArcGISRest from 'ol/source/ImageArcGISRest';
 
 import { DataSourceOptions } from './datasource.interface';
 
@@ -12,7 +11,6 @@ export interface ArcGISRestImageDataSourceOptions extends DataSourceOptions {
   attributions?: olAttribution;
   projection?: string;
   url?: string;
-  ol?: ImageArcGISRest;
   idColumn?: string;
   options?: any;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
@@ -29,6 +29,14 @@ export class ImageArcGISRestDataSource extends DataSource {
       : QueryHtmlTarget.BLANK;
   }
 
+  get saveableOptions(): Partial<ArcGISRestImageDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params
+    };
+  }
+
   protected createOlSource(): ImageArcGISRest {
     const params =
       this.options.layer === undefined

--- a/packages/geo/src/lib/datasource/shared/datasources/mvt-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/mvt-datasource.interface.ts
@@ -1,5 +1,3 @@
-import olSourceVectorTile from 'ol/source/VectorTile';
-
 import { DataSourceOptions } from './datasource.interface';
 
 export interface MVTDataSourceOptions extends DataSourceOptions {
@@ -7,7 +5,6 @@ export interface MVTDataSourceOptions extends DataSourceOptions {
   projection?: string;
   attributions?: string | string[];
   format?: any;
-  ol?: olSourceVectorTile;
   url?: string;
   pathOffline?: string;
   excludeAttribute?: string[];

--- a/packages/geo/src/lib/datasource/shared/datasources/mvt-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/mvt-datasource.ts
@@ -13,6 +13,10 @@ export class MVTDataSource extends DataSource {
   declare public options: MVTDataSourceOptions;
   declare public ol: olSourceVectorTile;
 
+  get saveableOptions(): Partial<MVTDataSourceOptions> {
+    return super.saveableOptions;
+  }
+
   protected createOlSource(): olSourceVectorTile {
     let mvtFormat;
     if (this.options.featureClass === 'feature') {

--- a/packages/geo/src/lib/datasource/shared/datasources/osm-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/osm-datasource.interface.ts
@@ -1,10 +1,7 @@
-import olSourceOSM from 'ol/source/OSM';
-
 import { DataSourceOptions } from './datasource.interface';
 
 export interface OSMDataSourceOptions extends DataSourceOptions {
   // type?: 'osm';
   maxZoom?: number;
   url?: string;
-  ol?: olSourceOSM;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/tilearcgisrest-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/tilearcgisrest-datasource.interface.ts
@@ -1,5 +1,3 @@
-import olSourceTileArcGISRest from 'ol/source/TileArcGISRest';
-
 import { DataSourceOptions } from './datasource.interface';
 
 export interface TileArcGISRestDataSourceOptions extends DataSourceOptions {
@@ -14,6 +12,5 @@ export interface TileArcGISRestDataSourceOptions extends DataSourceOptions {
   url?: string;
   urls?: string[];
 
-  ol?: olSourceTileArcGISRest;
   idColumn?: string;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/tilearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/tilearcgisrest-datasource.ts
@@ -30,6 +30,14 @@ export class TileArcGISRestDataSource extends DataSource {
       : QueryHtmlTarget.BLANK;
   }
 
+  get saveableOptions(): Partial<TileArcGISRestDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params
+    };
+  }
+
   protected createOlSource(): olSourceTileArcGISRest {
     return new olSourceTileArcGISRest(this.options as Options);
   }

--- a/packages/geo/src/lib/datasource/shared/datasources/tiledebug-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/tiledebug-datasource.interface.ts
@@ -1,11 +1,8 @@
-import TileDebug from 'ol/source/TileDebug';
-
 import { DataSourceOptions, TileGridOptions } from './datasource.interface';
 
 export interface TileDebugDataSourceOptions extends DataSourceOptions {
   projection?: string;
   wrapX?: boolean;
-  ol?: TileDebug;
   zDirection?: number;
   tileGrid?: TileGridOptions;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.interface.ts
@@ -1,6 +1,4 @@
-import olSource from 'ol/source/Source';
-import olSourceVector from 'ol/source/Vector';
-
+import { OgcFiltersOptions } from '../../../filter';
 import { FeatureDataSourceOptions } from './feature-datasource.interface';
 
 export interface WFSDataSourceOptions extends FeatureDataSourceOptions {
@@ -8,7 +6,7 @@ export interface WFSDataSourceOptions extends FeatureDataSourceOptions {
   params: WFSDataSourceOptionsParams; // Used by user
   paramsWFS?: WFSDataSourceOptionsParams; // Used by code
   urlWfs?: string; // Used by code
-  ol?: olSourceVector | olSource;
+  ogcFilters?: OgcFiltersOptions;
 }
 
 // TODO: Are those WFS protocol params or something else? This is not clear

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -44,6 +44,14 @@ export class WFSDataSource extends DataSource {
     return (this.options as OgcFilterableDataSourceOptions).ogcFilters;
   }
 
+  get saveableOptions(): Partial<WFSDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.options.params
+    };
+  }
+
   constructor(
     public options: WFSDataSourceOptions,
     protected wfsService: WFSService,

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.interface.ts
@@ -1,7 +1,6 @@
-import olSource from 'ol/source/Source';
-import olSourceVector from 'ol/source/Vector';
 import type { ServerType } from 'ol/source/wms';
 
+import { OgcFiltersOptions } from '../../../filter';
 import { TimeFilterOptions } from '../../../filter/shared/time-filter.interface';
 import { DataSourceOptions } from './datasource.interface';
 import { WFSDataSourceOptionsParams } from './wfs-datasource.interface';
@@ -17,10 +16,11 @@ export interface WMSDataSourceOptions extends DataSourceOptions {
   resolutions?: number[];
   serverType?: ServerType;
   ratio?: number;
-  ol?: olSourceVector | olSource;
   refreshIntervalSec?: number;
   contentDependentLegend?: boolean;
-  excludeAttribute?: string[];
+  excludeAttribute?: Array<string>;
+  ogcFilters?: OgcFiltersOptions;
+  timeFilter?: TimeFilterOptions;
 }
 
 export interface WMSDataSourceOptionsParams {

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -72,6 +72,14 @@ export class WMSDataSource extends DataSource {
   }
   readonly timeFilter$ = new BehaviorSubject<TimeFilterOptions>(undefined);
 
+  get saveableOptions(): Partial<WMSDataSourceOptions> {
+    const baseOptions = super.saveableOptions;
+    return {
+      ...baseOptions,
+      params: this.params
+    };
+  }
+
   constructor(
     public options: WMSDataSourceOptions,
     protected wfsService: WFSService

--- a/packages/geo/src/lib/datasource/shared/datasources/wmts-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wmts-datasource.interface.ts
@@ -1,5 +1,3 @@
-import olSourceWMTS from 'ol/source/WMTS';
-
 import { DataSourceOptions } from './datasource.interface';
 
 export interface WMTSDataSourceOptions extends DataSourceOptions {
@@ -12,5 +10,4 @@ export interface WMTSDataSourceOptions extends DataSourceOptions {
   matrixSet?: string;
   url?: string;
   urls?: string[];
-  ol?: olSourceWMTS;
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/xyz-datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/xyz-datasource.interface.ts
@@ -1,11 +1,8 @@
-import olSourceXYZ from 'ol/source/XYZ';
-
 import { DataSourceOptions } from './datasource.interface';
 
 export interface XYZDataSourceOptions extends DataSourceOptions {
   // type?: 'xyz';
   projection?: string;
-  ol?: olSourceXYZ;
   url?: string;
   urls?: string[];
   pathOffline?: string;

--- a/packages/geo/src/lib/layer/shared/layers/layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.ts
@@ -44,7 +44,7 @@ export abstract class Layer {
   }
 
   get id(): string {
-    return this.options.id || this.dataSource.id;
+    return String(this.options.id || this.dataSource.id);
   }
 
   get alias(): string {
@@ -134,6 +134,16 @@ export abstract class Layer {
 
   get showInLayerList(): boolean {
     return this.options.showInLayerList !== false;
+  }
+
+  get saveableOptions(): Partial<LayerOptions> {
+    return {
+      title: this.options.title,
+      zIndex: this.zIndex,
+      visible: this.visible,
+      security: this.options.security,
+      opacity: this.opacity
+    };
   }
 
   constructor(

--- a/packages/geo/src/lib/search/shared/sources/ilayer.interfaces.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.interfaces.ts
@@ -39,7 +39,7 @@ export interface ILayerDataHighlight {
 
 interface QueryWMSDataSourceOptions
   extends WMSDataSourceOptions,
-    QueryableDataSourceOptions {}
+    Omit<QueryableDataSourceOptions, 'url'> {}
 
 export interface ILayerItemResponse extends ImageLayerOptions {
   title: string;

--- a/projects/demo/src/app/geo/ogc-filter/ogc-filter.component.ts
+++ b/projects/demo/src/app/geo/ogc-filter/ogc-filter.component.ts
@@ -499,7 +499,7 @@ export class AppOgcFilterComponent {
         );
       });
 
-    const wmsOgcFilterOptions: WMSOptions = {
+    const wmsOgcFilterOptions: WMSDataSourceOptions = {
       type: 'wms',
       url: 'https://geoegl.msp.gouv.qc.ca/apis/wss/complet.fcgi',
       optionsFromCapabilities: false,
@@ -538,11 +538,7 @@ export class AppOgcFilterComponent {
         );
       });
 
-    interface WMSOptions
-      extends WMSDataSourceOptions,
-        OgcFilterableDataSourceOptions {}
-
-    const filterableWMSwithPushButtons: WMSOptions = {
+    const filterableWMSwithPushButtons: WMSDataSourceOptions = {
       type: 'wms',
       url: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',
       urlWfs: 'https://ws.mapserver.transports.gouv.qc.ca/swtq',


### PR DESCRIPTION
Permettre une meilleure distinctions des éléments sauvegardable selon les besoins de chaque layer/datasource. Nous allons avoir d'autres modiciation dans la branche sur la gestions des LayerGroup mais ces changements sont nécessaires pour la prochaine feature.

(cherry picked from commit f87c3ed1e137480748c3e862dfe2272554cfb768)
