### PR TITLE
feat(geo): split the add catalog dialog in tabs, predefined catalog and custom services

### DIFF
--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.html
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.html
@@ -1,104 +1,69 @@
-<h1 mat-dialog-title class="mat-typography">
-  {{ 'igo.geo.catalog.library.addTitle' | translate }}
-</h1>
-<div mat-dialog-content class="mat-typography">
-  <form class="igo-form" [formGroup]="form">
-    <div class="igo-input-container">
-      <mat-form-field>
-        <input
-          type="text"
-          formControlName="title"
-          placeholder="{{ 'igo.geo.printForm.title' | translate }}"
-          matInput
-          [matAutocomplete]="auto2"
-        />
-        <mat-autocomplete
-          #auto2="matAutocomplete"
-          (optionSelected)="changeUrlOrTitle($event.option.value)"
-        >
-          <mat-option
-            *ngFor="let predefinedCatalog of predefinedCatalogsList$ | async"
-            matTooltipShowDelay="500"
-            [matTooltip]="predefinedCatalog.title"
-            [value]="predefinedCatalog"
-          >
-            {{ predefinedCatalog.title }}
-          </mat-option>
-        </mat-autocomplete>
-      </mat-form-field>
-    </div>
-    <div class="igo-input-container">
-      <mat-form-field>
-        <input
-          type="text"
-          formControlName="url"
-          placeholder="URL"
-          matInput
-          [matAutocomplete]="auto"
-        />
-        <mat-autocomplete
-          #auto="matAutocomplete"
-          (optionSelected)="changeUrlOrTitle($event.option.value)"
-        >
-          <mat-option
-            *ngFor="let predefinedCatalog of predefinedCatalogsList$ | async"
-            matTooltipShowDelay="500"
-            [matTooltip]="predefinedCatalog.url"
-            [value]="predefinedCatalog"
-          >
-            {{ predefinedCatalog.url }}
-          </mat-option>
-        </mat-autocomplete>
-      </mat-form-field>
-    </div>
-    <div class="igo-input-container">
-      <mat-form-field>
-        <mat-select formControlName="type" placeholder="Type">
-          <mat-option
-            *ngFor="let type of typeCapabilities"
-            [value]="type"
-            (click)="$event.stopPropagation()"
-          >
-            <p matListItemTitle>{{ type }}</p>
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-    </div>
-  </form>
-  <span *ngIf="error && addedCatalog && emailAddress">
-    <p class="error">
-      {{
-        languageService.translate.instant(
-          'igo.geo.catalog.externalProvider.unavailableWithEmail',
-          { value: addedCatalog.url, email: emailAddress }
-        )
-      }}
-    </p>
-  </span>
-  <span *ngIf="error && addedCatalog && !emailAddress">
-    <p class="error">
-      {{
-        languageService.translate.instant('igo.geo.catalog.unavailable', {
-          value: addedCatalog.url
-        })
-      }}
-    </p>
-  </span>
-</div>
-<div mat-dialog-actions style="justify-content: center">
-  <div class="igo-form-button-group add-catalog-button-top-padding">
-    <button mat-raised-button type="button" (click)="cancel()">
-      {{ 'igo.geo.catalog.library.cancel' | translate }}
-    </button>
-    <button
-      id="addCatalogBtnDialog"
-      mat-raised-button
-      type="button"
-      color="primary"
-      [disabled]="!form.valid"
-      (click)="addCatalog(form.value)"
+<mat-tab-group
+  [selectedIndex]="!data.addedCatalog && data.predefinedCatalogs.length ? 0 : 1"
+>
+  <mat-tab
+    [label]="'igo.geo.catalog.library.predefined' | translate"
+    [disabled]="!data.predefinedCatalogs.length"
+  >
+    <igo-form
+      *ngIf="predefinedForm$ | async as form"
+      [form]="form"
+      [formData]="data$ | async"
+      (submitForm)="onPredefinedSubmit($any($event))"
     >
-      {{ 'igo.geo.catalog.library.add' | translate }}
-    </button>
-  </div>
-</div>
+      <div *ngIf="form.fields.length" class="form-container">
+        <igo-form-field
+          *ngFor="let field of form.fields"
+          [field]="field"
+        ></igo-form-field>
+      </div>
+
+      <div formButtons class="actions-container">
+        <button mat-flat-button type="submit" color="primary">
+          {{ 'igo.geo.catalog.library.add' | translate }}
+        </button>
+      </div>
+    </igo-form>
+  </mat-tab>
+
+  <mat-tab class="tabs" [label]="'igo.geo.catalog.library.custom' | translate">
+    <igo-form
+      *ngIf="customForm$ | async as form"
+      [form]="form"
+      [formData]="customData$ | async"
+      (submitForm)="onCustomSubmit($any($event))"
+    >
+      <div *ngIf="form.fields.length" class="form-container">
+        <igo-form-field
+          *ngFor="let field of form.fields"
+          [field]="field"
+        ></igo-form-field>
+      </div>
+
+      <div formButtons class="actions-container">
+        <button mat-flat-button type="submit" color="primary">
+          {{ 'igo.geo.catalog.library.add' | translate }}
+        </button>
+      </div>
+    </igo-form>
+    <span *ngIf="data.error && data.addedCatalog && emailAddress">
+      <p class="error">
+        {{
+          languageService.translate.instant(
+            'igo.geo.catalog.externalProvider.unavailableWithEmail',
+            { value: data.addedCatalog.url, email: emailAddress }
+          )
+        }}
+      </p>
+    </span>
+    <span *ngIf="data.error && data.addedCatalog && !emailAddress">
+      <p class="error">
+        {{
+          languageService.translate.instant('igo.geo.catalog.unavailable', {
+            value: data.addedCatalog.url
+          })
+        }}
+      </p>
+    </span>
+  </mat-tab>
+</mat-tab-group>

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.scss
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.scss
@@ -1,29 +1,27 @@
-mat-form-field {
-  width: 100%;
-}
+:host {
+  mat-tab-group {
+    padding: 10px;
+  }
+  igo-form {
+    overflow: hidden;
+  }
 
-.add-catalog-button-top-padding {
-  padding-top: 25px;
-}
+  .actions-container {
+    button:not(:last-child) {
+      margin-right: 8px;
+    }
+  }
+  .form-container {
+    width: 100%;
+    height: auto;
+    padding: 10px;
 
-.igo-form {
-  padding: 10px 5px 5px;
-}
-
-.igo-form-button-group {
-  text-align: center;
-}
-
-button {
-  cursor: pointer;
-}
-
-button#addCatalogBtnDialog[disabled='true'] {
-  cursor: default;
-  background-color: rgba(0, 0, 0, 0.12);
-  color: rgba(0, 0, 0, 0.26);
-}
-
-.error {
-  color: red;
+    igo-form-field {
+      display: block;
+      height: auto;
+    }
+  }
+  .error {
+    color: red;
+  }
 }

--- a/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-library/add-catalog-dialog.component.ts
@@ -1,29 +1,24 @@
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, Inject, OnDestroy, OnInit, Optional } from '@angular/core';
-import {
-  FormsModule,
-  ReactiveFormsModule,
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators
-} from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatOptionModule } from '@angular/material/core';
-import {
-  MAT_DIALOG_DATA,
-  MatDialogActions,
-  MatDialogContent,
-  MatDialogRef,
-  MatDialogTitle
-} from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatSelectModule } from '@angular/material/select';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { EntityStore } from '@igo2/common/entity';
+import {
+  Form,
+  FormComponent,
+  FormFieldComponent,
+  FormService
+} from '@igo2/common/form';
 import { ConfigService } from '@igo2/core/config';
 import { LanguageService } from '@igo2/core/language';
 import { IgoLanguageModule } from '@igo2/core/language';
@@ -39,42 +34,36 @@ import { Catalog } from '../shared/catalog.abstract';
   styleUrls: ['./add-catalog-dialog.component.scss'],
   standalone: true,
   imports: [
-    MatDialogTitle,
-    MatDialogContent,
     FormsModule,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,
     MatAutocompleteModule,
+    MatTabsModule,
     NgFor,
     MatOptionModule,
     MatTooltipModule,
     MatSelectModule,
     MatListModule,
     NgIf,
-    MatDialogActions,
     MatButtonModule,
     AsyncPipe,
-    IgoLanguageModule
+    IgoLanguageModule,
+    FormComponent,
+    FormFieldComponent
   ]
 })
 export class AddCatalogDialogComponent implements OnInit, OnDestroy {
-  public form: UntypedFormGroup;
-  private defaultAddedCatalogType = 'wms';
-  private addedCatalogType$$: Subscription;
-  public predefinedCatalogsList$ = new BehaviorSubject<Catalog[]>([]);
-  typeCapabilities: string[];
-  predefinedCatalogs: Catalog[] = [];
-  store: EntityStore<Catalog>;
-  error = false;
-  addedCatalog: Catalog;
+  predefinedForm$ = new BehaviorSubject<Form>(undefined);
+  customForm$ = new BehaviorSubject<Form>(undefined);
+  data$ = new BehaviorSubject<Catalog>(undefined);
+  customData$ = new BehaviorSubject<Catalog>(undefined);
   emailAddress: string;
   private storeViewAll$$: Subscription;
-
   constructor(
-    private formBuilder: UntypedFormBuilder,
     public languageService: LanguageService,
     private configService: ConfigService,
+    private formService: FormService,
     public dialogRef: MatDialogRef<AddCatalogDialogComponent>,
     @Optional()
     @Inject(MAT_DIALOG_DATA)
@@ -84,66 +73,112 @@ export class AddCatalogDialogComponent implements OnInit, OnDestroy {
       error: boolean;
       addedCatalog: Catalog;
     }
-  ) {
-    this.store = data.store;
-    this.predefinedCatalogs = data.predefinedCatalogs;
-    this.error = data.error;
-    this.addedCatalog = data.addedCatalog;
-    this.form = this.formBuilder.group({
-      id: ['', []],
-      title: ['', []],
-      url: ['', [Validators.required]],
-      type: [this.defaultAddedCatalogType, [Validators.required]]
-    });
-  }
+  ) {}
 
   ngOnInit() {
-    this.store.state.clear();
-    this.typeCapabilities = Object.keys(TypeCapabilities);
+    if (this.data.addedCatalog) {
+      this.customData$.next(this.data.addedCatalog);
+    }
+    const types = Object.keys(TypeCapabilities).map((t) => {
+      return { value: t, title: t };
+    });
+    this.storeViewAll$$ = this.data.store.view.all$().subscribe(() => {
+      const predefinedChoices = this.data.predefinedCatalogs
+        .filter((c) => !this.data.store.get(c.id))
+        .map((predefinedCatalog) => {
+          return {
+            value: predefinedCatalog.id,
+            title: predefinedCatalog.title
+          };
+        });
 
-    this.addedCatalogType$$ = this.form
-      .get('type')
-      .valueChanges.subscribe((value) => {
-        if (value === 'wmts') {
-          this.form.get('title').setValidators(Validators.required);
-        } else {
-          this.form.get('title').setValidators([]);
+      const predefinedFieldConfigs = [
+        {
+          name: 'id',
+          title: this.languageService.translate.instant(
+            'igo.geo.catalog.library.predefined.select'
+          ),
+          type: 'select',
+          options: {
+            cols: 1,
+            validator: Validators.required
+          },
+          inputs: {
+            choices: predefinedChoices
+          }
         }
-        this.form.get('title').updateValueAndValidity();
-      });
-
-    this.computePredefinedCatalogList();
-    this.storeViewAll$$ = this.store.view
-      .all$()
-      .subscribe(() => this.computePredefinedCatalogList());
-
+      ];
+      const predefinedFormFields = predefinedFieldConfigs.map((config) =>
+        this.formService.field(config)
+      );
+      this.predefinedForm$.next(
+        this.formService.form(predefinedFormFields, [])
+      );
+    });
+    const customFieldConfigs = [
+      {
+        name: 'title',
+        title: this.languageService.translate.instant(
+          'igo.geo.catalog.library.custom.title'
+        ),
+        type: 'text',
+        options: {
+          validator: Validators.required
+        }
+      },
+      {
+        name: 'url',
+        title: 'URL',
+        type: 'text',
+        options: {
+          validator: Validators.required
+        }
+      },
+      {
+        name: 'type',
+        title: 'Type',
+        type: 'select',
+        options: {
+          cols: 1,
+          validator: Validators.required
+        },
+        inputs: {
+          choices: types
+        }
+      }
+    ];
+    const customFieldFormFields = customFieldConfigs.map((config) =>
+      this.formService.field(config)
+    );
+    this.customForm$.next(this.formService.form(customFieldFormFields, []));
     this.emailAddress = this.configService.getConfig('emailAddress');
   }
 
+  onPredefinedSubmit(data: Catalog) {
+    const catalog = this.data.predefinedCatalogs.find((c) => c.id === data.id);
+    if (this.checkFieldsValidity(this.predefinedForm$)) {
+      this.dialogRef.close(catalog);
+    }
+  }
+  onCustomSubmit(catalog: Catalog) {
+    if (this.checkFieldsValidity(this.customForm$)) {
+      this.dialogRef.close(catalog);
+    }
+  }
   ngOnDestroy() {
-    this.addedCatalogType$$.unsubscribe();
-    this.storeViewAll$$.unsubscribe();
+    this.storeViewAll$$?.unsubscribe();
   }
 
-  changeUrlOrTitle(catalog: Catalog) {
-    this.form.patchValue(catalog);
-    this.error = false;
-    this.computePredefinedCatalogList();
-  }
-
-  computePredefinedCatalogList() {
-    this.predefinedCatalogsList$.next(
-      this.predefinedCatalogs.filter((c) => !this.store.get(c.id))
-    );
-  }
-
-  addCatalog(addedCatalog: Catalog) {
-    this.error = false;
-    this.dialogRef.close(addedCatalog);
-  }
-
-  cancel() {
-    this.error = false;
-    this.dialogRef.close();
+  checkFieldsValidity(form$: BehaviorSubject<Form>): boolean {
+    const fields = form$.getValue().fields;
+    return fields
+      .map((field) => {
+        if (field.control.invalid) {
+          field.control.markAsTouched();
+          field.control.updateValueAndValidity();
+        }
+        return field.control.valid;
+      })
+      .every((e) => e);
   }
 }

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -19,14 +19,16 @@
           "layer": "This layer comes from an external organization.",
           "unavailableWithEmail": "The catalog '{{value}}' is unavailable at the moment. To add an external service to the predefined list, please contact us at {{emailAddress}}. Delays can apply if problems occurs with the provider."
         },
+        "library.predefined.select": "Select a catalog",
+        "library.custom.title": "Title",
         "library.add": "Add this catalog to the list",
-        "library.cancel": "Cancel",
+        "library.predefined": "Predefined list",
+        "library.custom": "Advanced configuration",
         "library.remove": "Remove this catalog from the list",
         "library.inlist": {
           "title": "Catalog already contained",
           "message": "The catalog is already contained in the list."
         },
-        "library.addTitle": "Adding a catalog",
         "library.addBtn": "Add a catalog"
       },
       "clickOnMap": {

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -19,14 +19,16 @@
           "layer": "Cette couche provient d'une organisation externe.",
           "unavailableWithEmail": "Le catalogue '{{value}}' est indisponible pour le moment. Pour ajouter un service externe à la liste prédéfinie, veuillez contacter {{email}}. Des délais peuvent s'appliquer si problème il y a avec le fournisseur externe."
         },
+        "library.predefined.select": "Sélectionner un catalogue",
+        "library.custom.title": "Titre",
         "library.add": "Ajouter ce catalogue",
-        "library.cancel": "Annuler",
+        "library.predefined": "Liste prédéfinie",
+        "library.custom": "Configuration avancées",
         "library.remove": "Retirer ce catalogue de la liste",
         "library.inlist": {
           "title": "Catalogue déjà contenu",
           "message": "Le catalogue à ajouter est déjà dans la liste"
         },
-        "library.addTitle": "Ajout d'un catalogue",
         "library.addBtn": "Ajouter un catalogue"
       },
       "clickOnMap": {

--- a/projects/demo/src/app/geo/catalog/catalog.component.html
+++ b/projects/demo/src/app/geo/catalog/catalog.component.html
@@ -12,6 +12,7 @@
 
     <igo-panel title="Catalog Library">
       <igo-catalog-library
+        [addCatalogAllowed]="true"
         [store]="$any(catalogStore)"
         (catalogSelectChange)="onCatalogSelectChange($event)"
       >


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
If we configure composite catalogs to be added to the predefined list, the catalogs is not added to the catalog store.
refer to  https://github.com/infra-geo-ouverte/igo2-lib/issues/1631

**What is the new behavior?**
Refactor the add catalog dialog to split predefined catalog and custom catalogs. 


![chrome_2024-02-08_10-10-34](https://github.com/infra-geo-ouverte/igo2-lib/assets/7397743/900c7390-efd6-4529-a8cd-8ba7fc512dcb)



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**


**Other information**:
