### PR TITLE
chore: tsconfig remove deprecated baseUrl  and disable strict types

### DIFF
--- a/packages/auth/monitoring/src/auth-monitoring/auth-monitoring.service.spec.ts
+++ b/packages/auth/monitoring/src/auth-monitoring/auth-monitoring.service.spec.ts
@@ -12,8 +12,8 @@ import {
 } from '@igo2/core/monitoring';
 
 import { ToastrModule, ToastrService } from 'ngx-toastr';
-import { mergeTestConfig } from 'packages/auth/test-config';
 
+import { mergeTestConfig } from '../../../test-config';
 import { AuthMonitoringService } from './auth-monitoring.service';
 
 const initialize = (

--- a/packages/auth/src/lib/shared/auth.service.spec.ts
+++ b/packages/auth/src/lib/shared/auth.service.spec.ts
@@ -3,8 +3,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { provideMockTranslation } from '@igo2/core/language';
 import { IgoMessageModule } from '@igo2/core/message';
 
-import { mergeTestConfig } from 'packages/auth/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {

--- a/packages/auth/src/lib/shared/user/user.service.spec.ts
+++ b/packages/auth/src/lib/shared/user/user.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/auth/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { USER_AUTH_OPTIONS, UserService } from './user.service';
 
 describe('UserService', () => {

--- a/packages/auth/tsconfig.lib.json
+++ b/packages/auth/tsconfig.lib.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"],
+  "exclude": ["./src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
     "compilationMode": "partial"
   }

--- a/packages/common/backdrop/src/backdrop.component.spec.ts
+++ b/packages/common/backdrop/src/backdrop.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { BackdropComponent } from './backdrop.component';
 
 describe('BackdropComponent', () => {

--- a/packages/common/clickout/src/clickout.directive.spec.ts
+++ b/packages/common/clickout/src/clickout.directive.spec.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { ClickoutDirective } from './clickout.directive';
 
 @Component({

--- a/packages/common/collapsible/src/collapse.directive.spec.ts
+++ b/packages/common/collapsible/src/collapse.directive.spec.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { mergeTestConfig } from 'packages/auth/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { CollapseDirective } from './collapse.directive';
 
 @Component({

--- a/packages/common/collapsible/src/collapsible.component.spec.ts
+++ b/packages/common/collapsible/src/collapsible.component.spec.ts
@@ -3,8 +3,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MatListModule } from '@angular/material/list';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { CollapseDirective } from './collapse.directive';
 import { CollapsibleComponent } from './collapsible.component';
 

--- a/packages/common/datepicker/src/datepicker.spec.ts
+++ b/packages/common/datepicker/src/datepicker.spec.ts
@@ -12,8 +12,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TimeFrame } from '@igo2/utils';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { DatepickerComponent } from './datepicker.component';
 
 describe('DatepickerComponent', () => {

--- a/packages/common/drag-drop/src/tree-drag-drop/tree-drag-drop.directive.spec.ts
+++ b/packages/common/drag-drop/src/tree-drag-drop/tree-drag-drop.directive.spec.ts
@@ -3,8 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTree, MatTreeModule, MatTreeNode } from '@angular/material/tree';
 import { By } from '@angular/platform-browser';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { TreeDragDropDirective } from './tree-drag-drop.directive';
 import { DropPositionType } from './tree-drag-drop.interface';
 import { ITREE_ITEM_MOCK, TREE_MOCK } from './tree-drag-drop.mock';

--- a/packages/common/flexible/src/flexible.component.spec.ts
+++ b/packages/common/flexible/src/flexible.component.spec.ts
@@ -2,8 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MediaService } from '@igo2/core/media';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { FlexibleComponent } from './flexible.component';
 
 describe('FlexibleComponent', () => {

--- a/packages/common/icon/src/icon/icon.component.spec.ts
+++ b/packages/common/icon/src/icon/icon.component.spec.ts
@@ -1,8 +1,7 @@
 import { inputBinding } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { IgoIconComponent } from './icon.component';
 
 describe('IconComponent', () => {

--- a/packages/common/icon/src/shared/icon.service.spec.ts
+++ b/packages/common/icon/src/shared/icon.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { IconService } from './icon.service';
 
 describe('IconService', () => {

--- a/packages/common/list/src/list-item.directive.spec.ts
+++ b/packages/common/list/src/list-item.directive.spec.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { ListItemDirective } from './list-item.directive';
 
 @Component({

--- a/packages/common/list/src/list.component.spec.ts
+++ b/packages/common/list/src/list.component.spec.ts
@@ -1,8 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatListModule } from '@angular/material/list';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { ListComponent } from './list.component';
 
 describe('ListComponent', () => {

--- a/packages/common/panel/src/panel.component.spec.ts
+++ b/packages/common/panel/src/panel.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { PanelComponent } from './panel.component';
 
 describe('PanelComponent', () => {

--- a/packages/common/resizable-bar/src/resizable-bar.component.spec.ts
+++ b/packages/common/resizable-bar/src/resizable-bar.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { ResizableBarComponent } from './resizable-bar.component';
 
 describe('ResizableBarComponent', () => {

--- a/packages/common/resizable-bar/src/shared/resize.directive.spec.ts
+++ b/packages/common/resizable-bar/src/shared/resize.directive.spec.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { ResizeDirective } from './resize.directive';
 
 // 1. Define a minimal host component

--- a/packages/common/spinner/src/spinner.component.spec.ts
+++ b/packages/common/spinner/src/spinner.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { SpinnerComponent } from './spinner.component';
 
 describe('SpinnerComponent', () => {

--- a/packages/common/timepicker/src/timepicker.spec.ts
+++ b/packages/common/timepicker/src/timepicker.spec.ts
@@ -8,8 +8,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TimeFrame } from '@igo2/utils';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { TimepickerComponent } from './timepicker.component';
 
 describe('TimepickerComponent', () => {

--- a/packages/common/tool/src/shared/tool.service.spec.ts
+++ b/packages/common/tool/src/shared/tool.service.spec.ts
@@ -4,8 +4,7 @@ import {
 } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/common/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { ToolService } from './tool.service';
 
 describe('ToolService', () => {

--- a/packages/common/tsconfig.lib.json
+++ b/packages/common/tsconfig.lib.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"],
+  "exclude": ["./src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
     "compilationMode": "partial"
   }

--- a/packages/context/src/lib/context-manager/context-permissions/context-permission-item/context-permission-item.component.spec.ts
+++ b/packages/context/src/lib/context-manager/context-permissions/context-permission-item/context-permission-item.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/context/test-config';
-
+import { mergeTestConfig } from '../../../../../test-config';
 import { ContextPermissionItemComponent } from './context-permission-item.component';
 
 describe('ContextPermissionItemComponent', () => {

--- a/packages/context/src/lib/context-manager/context-permissions/context-permission.service.spec.ts
+++ b/packages/context/src/lib/context-manager/context-permissions/context-permission.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/context/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { ContextPermissionService } from './context-permission.service';
 
 describe('ContextPermissionService', () => {

--- a/packages/context/src/lib/context-manager/shared/layer-context.directive.spec.ts
+++ b/packages/context/src/lib/context-manager/shared/layer-context.directive.spec.ts
@@ -18,9 +18,9 @@ import {
 import { LayerService } from '@igo2/geo';
 import { StyleListService, StyleService } from '@igo2/geo';
 
-import { mergeTestConfig } from 'packages/context/test-config';
 import { BehaviorSubject } from 'rxjs';
 
+import { mergeTestConfig } from '../../../../test-config';
 import { ShareMapService } from '../../share-map/shared/share-map.service';
 import { ContextService } from './context.service';
 import { LayerContextDirective } from './layer-context.directive';

--- a/packages/context/tsconfig.lib.json
+++ b/packages/context/tsconfig.lib.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"],
+  "exclude": ["./src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
     "compilationMode": "partial"
   }

--- a/packages/core/activity/src/activity.service.spec.ts
+++ b/packages/core/activity/src/activity.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/core/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { ActivityService } from './activity.service';
 
 describe('ActivityService', () => {

--- a/packages/core/config/src/config.service.spec.ts
+++ b/packages/core/config/src/config.service.spec.ts
@@ -4,8 +4,7 @@ import {
 } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/core/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { ConfigService } from './config.service';
 
 describe('ConfigService', () => {

--- a/packages/core/language/src/shared/language.service.spec.ts
+++ b/packages/core/language/src/shared/language.service.spec.ts
@@ -5,8 +5,8 @@ import {
 import { TestBed, inject } from '@angular/core/testing';
 
 import { TranslateModule } from '@ngx-translate/core';
-import { mergeTestConfig } from 'packages/core/test-config';
 
+import { mergeTestConfig } from '../../../test-config';
 import { LanguageService } from './language.service';
 
 describe('LanguageService', () => {

--- a/packages/core/media/src/media.service.spec.ts
+++ b/packages/core/media/src/media.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/core/test-config';
-
+import { mergeTestConfig } from '../../test-config';
 import { MediaService } from './media.service';
 
 describe('MediaService', () => {

--- a/packages/core/route/src/route.service.spec.ts
+++ b/packages/core/route/src/route.service.spec.ts
@@ -2,9 +2,9 @@ import { TestBed, inject } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { mergeTestConfig } from 'packages/core/test-config';
 import { of } from 'rxjs';
 
+import { mergeTestConfig } from '../../test-config';
 import { RouteService } from './route.service';
 
 describe('RouteService', () => {

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"],
+  "exclude": ["./src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
     "compilationMode": "partial"
   }

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.spec.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { CapabilitiesService } from './capabilities.service';
 
 describe('CapabilitiesService', () => {

--- a/packages/geo/src/lib/filter/ogc-filterable-list/ogc-filterable-list-binding.directive.spec.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-list/ogc-filterable-list-binding.directive.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
+import { mergeTestConfig } from '../../../../test-config';
 
 describe('OgcFilterableListBindingDirective', () => {
   beforeEach(() => {

--- a/packages/geo/src/lib/metadata/shared/metadata.service.spec.ts
+++ b/packages/geo/src/lib/metadata/shared/metadata.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { MetadataService } from './metadata.service';
 
 describe('MetadataService', () => {

--- a/packages/geo/src/lib/query/shared/query.directive.spec.ts
+++ b/packages/geo/src/lib/query/shared/query.directive.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/auth/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { QueryService } from '../shared';
 
 describe('QueryDirective', () => {

--- a/packages/geo/src/lib/query/shared/query.service.spec.ts
+++ b/packages/geo/src/lib/query/shared/query.service.spec.ts
@@ -3,8 +3,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { provideMockTranslation } from '@igo2/core/language';
 import { IgoMessageModule } from '@igo2/core/message';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { QueryService } from './query.service';
 
 describe('QueryService', () => {

--- a/packages/geo/src/lib/search/search-settings/search-settings.component.spec.ts
+++ b/packages/geo/src/lib/search/search-settings/search-settings.component.spec.ts
@@ -12,8 +12,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { provideMockTranslation } from '@igo2/core/language';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { SearchSourceService } from '../shared/search-source.service';
 import { provideDefaultCoordinatesSearchResultFormatter } from '../shared/sources/coordinates.providers';
 import { provideDefaultIChercheSearchResultFormatter } from '../shared/sources/icherche.providers';

--- a/packages/geo/src/lib/style/style-list/style-list.service.spec.ts
+++ b/packages/geo/src/lib/style/style-list/style-list.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { StyleListService } from './style-list.service';
 
 describe('StyleListService', () => {

--- a/packages/geo/src/lib/style/style-service/style.service.spec.ts
+++ b/packages/geo/src/lib/style/style-service/style.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/auth/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { StyleService } from './style.service';
 
 describe('StyleService', () => {

--- a/packages/geo/src/lib/wkt/shared/wkt.service.spec.ts
+++ b/packages/geo/src/lib/wkt/shared/wkt.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'packages/geo/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { MapService } from '../../map/shared';
 import { WktService } from './wkt.service';
 

--- a/packages/geo/tsconfig.lib.json
+++ b/packages/geo/tsconfig.lib.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"],
+  "exclude": ["./src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
     "compilationMode": "partial"
   }

--- a/packages/integration/tsconfig.lib.json
+++ b/packages/integration/tsconfig.lib.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"],
+  "exclude": ["./src/test.ts", "**/*.spec.ts"],
   "angularCompilerOptions": {
     "compilationMode": "partial"
   }

--- a/packages/utils/tsconfig.lib.json
+++ b/packages/utils/tsconfig.lib.json
@@ -1,13 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "../../out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "paths": {
-      "@igo2/*": ["dist/*"]
+      "@igo2/*": ["../../dist/*"]
     }
   },
   "exclude": ["**/*.spec.ts"],

--- a/projects/demo/src/app/app.component.spec.ts
+++ b/projects/demo/src/app/app.component.spec.ts
@@ -11,8 +11,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { IgoAuthFormModule } from '@igo2/auth/form';
 
-import { mergeTestConfig } from 'projects/demo/src/test-config';
-
+import { mergeTestConfig } from '../test-config';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {

--- a/projects/demo/src/app/common/icon/icon.component.spec.ts
+++ b/projects/demo/src/app/common/icon/icon.component.spec.ts
@@ -1,8 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { mergeTestConfig } from 'projects/demo/src/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { AppIconComponent } from './icon.component';
 
 describe('AppIconComponent', () => {

--- a/projects/demo/src/app/components/doc-viewer/doc-viewer.component.spec.ts
+++ b/projects/demo/src/app/components/doc-viewer/doc-viewer.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'projects/demo/src/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { DocViewerComponent } from './doc-viewer.component';
 
 describe('DocViewerComponent', () => {

--- a/projects/demo/src/app/components/example/example-see-code/example-see-code.component.spec.ts
+++ b/projects/demo/src/app/components/example/example-see-code/example-see-code.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { mergeTestConfig } from 'projects/demo/src/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { ExampleSeeCodeComponent } from './example-see-code.component';
 
 describe('ExampleSeeCodeComponent', () => {

--- a/projects/demo/src/app/components/example/example-viewer/example-viewer.component.spec.ts
+++ b/projects/demo/src/app/components/example/example-viewer/example-viewer.component.spec.ts
@@ -2,8 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
 
-import { mergeTestConfig } from 'projects/demo/src/test-config';
-
+import { mergeTestConfig } from '../../../../test-config';
 import { ExampleViewerComponent } from './example-viewer.component';
 
 describe('ExampleViewerComponent', () => {

--- a/projects/demo/src/app/core/monitoring/monitoring.component.spec.ts
+++ b/projects/demo/src/app/core/monitoring/monitoring.component.spec.ts
@@ -5,8 +5,7 @@ import {
   MONITORING_OPTIONS
 } from '@igo2/core/monitoring';
 
-import { mergeTestConfig } from 'projects/demo/src/test-config';
-
+import { mergeTestConfig } from '../../../test-config';
 import { AppMonitoringComponent } from './monitoring.component';
 
 describe('MonitoringComponent', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -10,43 +9,45 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "strict": false,
     "moduleResolution": "bundler",
     "module": "ES2022",
     "target": "ES2022",
+    "types": ["node", "jasmine"],
     "lib": [
       "ES2022",
       "dom"
     ],
     "paths": {
       "@igo2/core": [
-        "packages/core/src/public_api"
+        "./packages/core/src/public_api"
       ],
       "@igo2/core/*": [
-        "packages/core/*/src/public_api"
+        "./packages/core/*/src/public_api"
       ],
       "@igo2/auth": [
-        "packages/auth/src/public_api"
+        "./packages/auth/src/public_api"
       ],
       "@igo2/auth/*": [
-        "packages/auth/*/src/public_api"
+        "./packages/auth/*/src/public_api"
       ],
       "@igo2/common": [
-        "packages/common/src/public_api"
+        "./packages/common/src/public_api"
       ],
       "@igo2/common/*": [
-        "packages/common/*/src/public_api"
+        "./packages/common/*/src/public_api"
       ],
       "@igo2/context": [
-        "packages/context/src/public_api"
+        "./packages/context/src/public_api"
       ],
       "@igo2/geo": [
-        "packages/geo/src/public_api"
+        "./packages/geo/src/public_api"
       ],
       "@igo2/integration": [
-        "packages/integration/src/public_api"
+        "./packages/integration/src/public_api"
       ],
       "@igo2/utils": [
-        "packages/utils/src/public_api"
+        "./packages/utils/src/public_api"
       ]
     }
   },
@@ -56,8 +57,6 @@
     "projects/**/e2e/**/*"
   ],
   "angularCompilerOptions": {
-    "skipTemplateCodegen": true,
-    "strictMetadataEmit": true,
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,


### PR DESCRIPTION
Vscode v1.114.x a migré le moteur par défaut de Typescript à la v6, certaines options sont dépréciés alors que le mode strict est activé par défaut. Nous ne sommes pas tout à fait prêt pour migrer vers le strict, je proposerais de l'inclure dans la prochaine version 21
