### PR TITLE
feat(search): add reset options functionality to search source options

### DIFF
--- a/packages/geo/src/lib/query/shared/query-search-source.ts
+++ b/packages/geo/src/lib/query/shared/query-search-source.ts
@@ -25,7 +25,7 @@ export class QuerySearchSource extends SearchSource {
     return QuerySearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     return {
       title: 'Carte'
     };

--- a/packages/geo/src/lib/search/search-bar/search-bar.component.html
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.html
@@ -52,6 +52,7 @@
     <igo-search-settings
       *ngIf="searchSettings"
       [pointerSummaryEnabled]="pointerSummaryEnabled"
+      [allowResetSearchSourcesOptions]="allowResetSearchSourcesOptions"
       (pointerSummaryStatus)="pointerSummaryStatus.emit($event)"
       [searchResultsGeometryEnabled]="searchResultsGeometryEnabled"
       (searchResultsGeometryStatus)="searchResultsGeometryStatus.emit($event)"

--- a/packages/geo/src/lib/search/search-bar/search-bar.component.ts
+++ b/packages/geo/src/lib/search/search-bar/search-bar.component.ts
@@ -167,6 +167,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   readonly disabled$ = new BehaviorSubject<boolean>(false);
 
   @Input() pointerSummaryEnabled = false;
+  @Input() allowResetSearchSourcesOptions = true;
   @Input() searchResultsGeometryEnabled = false;
 
   /**

--- a/packages/geo/src/lib/search/search-settings/search-settings.component.html
+++ b/packages/geo/src/lib/search/search-settings/search-settings.component.html
@@ -172,6 +172,15 @@
           {{ 'igo.geo.search.reverseCoordFormat.title' | translate }}
         </mat-slide-toggle>
       </div>
+      <div mat-menu-item *ngIf="allowResetSearchSourcesOptions">
+        <button
+          mat-raised-button
+          class="check-default-button"
+          (click)="resetSourceOptions($event)"
+        >
+          {{ 'igo.geo.search.searchSources.settings.reset.button' | translate }}
+        </button>
+      </div>
     </span>
   </mat-menu>
 </div>

--- a/packages/geo/src/lib/search/search-settings/search-settings.component.ts
+++ b/packages/geo/src/lib/search/search-settings/search-settings.component.ts
@@ -8,6 +8,7 @@ import {
   OnInit,
   Output
 } from '@angular/core';
+import { Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import {
   MatCheckboxChange,
@@ -20,8 +21,14 @@ import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
+import {
+  FormDialogService,
+  FormFieldConfig,
+  IgoFormDialogModule
+} from '@igo2/common/form';
 import { IgoLanguageModule } from '@igo2/core/language';
 import { MediaService } from '@igo2/core/media';
+import { MessageService } from '@igo2/core/message';
 import { StorageService } from '@igo2/core/storage';
 
 import { SearchSourceService } from '../shared/search-source.service';
@@ -62,6 +69,7 @@ import {
     MatRadioModule,
     MatDividerModule,
     MatSlideToggleModule,
+    IgoFormDialogModule,
     IgoLanguageModule
   ]
 })
@@ -81,6 +89,7 @@ export class SearchSettingsComponent implements OnInit {
   @Input() pointerSummaryEnabled = false;
   @Input() searchResultsGeometryEnabled = false;
   @Input() reverseSearchCoordsFormatEnabled = false;
+  @Input() allowResetSearchSourcesOptions = true;
 
   /**
    * Event emitted when the enabled search source changes
@@ -111,6 +120,8 @@ export class SearchSettingsComponent implements OnInit {
   }
 
   constructor(
+    private formDialogService: FormDialogService,
+    private messageService: MessageService,
     private searchSourceService: SearchSourceService,
     private mediaService: MediaService,
     private storageService: StorageService
@@ -202,6 +213,56 @@ export class SearchSettingsComponent implements OnInit {
     ).length;
     this.searchSourcesAllEnabled =
       enabledSourcesCnt >= disabledSourcesCnt ? false : true;
+  }
+
+  resetSourceOptions(event) {
+    event.stopPropagation();
+    const formFieldConfigs: FormFieldConfig[] = [
+      {
+        name: 'sources',
+        title:
+          'igo.geo.search.searchSources.settings.reset.dialog.form.field.title',
+        type: 'select',
+        options: {
+          cols: 2,
+          validator: Validators.required
+        },
+        inputs: {
+          multiple: true,
+          choices: this.getSearchSources()
+            .filter((s) => s.settings.length)
+            .map((source) => {
+              return {
+                value: source,
+                title: source.title
+              };
+            })
+        }
+      }
+    ];
+
+    this.formDialogService
+      .open(
+        { formFieldConfigs },
+        {
+          minWidth: '50vw',
+          minHeight: '15vh',
+          title: 'igo.geo.search.searchSources.settings.reset.dialog.title'
+        }
+      )
+      .subscribe((data) => {
+        if (data) {
+          data.sources.forEach((source) => {
+            source.resetSourceOptions();
+            this.searchSourceChange.emit(source);
+          });
+          const message =
+            data.sources.length > 1
+              ? 'igo.geo.search.searchSources.settings.reset.notice.multiple'
+              : 'igo.geo.search.searchSources.settings.reset.notice.single';
+          this.messageService.success(message);
+        }
+      });
   }
 
   /**

--- a/packages/geo/src/lib/search/shared/sources/cadastre.ts
+++ b/packages/geo/src/lib/search/shared/sources/cadastre.ts
@@ -50,7 +50,7 @@ export class CadastreSearchSource extends SearchSource implements TextSearch {
   /*
    * Source : https://wiki.openstreetmap.org/wiki/Key:amenity
    */
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     return {
       title: 'Cadastre (Québec)',
       searchUrl: 'https://carto.cptaq.gouv.qc.ca/php/find_lot_v1.php?'

--- a/packages/geo/src/lib/search/shared/sources/coordinates.ts
+++ b/packages/geo/src/lib/search/shared/sources/coordinates.ts
@@ -78,7 +78,7 @@ export class CoordinatesReverseSearchSource
     return CoordinatesReverseSearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     return {
       title: 'igo.geo.search.coordinates.name',
       order: 1,

--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -75,6 +75,17 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
   static propertiesBlacklist: string[] = [];
   title$: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
+  static defaultIchercheTypes = [
+    'adresses',
+    'codes-postaux',
+    'routes',
+    'intersections',
+    'municipalites',
+    'mrc',
+    'regadmin',
+    'lieux'
+  ];
+
   private hashtagsLieuxToKeep = [];
 
   get title(): string {
@@ -118,7 +129,7 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
     return IChercheSearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     const limit =
       this.options.params && this.options.params.limit
         ? Number(this.options.params.limit)
@@ -130,16 +141,7 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
 
     const types = this.options.params?.type
       ? this.options.params.type.replace(/\s/g, '').toLowerCase().split(',')
-      : [
-          'adresses',
-          'codes-postaux',
-          'routes',
-          'intersections',
-          'municipalites',
-          'mrc',
-          'regadmin',
-          'lieux'
-        ];
+      : IChercheSearchSource.defaultIchercheTypes;
 
     const showAdvancedParams = this.options.showAdvancedSettings;
 
@@ -404,7 +406,7 @@ export class IChercheSearchSource extends SearchSource implements TextSearch {
       catchError((err) => {
         err.error.toDisplay = true;
         err.error.title = this.languageService.translate.instant(
-          this.getDefaultOptions().title
+          this.defaultOptions.title
         );
         throw err;
       })
@@ -682,6 +684,13 @@ export class IChercheReverseSearchSource
   static type = FEATURE;
   static propertiesBlacklist: string[] = [];
 
+  static defaultIchercheTypes = [
+    'adresses',
+    'municipalites',
+    'mrc',
+    'regadmin'
+  ];
+
   title$: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
   get title(): string {
@@ -723,11 +732,11 @@ export class IChercheReverseSearchSource
     return IChercheReverseSearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     const types =
       this.options.params && this.options.params.type
         ? this.options.params.type.replace(/\s/g, '').toLowerCase().split(',')
-        : ['adresses', 'municipalites', 'mrc', 'regadmin'];
+        : IChercheReverseSearchSource.defaultIchercheTypes;
 
     return {
       title: 'igo.geo.search.ichercheReverse.name',

--- a/packages/geo/src/lib/search/shared/sources/ilayer.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.ts
@@ -104,7 +104,7 @@ export class ILayerSearchSource extends SearchSource implements TextSearch {
     return ILayerSearchSource.type;
   }
 
-  protected getDefaultOptions(): ILayerSearchSourceOptions {
+  protected getEffectiveOptions(): ILayerSearchSourceOptions {
     const limit =
       this.options.params && this.options.params.limit
         ? Number(this.options.params.limit)

--- a/packages/geo/src/lib/search/shared/sources/nominatim.ts
+++ b/packages/geo/src/lib/search/shared/sources/nominatim.ts
@@ -46,7 +46,7 @@ export class NominatimSearchSource extends SearchSource implements TextSearch {
   /*
    * Source : https://wiki.openstreetmap.org/wiki/Key:amenity
    */
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     return {
       title: 'Nominatim (OSM)',
       searchUrl: 'https://nominatim.openstreetmap.org/search',

--- a/packages/geo/src/lib/search/shared/sources/source.ts
+++ b/packages/geo/src/lib/search/shared/sources/source.ts
@@ -30,6 +30,7 @@ export class SearchSource {
    * @internal
    */
   protected options: SearchSourceOptions;
+  protected defaultOptions: SearchSourceOptions = {};
 
   /**
    * Get search source's id
@@ -50,8 +51,8 @@ export class SearchSource {
    * Get search source's default options
    * @returns Search source default options
    */
-  protected getDefaultOptions(): SearchSourceOptions {
-    throw new Error('You have to implement the method "getDefaultOptions".');
+  protected getEffectiveOptions(): SearchSourceOptions {
+    throw new Error('You have to implement the method "getEffectiveOptions".');
   }
 
   /**
@@ -116,6 +117,10 @@ export class SearchSource {
     return this._featureStoresWithIndex;
   }
   private _featureStoresWithIndex: FeatureStore[];
+
+  public resetSourceOptions() {
+    this.options = ObjectUtils.copyDeep(this.defaultOptions);
+  }
 
   setWorkspaces(workspaces: Workspace[]) {
     if (
@@ -194,6 +199,10 @@ export class SearchSource {
     private storageService?: StorageService
   ) {
     this.options = options;
+    this.defaultOptions = ObjectUtils.mergeDeep(
+      this.getEffectiveOptions(),
+      this.options
+    );
     if (this.storageService) {
       const storageOptions = this.storageService.get(
         this.getId() + '.options'
@@ -204,7 +213,7 @@ export class SearchSource {
     }
 
     this.options = ObjectUtils.mergeDeep(
-      this.getDefaultOptions(),
+      this.getEffectiveOptions(),
       this.options
     );
 
@@ -258,7 +267,7 @@ export class SearchSource {
   }
 
   getSettingsValues(search: string): SearchSourceSettings {
-    return this.getDefaultOptions().settings.find(
+    return this.getEffectiveOptions().settings.find(
       (value: SearchSourceSettings) => {
         return value.name === search;
       }

--- a/packages/geo/src/lib/search/shared/sources/storedqueries.ts
+++ b/packages/geo/src/lib/search/shared/sources/storedqueries.ts
@@ -149,7 +149,7 @@ export class StoredQueriesSearchSource
     return StoredQueriesSearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     return {
       title: 'Stored Queries',
       searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq'
@@ -452,7 +452,7 @@ export class StoredQueriesReverseSearchSource
     return StoredQueriesReverseSearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     return {
       title: 'Stored Queries (reverse)',
       searchUrl: 'https://ws.mapserver.transports.gouv.qc.ca/swtq'

--- a/packages/geo/src/lib/search/shared/sources/workspace.ts
+++ b/packages/geo/src/lib/search/shared/sources/workspace.ts
@@ -49,7 +49,7 @@ export class WorkspaceSearchSource extends SearchSource implements TextSearch {
     return WorkspaceSearchSource.type;
   }
 
-  protected getDefaultOptions(): SearchSourceOptions {
+  protected getEffectiveOptions(): SearchSourceOptions {
     const limit = 5;
 
     return {

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -578,6 +578,17 @@
           "selectAll": "Select All",
           "unselectAll": "Unselect All",
           "settings": {
+            "reset": {
+              "button": "Reset search options",
+              "dialog": {
+                "title": "Choose search services to reset",
+                "form.field.title": "Choose search service(s)"
+              },
+              "notice": {
+                "multiple": "The options for the selected search services have been reset.",
+                "single": "The options for the selected search service have been reset."
+              }
+            },
             "datasets": "Datasets",
             "results type": "Results type",
             "ecmax": "Maximum deviation",

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -577,6 +577,17 @@
           "selectAll": "Tout sélectionner",
           "unselectAll": "Tout désélectionner",
           "settings": {
+            "reset": {
+              "button": "Réinitialiser les options de recherche",
+              "dialog": {
+                "title": "Choisir les services de recherche à réinitialiser",
+                "form.field.title": "Choisir le(s) service(s) de recherche"
+              },
+              "notice": {
+                "multiple": "Les options des services de recherche sélectionnés ont été réinitialisés.",
+                "single": "Les options du service de recherche sélectionné ont été réinitialisés."
+              }
+            },
             "datasets": "Jeu de données",
             "results type": "Type de résultat",
             "ecmax": "Écart maximal",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
There is no way to reset the seach sources options. 
**What is the new behavior?**
Add a button/method to reset/store the default options from each search sources.
Configurable with a parameter. 

See the PR in the IGO2 project to test along. 


https://github.com/user-attachments/assets/d8c0c35b-8d84-477a-9c86-f569b9a0af4a



**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**

**Other information**:
