### PR TITLE
fix(geo): issue#1168 in igo2 - eye group layer button

### DIFF
--- a/packages/geo/src/lib/layer/layer-viewer-bottom-actions/layer-viewer-bottom-actions.component.ts
+++ b/packages/geo/src/lib/layer/layer-viewer-bottom-actions/layer-viewer-bottom-actions.component.ts
@@ -173,9 +173,15 @@ export class LayerViewerBottomActionsComponent {
     this.opacity = event.value;
   }
 
-  toggleSelectionVisibility(): void {
-    this.selected.forEach((layer) => {
-      layer.visible = !layer.visible;
+  toggleSelectionVisibility(
+    layers = this.selected,
+    visibility = this.allSelectionVisibilityHidden
+  ): void {
+    layers.forEach((layer) => {
+      layer.visible = visibility;
+      if (isLayerGroup(layer)) {
+        this.toggleSelectionVisibility(layer.children, visibility);
+      }
     });
     this.layerChange.emit();
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

What is the current behavior? (You can also link to an open here)
This PR fix the IGO2 issue https://github.com/infra-geo-ouverte/igo2-lib/issues/1168 (the issue is not in igo2-lib) but for the IGO2-lib trunk and not for foret ouverte.
The problem was that clicking on the eye button to change the visiblity of many selected layers at the same time did not render then all visible or all invisible. It way only togging the visibility status (visible = !visible) .

What is the new behavior?
Now if any layer are visible (first click) make them all invisible and then (second click) all visible.
Layers in a layer group are also changed.

Does this PR introduce a breaking change? (check one with "x")

- [ ] Yes
- [ x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**

**Other information**:
