### PR TITLE
fix(geo): layer - adjust the cancellation of ongoing request

### DIFF
--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -131,10 +131,9 @@ export class WFSDataSource extends DataSource {
     const currentExtent = extent
       ? OlProj.transformExtent(extent, projection, wfsProj)
       : undefined;
-    const ogcFilters = this.ogcFilters;
 
     paramsWFS.srsName = paramsWFS.srsName || projection.getCode();
-    let url = buildUrl(this.options, currentExtent, wfsProj, ogcFilters);
+    let url = buildUrl(this.options, currentExtent, wfsProj);
 
     // Exportation want to fetch without extent/bbox restrictions
     if (!extent && url.includes('bbox')) {

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-wfs.utils.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-wfs.utils.ts
@@ -30,9 +30,9 @@ export function buildUrl(
   options: WFSDataSourceOptions,
   extent: Extent,
   proj: olProjection,
-  ogcFilters: OgcFiltersOptions,
   randomParam?: boolean
 ): string {
+  const ogcFilters = options.ogcFilters;
   const paramsWFS = options.paramsWFS;
   const queryStringValues = formatWFSQueryString(
     options,

--- a/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
+++ b/packages/geo/src/lib/workspace/shared/edition-workspace.service.ts
@@ -761,7 +761,6 @@ export class EditionWorkspaceService {
       layer.customWFSLoader(
         layer.ol.getSource(),
         layer.options.sourceOptions as WFSDataSourceOptions,
-        this.authInterceptor,
         extent,
         resolution,
         proj,


### PR DESCRIPTION
Refactor and fix cancellation of current request. We had a race condition when we zoom out quickly with a WFS that contains a lot of data. The calls were carried away and created an infinite loop