### PR TITLE
fix(geo): datasource refresh implement event manager and add compatibility with workspace linked layer

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -130,6 +130,8 @@ export interface TileGridOptions {
   tileSizes?: [number, number][];
 }
 
-export type EventName = 'refresh';
+export type AnyEventName = EventRefresh;
+export const EventRefresh = 'refresh' as const;
+export type EventRefresh = typeof EventRefresh;
 
-export type DatasourceEvent = [EventName, Observable<unknown>];
+export type DatasourceEvent = [AnyEventName, Observable<unknown>];

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -1,6 +1,7 @@
 import type { Type } from 'ol/geom/Geometry';
 
 import { Encoders, Preset, Tokenizer } from 'flexsearch';
+import type { Observable } from 'rxjs';
 
 import { DownloadOptions } from '../../../download/shared/download.interface';
 import { OgcFilterOperatorType } from '../../../filter/shared/ogc-filter.enum';
@@ -128,3 +129,7 @@ export interface TileGridOptions {
   tileSize?: [number, number];
   tileSizes?: [number, number][];
 }
+
+export type EventName = 'refresh';
+
+export type DatasourceEvent = [EventName, Observable<unknown>];

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
@@ -2,10 +2,17 @@ import olClusterSource from 'ol/source/Cluster';
 import olSource from 'ol/source/Source';
 import olVectorSource from 'ol/source/Vector';
 
+import { Observable, Subscription } from 'rxjs';
+
 import { LegendOptions } from '../../../layer/shared/layers/legend.interface';
 import { generateIdFromSourceOptions } from '../../../utils/id-generator';
 import { DataService } from './data.service';
-import { DataSourceOptions, Legend } from './datasource.interface';
+import {
+  DataSourceOptions,
+  DatasourceEvent,
+  EventName,
+  Legend
+} from './datasource.interface';
 
 export abstract class DataSource {
   public id: string;
@@ -19,6 +26,8 @@ export abstract class DataSource {
       url: this.options.url
     };
   }
+
+  protected events = new Map<EventName, Subscription>();
 
   constructor(
     public options: DataSourceOptions = {},
@@ -49,6 +58,37 @@ export abstract class DataSource {
     }
 
     return this.legend;
+  }
+
+  refresh(): void {
+    this.ol.refresh();
+  }
+
+  addEvents(events: DatasourceEvent[] = []): void {
+    events.forEach(([name, observable]) => {
+      this.addEvent(name, observable);
+    });
+  }
+
+  removeEvents(): void {
+    Array.from(this.events.entries()).forEach(([name, event]) => {
+      event.unsubscribe();
+      this.events.delete(name);
+    });
+  }
+
+  private addEvent(name: EventName, obs: Observable<unknown>): void {
+    const subscription = this.events.get(name);
+    if (subscription) {
+      subscription.unsubscribe();
+    }
+    this.events.set(name, obs.subscribe());
+  }
+
+  public destroy(): void {
+    this.events.forEach((lisner) => {
+      lisner.unsubscribe();
+    });
   }
 
   protected abstract onUnwatch();

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
@@ -86,8 +86,8 @@ export abstract class DataSource {
   }
 
   public destroy(): void {
-    this.events.forEach((lisner) => {
-      lisner.unsubscribe();
+    this.events.forEach((listener) => {
+      listener.unsubscribe();
     });
   }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
@@ -8,9 +8,9 @@ import { LegendOptions } from '../../../layer/shared/layers/legend.interface';
 import { generateIdFromSourceOptions } from '../../../utils/id-generator';
 import { DataService } from './data.service';
 import {
+  AnyEventName,
   DataSourceOptions,
   DatasourceEvent,
-  EventName,
   Legend
 } from './datasource.interface';
 
@@ -27,7 +27,7 @@ export abstract class DataSource {
     };
   }
 
-  protected events = new Map<EventName, Subscription>();
+  protected events = new Map<AnyEventName, Subscription>();
 
   constructor(
     public options: DataSourceOptions = {},
@@ -77,7 +77,7 @@ export abstract class DataSource {
     });
   }
 
-  private addEvent(name: EventName, obs: Observable<unknown>): void {
+  private addEvent(name: AnyEventName, obs: Observable<unknown>): void {
     const subscription = this.events.get(name);
     if (subscription) {
       subscription.unsubscribe();

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
@@ -29,6 +29,8 @@ export abstract class DataSource {
 
   protected events = new Map<AnyEventName, Subscription>();
 
+  properties = new DatasourceProperties();
+
   constructor(
     public options: DataSourceOptions = {},
     protected dataService?: DataService
@@ -92,4 +94,31 @@ export abstract class DataSource {
   }
 
   protected abstract onUnwatch();
+}
+
+class DatasourceProperties {
+  /** General object to store general properties */
+  private properties = new Map<string, unknown>();
+
+  get(key: string): unknown {
+    return this.properties.get(key);
+  }
+
+  getAll(): Record<string, unknown> {
+    return { ...Object.fromEntries(this.properties.entries()) };
+  }
+
+  set(key: string, value: unknown): void {
+    this.properties.set(key, value);
+  }
+
+  setMany(object: Record<string, unknown>): void {
+    Object.entries(object).forEach(([key, value]) =>
+      this.properties.set(key, value)
+    );
+  }
+
+  delete(key: string): void {
+    this.properties.delete(key);
+  }
 }

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -18,6 +18,7 @@ import {
   OgcFiltersOptions
 } from '../../../filter/shared/ogc-filter.interface';
 import { DataSource } from './datasource';
+import { EventRefresh } from './datasource.interface';
 import { WFSDataSourceOptions } from './wfs-datasource.interface';
 import { WFSService } from './wfs.service';
 import {
@@ -120,6 +121,13 @@ export class WFSDataSource extends DataSource {
 
   public onUnwatch() {
     // empty
+  }
+
+  refresh(): void {
+    this.ol.setProperties({
+      [EventRefresh]: Math.random()
+    });
+    super.refresh();
   }
 
   fetchFeatures({

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -124,9 +124,7 @@ export class WFSDataSource extends DataSource {
   }
 
   refresh(): void {
-    this.ol.setProperties({
-      [EventRefresh]: Math.random()
-    });
+    this.properties.set(EventRefresh, Math.random());
     super.refresh();
   }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -18,7 +18,7 @@ import { TimeFilterOptions } from '../../../filter/shared/time-filter.interface'
 import { LegendMapViewOptions } from '../../../layer/shared/layers/legend.interface';
 import { QueryHtmlTarget } from '../../../query/shared/query.enums';
 import { DataSource } from './datasource';
-import { DatasourceEvent, Legend } from './datasource.interface';
+import { DatasourceEvent, EventRefresh, Legend } from './datasource.interface';
 import { WFSService } from './wfs.service';
 import {
   TimeFilterableDataSourceOptions,
@@ -122,8 +122,6 @@ export class WMSDataSource extends DataSource {
     sourceParams.DPI = dpi;
     sourceParams.MAP_RESOLUTION = dpi;
     sourceParams.FORMAT_OPTIONS = 'dpi:' + dpi;
-
-    this.addEvents();
 
     let fieldNameGeometry = defaultFieldNameGeometry;
 
@@ -263,18 +261,6 @@ export class WMSDataSource extends DataSource {
     }
   }
 
-  private addRefreshInterval(refreshInterval: number): Observable<number> {
-    const intervalMs = refreshInterval * 1000; // secondes to MS
-    return interval(intervalMs).pipe(
-      tap(() => {
-        this.ol.updateParams({ igoRefresh: Math.random() });
-        if (this.enableRefresh) {
-          this.ol.notify('refresh', this.enableRefresh);
-        }
-      })
-    );
-  }
-
   addEvents(): void {
     const events: DatasourceEvent[] = [];
 
@@ -284,14 +270,6 @@ export class WMSDataSource extends DataSource {
     }
 
     super.addEvents(events);
-  }
-
-  private buildDynamicDownloadUrlFromParamsWFS(asWFSDataSourceOptions) {
-    const queryStringValues = formatWFSQueryString(asWFSDataSourceOptions);
-    const downloadUrl = queryStringValues.find(
-      (f) => f.name === 'getfeature'
-    ).value;
-    return downloadUrl;
   }
 
   protected createOlSource(): olSourceImageWMS {
@@ -377,6 +355,26 @@ export class WMSDataSource extends DataSource {
 
   public onUnwatch() {
     // empty
+  }
+
+  private addRefreshInterval(refreshInterval: number): Observable<number> {
+    const intervalMs = refreshInterval * 1000; // secondes to MS
+    return interval(intervalMs).pipe(
+      tap(() => {
+        this.ol.updateParams({ [EventRefresh]: Math.random() });
+        if (this.enableRefresh) {
+          this.ol.notify('refresh', this.enableRefresh);
+        }
+      })
+    );
+  }
+
+  private buildDynamicDownloadUrlFromParamsWFS(asWFSDataSourceOptions) {
+    const queryStringValues = formatWFSQueryString(asWFSDataSourceOptions);
+    const downloadUrl = queryStringValues.find(
+      (f) => f.name === 'getfeature'
+    ).value;
+    return downloadUrl;
   }
 }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -266,7 +266,7 @@ export class WMSDataSource extends DataSource {
 
     const refreshInterval = this.options.refreshIntervalSec;
     if (refreshInterval && refreshInterval > 0) {
-      events.push(['refresh', this.addRefreshInterval(refreshInterval)]);
+      events.push([EventRefresh, this.addRefreshInterval(refreshInterval)]);
     }
 
     super.addEvents(events);
@@ -363,7 +363,7 @@ export class WMSDataSource extends DataSource {
       tap(() => {
         this.ol.updateParams({ [EventRefresh]: Math.random() });
         if (this.enableRefresh) {
-          this.ol.notify('refresh', this.enableRefresh);
+          this.ol.notify(EventRefresh, this.enableRefresh);
         }
       })
     );

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-wfs.utils.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-wfs.utils.ts
@@ -21,6 +21,7 @@ import {
   OgcInterfaceFilterOptions,
   OgcSelectorFields
 } from '../../../filter/shared/ogc-filter.interface';
+import { EventRefresh } from './datasource.interface';
 import { WFSDataSourceOptions } from './wfs-datasource.interface';
 import { WMSDataSourceOptions } from './wms-datasource.interface';
 
@@ -169,6 +170,10 @@ export function formatWFSQueryString(
   const getCapabilities = `${url}${separator}service=WFS&request=GetCapabilities&${version}`;
   let getFeature = `${url}${separator}service=WFS&request=GetFeature&${version}&${featureTypes}&`;
   getFeature += `${outputFormat}&${srs}&${cnt}&${propertyName}&${effectiveStartIndex}`;
+
+  if (dataSourceOptions[EventRefresh]) {
+    getFeature += `&${EventRefresh}=${dataSourceOptions[EventRefresh]}`;
+  }
 
   let getpropertyvalue = `${url}?service=WFS&request=GetPropertyValue&version=${versionWfs200}&${featureTypes}&`;
   getpropertyvalue += `&${cnt}&${valueReference}`;

--- a/packages/geo/src/lib/layer/shared/layers/layer-base.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer-base.ts
@@ -203,6 +203,7 @@ export abstract class LayerBase {
     this.parent
       ? this.parent.removeChild(this)
       : this.map.ol.removeLayer(this.ol);
+    this.dataSource?.destroy();
   }
 
   reset(parent?: LayerGroupBase): void {

--- a/packages/geo/src/lib/layer/shared/layers/layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.ts
@@ -101,6 +101,10 @@ export abstract class Layer extends LayerBase {
       this.legend = this.dataSource.setLegend(options.legendOptions);
     }
 
+    if (this.visible) {
+      this.dataSource.addEvents();
+    }
+
     this.ol = this.createOlLayer();
     this.ol.set('_layer', this, true);
 

--- a/packages/geo/src/lib/layer/shared/layers/layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/layer.ts
@@ -48,6 +48,8 @@ export abstract class Layer extends LayerBase {
         .filter((m) => m.options?.showOnEachLayerVisibility)
         .map((message) => this.showMessage(message));
     }
+
+    value ? this.dataSource.addEvents() : this.dataSource.removeEvents();
   }
 
   get maxResolution() {

--- a/packages/geo/src/lib/layer/shared/layers/linked/linked-layer.interface.ts
+++ b/packages/geo/src/lib/layer/shared/layers/linked/linked-layer.interface.ts
@@ -32,5 +32,6 @@ export enum LinkedProperties {
   MINRESOLUTION = 'minResolution',
   MAXRESOLUTION = 'maxResolution',
   ZINDEX = 'zIndex',
-  TIMEFILTER = 'timeFilter'
+  TIMEFILTER = 'timeFilter',
+  REFRESH = 'refresh'
 }

--- a/packages/geo/src/lib/layer/shared/layers/linked/linked-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/linked/linked-layer.ts
@@ -303,6 +303,10 @@ export class Linked {
       return this.handleDisplayChange(change, layers);
     }
 
+    if (property === LinkedProperties.REFRESH) {
+      this.handleRefreshChanges(layers);
+    }
+
     handleLayerPropertyChange(layers, change, this.map.viewController);
   };
 
@@ -335,5 +339,11 @@ export class Linked {
 
       return linked.concat(layerFromLink);
     }, []);
+  }
+
+  private handleRefreshChanges(children: Layer[]) {
+    children.forEach((child) => {
+      child.dataSource.refresh();
+    });
   }
 }

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -468,7 +468,13 @@ export class VectorLayer extends Layer {
       this.abortRequests(vectorSource);
     }
 
-    const url = buildUrl(options, currentExtent, wfsProj, randomParam);
+    const properties = this.dataSource.ol.getProperties();
+    const url = buildUrl(
+      { ...options, ...properties },
+      currentExtent,
+      wfsProj,
+      randomParam
+    );
 
     const request: VectorRequest = {
       xhr: undefined,

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -468,7 +468,7 @@ export class VectorLayer extends Layer {
       this.abortRequests(vectorSource);
     }
 
-    const properties = this.dataSource.ol.getProperties();
+    const properties = this.dataSource.properties.getAll();
     const url = buildUrl(
       { ...options, ...properties },
       currentExtent,

--- a/packages/geo/src/lib/map/utils/layer-watcher.ts
+++ b/packages/geo/src/lib/map/utils/layer-watcher.ts
@@ -55,7 +55,8 @@ export class LayerWatcher extends Watcher {
         LinkedProperties.MINRESOLUTION,
         LinkedProperties.MAXRESOLUTION,
         LinkedProperties.ZINDEX,
-        LinkedProperties.DISPLAYED
+        LinkedProperties.DISPLAYED,
+        LinkedProperties.REFRESH
       ].includes(change.event.key as any)
     ) {
       return;

--- a/packages/geo/src/lib/workspace/shared/index.ts
+++ b/packages/geo/src/lib/workspace/shared/index.ts
@@ -5,3 +5,4 @@ export * from './feature-workspace.service';
 export * from './edition-workspace';
 export * from './edition-workspace.service';
 export * from './workspace.utils';
+export * from './workspace.interface';

--- a/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/wms-workspace.service.ts
@@ -98,6 +98,9 @@ export class WmsWorkspaceService {
     if (!layer.options.workspace?.maxResolution) {
       linkProperties.properties.push(LinkedProperties.MAXRESOLUTION);
     }
+    if (dataSource.options.refreshIntervalSec) {
+      linkProperties.properties.push(LinkedProperties.REFRESH);
+    }
 
     let clonedLinks: LayersLinkProperties[] = [];
     if (layer.options.linkedLayers.links) {

--- a/packages/geo/src/lib/workspace/shared/workspace.interface.ts
+++ b/packages/geo/src/lib/workspace/shared/workspace.interface.ts
@@ -1,0 +1,5 @@
+import { EditionWorkspace } from './edition-workspace';
+import { FeatureWorkspace } from './feature-workspace';
+import { WfsWorkspace } from './wfs-workspace';
+
+export type AnyWorkspace = WfsWorkspace | FeatureWorkspace | EditionWorkspace;


### PR DESCRIPTION
This fix the refresh interval that was not working. We implement it to work with WMS and WFS datasource. This usefull when we have a WMS that need to be refresh a certain interval and we could have a LinkedLayer for the workspace and this layer will also sync at the refresh if we add the configuration.

For testing add `"refreshIntervalSec": 2` to your WmsDatasourceOptions. You could also add a LinkedLayer with the `LinkedProperties.REFRESH` and it should refresh at the same time of it's parent