### PR TITLE
fix(common): tree-drag-drop --dragging class always on

### DIFF
--- a/packages/common/drag-drop/src/tree-drag-drop/tree-drag-drop.directive.spec.ts
+++ b/packages/common/drag-drop/src/tree-drag-drop/tree-drag-drop.directive.spec.ts
@@ -92,6 +92,21 @@ describe('DragDropTreeDirective', () => {
     expect(directive.dragEnd).toHaveBeenCalled();
   });
 
+  it('should toggle --dragging class on host element', () => {
+    const hostElement = fixture.debugElement.query(
+      By.directive(TreeDragDropDirective)
+    ).nativeElement;
+    expect(hostElement.classList.contains('--dragging')).toBe(false);
+
+    directive.onDragStart(fixture.componentInstance.dataSource[0]);
+    fixture.detectChanges();
+    expect(hostElement.classList.contains('--dragging')).toBe(true);
+
+    directive.dragEnd();
+    fixture.detectChanges();
+    expect(hostElement.classList.contains('--dragging')).toBe(false);
+  });
+
   it('should handle drag over and leave events', () => {
     const treeNodeDragged = treeNodesDebug[1].nativeElement;
     const treeNode = treeNodesDebug[0].nativeElement;

--- a/packages/common/drag-drop/src/tree-drag-drop/tree-drag-drop.directive.ts
+++ b/packages/common/drag-drop/src/tree-drag-drop/tree-drag-drop.directive.ts
@@ -2,8 +2,6 @@ import { CdkTree } from '@angular/cdk/tree';
 import {
   Directive,
   ElementRef,
-  HostBinding,
-  HostListener,
   OnDestroy,
   Renderer2,
   booleanAttribute,
@@ -43,7 +41,13 @@ export interface ITreeConfig<T> {
  */
 @Directive({
   selector: '[igoTreeDragDrop]',
-  standalone: true
+  standalone: true,
+  host: {
+    '[class.--dragging]': 'dragging()',
+    '(dragover)': 'hostDragOver($event)',
+    '(dragleave)': 'hostDragLeave($event)',
+    '(drop)': 'hostDrop($event)'
+  }
 })
 export class TreeDragDropDirective<
   T extends { id: string | number } = { id: string | number },
@@ -63,6 +67,7 @@ export class TreeDragDropDirective<
   dropLineTarget = signal<HTMLElement | null>(null);
   previousDropLine = signal<HTMLElement | null>(null);
   dropPosition = signal<DropPosition | null>(null);
+  dragging = signal(false);
   // Use a Set or just manage classes manually since SelectionModel was providing simple toggle
   // But we can stick to simple class logic
   highlightedNode: T | undefined;
@@ -83,28 +88,6 @@ export class TreeDragDropDirective<
   readonly dropped = output<TreeDropEvent<T>>();
 
   readonly droppedError = output<DropPermission>();
-
-  @HostListener('dragover', ['$event']) hostDragOver(event: Event): void {
-    event.preventDefault();
-  }
-
-  @HostListener('dragleave', ['$event']) hostDragLeave(event: DragEvent): void {
-    const rect = this.elementRef.nativeElement.getBoundingClientRect();
-    if (
-      event.clientY < rect.top ||
-      event.clientY >= rect.bottom ||
-      event.clientX < rect.left ||
-      event.clientX >= rect.right
-    ) {
-      this.dragLeave();
-    }
-  }
-
-  @HostListener('drop', ['$event']) hostDrop(event: DragEvent): void {
-    this.drop(event);
-  }
-
-  @HostBinding('class.--dragging') dragging = signal(false);
 
   readonly nodes = contentChildren(MatTreeNode, { descendants: true });
 
@@ -134,6 +117,9 @@ export class TreeDragDropDirective<
     });
 
     effect(() => {
+      if (!this.dragging()) {
+        return;
+      }
       const targetNode = this.dropNodeTarget();
       const position = this.dropPosition();
       const dropLineTarget = this.dropLineTarget();
@@ -168,6 +154,26 @@ export class TreeDragDropDirective<
     }
   }
 
+  hostDragOver(event: Event): void {
+    event.preventDefault();
+  }
+
+  hostDragLeave(event: DragEvent): void {
+    const rect = this.elementRef.nativeElement.getBoundingClientRect();
+    if (
+      event.clientY < rect.top ||
+      event.clientY >= rect.bottom ||
+      event.clientX < rect.left ||
+      event.clientX >= rect.right
+    ) {
+      this.dragLeave();
+    }
+  }
+
+  hostDrop(event: DragEvent): void {
+    this.drop(event);
+  }
+
   onDragStart(node: T): void {
     this.addDropTargetLine();
 
@@ -180,6 +186,9 @@ export class TreeDragDropDirective<
 
   dragEnd(): void {
     this.dragging.set(false);
+    this.dropNodeTarget.set(null);
+    this.dropPosition.set(null);
+
     if (this.draggedNode) {
       this.removeNodeClass(this.draggedNode.id, '--dragged');
       this.draggedNode = null;


### PR DESCRIPTION
Il y avait deux bogues, lorsqu'on dragguait une couche on n'avait plus l'affichage du carré bleu autour pour indiquer la sélection car la classe --dragging était toujours évalué a vrai
Le deuxième lorsqu'on glisse une couche sur le titre d'un groupe, le style pour identifier le groupe mis en évidence restait collé.

fix(common): tree-drag-drop --dragging class always on
fix(common): tree-drag-drop dropping into group let's the group higlithed