### PR TITLE
fix(geo): reorder parameters to pass "code" params over user params

### DIFF
--- a/packages/geo/src/lib/search/shared/sources/icherche.ts
+++ b/packages/geo/src/lib/search/shared/sources/icherche.ts
@@ -958,8 +958,8 @@ export class IChercheReverseSearchSource
           geometry: true,
           icon: true
         },
-        options.params || {},
-        this.params
+        this.params,
+        options.params || {}
       )
     });
   }


### PR DESCRIPTION
In terrapi, there is no way to call this service without considering users parameters 

<img width="375" height="323" alt="image" src="https://github.com/user-attachments/assets/233c6cf1-c4ee-4294-bd87-e5e61f4e2297" />

With this change, you could pass params within code, without being overided by user params.
```
            this.searchService
              .reverseSearch(stopToSearch.coordinates, {
                params: { type: 'adresses' }
              })
```