### PR TITLE
fix(core): language add static loader and options to ignores libs locale

### DIFF
--- a/packages/core/language/src/shared/language.interface.ts
+++ b/packages/core/language/src/shared/language.interface.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 
 export interface LanguageOptions {
   prefix?: string | string[];
+  ignoreLibsLocale?: boolean;
 }
 
 export abstract class LanguageLoaderBase implements TranslateLoader {

--- a/packages/core/src/lib/core.module.ts
+++ b/packages/core/src/lib/core.module.ts
@@ -7,7 +7,11 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { IgoActivityModule } from '@igo2/core/activity';
 import { ConfigOptions, provideConfig } from '@igo2/core/config';
-import { IgoLanguageModule, provideTranslation } from '@igo2/core/language';
+import {
+  IgoLanguageModule,
+  provideTranslation,
+  withAsyncConfig
+} from '@igo2/core/language';
 import { provideMessage } from '@igo2/core/message';
 import { IgoErrorModule } from '@igo2/core/request';
 
@@ -27,7 +31,7 @@ export class IgoCoreModule {
   ): ModuleWithProviders<IgoCoreModule> {
     return {
       ngModule: IgoCoreModule,
-      providers: [provideConfig(options), provideTranslation()]
+      providers: [provideConfig(options), provideTranslation(withAsyncConfig())]
     };
   }
 }

--- a/projects/demo/src/main.ts
+++ b/projects/demo/src/main.ts
@@ -26,7 +26,7 @@ import { provideAuthentification } from '@igo2/auth';
 import { provideIcon } from '@igo2/common/icon';
 import { IgoCoreModule } from '@igo2/core';
 import { provideConfig } from '@igo2/core/config';
-import { provideTranslation } from '@igo2/core/language';
+import { provideTranslation, withStaticConfig } from '@igo2/core/language';
 
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routing';
@@ -61,7 +61,7 @@ bootstrapApplication(AppComponent, {
     provideConfig({
       default: environment.igo
     }),
-    provideTranslation(),
+    provideTranslation(withStaticConfig(environment.igo.language)),
     provideAuthentification(),
     provideIcon(),
     {


### PR DESCRIPTION
L'objectif est de permettre l'utilisation du module Language sans avoir besoin du module de Config. Aussi dans certain cas on veut l'utiliser sans nécessairement télécharger les fichiers de translation de la lib par exemple pour SDG, lorsqu'on utiliser les composantes de bases.

Cette PR est basé sur la branche fix/language, il y a aussi une branche correspondante pour l'assemblage

https://github.com/infra-geo-ouverte/igo2/pull/1169