### PR TITLE
fix(geo): catalog preview without adding it permanently to the map #1855

### DIFF
--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser-layer.component.ts
@@ -123,7 +123,7 @@ export class CatalogBrowserLayerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.isPreview$$.unsubscribe();
-    this.resolution$$.unsubscribe();
+    this.resolution$$?.unsubscribe();
     this.layers$$.unsubscribe();
   }
 

--- a/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
+++ b/packages/geo/src/lib/catalog/catalog-browser/catalog-browser.component.ts
@@ -192,6 +192,7 @@ export class CatalogBrowserComponent implements OnInit, OnDestroy {
       if (catalog.profils?.length) {
         layer.options.security = { profils: catalog.profils };
       }
+      layer.options.id = layer.id;
       return this.layerService.createAsyncLayer(layer.options);
     });
     zip(...layers$).subscribe((layers) => {
@@ -225,14 +226,14 @@ export class CatalogBrowserComponent implements OnInit, OnDestroy {
     layers.forEach((layer: CatalogItemLayer) => {
       this.store().state.update(layer, { added: false });
       if (layer.options.baseLayer === true) {
-        const currLayer = this.map().layerController.getById(
+        const currLayer = this.map().layerController.getBySourceId(
           String(layer.options.id)
         );
         if (currLayer !== undefined) {
           this.map().layerController.remove(currLayer);
         }
       } else {
-        const currLayer = this.map().layerController.getById(layer.id);
+        const currLayer = this.map().layerController.getBySourceId(layer.id);
         if (currLayer !== undefined) {
           this.map().layerController.remove(currLayer);
         }


### PR DESCRIPTION
Synchronisation entre notre code interne MSP pour le catalogue. Il y a eu beaucoup de changements dont une ré-architecture du CatalogService pour isoler la logique d'affaire des catalogues ESRI. 

Bogue fixe pour la gestion des id's pour le preview des couches #1855 