### PR TITLE
fix(geo): guard sourceOptions.url in VectorLayer IDB sync to prevent import crash

### DIFF
--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -333,7 +333,7 @@ export class VectorLayer extends Layer {
     const geoDB = new GeoDB();
     geoDB
       .update(
-        this.options.sourceOptions?.url || this.id.toString(),
+        this.options?.sourceOptions?.url || this.id.toString(),
         this.id,
         geojsonObject,
         InsertSourceInsertDBEnum.User,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

When a vector layer is created from imported file data (e.g. Shapefile/GeoJSON/KML), `VectorLayer.maintainFeaturesInIdb()` can throw:
`TypeError: Cannot read properties of undefined (reading 'url')`.

Root cause: the method assumes `this.options.sourceOptions` always exists and directly reads `this.options.sourceOptions.url`.  
In some import flows, `sourceOptions` is not defined, even though the layer is valid.

**What is the new behavior?**

`maintainFeaturesInIdb()` now safely resolves the URL with optional chaining:
- from `this.options.sourceOptions.url || this.id.toString()`
- to `this.options?.sourceOptions?.url || this.id.toString()`

If `sourceOptions` is missing, no crash occurs and the existing fallback to `layer id` is used.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**

N/A

**Other information**:

This is a minimal, backward-compatible bug fix in the library.  
Behavior is unchanged when `sourceOptions.url` is present; only the error path is fixed for import-created vector layers.
