### PR TITLE
feat(core): Allow to use secure cookies on https instances

### DIFF
--- a/packages/core/analytics/src/analytics.service.ts
+++ b/packages/core/analytics/src/analytics.service.ts
@@ -36,6 +36,7 @@ export class AnalyticsService {
     (() => {
       this.paq.push(['setTrackerUrl', url + '.php']);
       this.paq.push(['setSiteId', this.options.id]);
+      this.paq.push(['setSecureCookie', location.protocol === 'https:']);
       const g = document.createElement('script');
       const s = document.getElementsByTagName('script')[0];
       g.type = 'text/javascript';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Current cookies defined by Matomo are unsecure by default.

**What is the new behavior?**
Ensure to have secured cookies on https
![image](https://github.com/user-attachments/assets/646ecdfc-b083-4df3-af50-a8ae6d4f4c7d)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
