### PR TITLE
fix(utils): strict types activation

### DIFF
--- a/packages/common/entity/src/entity-table/entity-table.component.html
+++ b/packages/common/entity/src/entity-table/entity-table.component.html
@@ -96,7 +96,6 @@
                       } @else {
                         <span>{{ 'igo.geo.targetHtmlUrl' | translate }} </span>
                       }
-                      >
                     </a>
                   </td>
                 }
@@ -293,7 +292,6 @@
                             >{{ 'igo.geo.targetHtmlUrl' | translate }}
                           </span>
                         }
-                        >
                       </a>
                     </td>
                   }
@@ -403,7 +401,6 @@
                           'igo.common.entity-table.targetHtmlUrl' | translate
                         }}</span>
                       }
-                      >
                     </a>
                   </td>
                 }

--- a/packages/common/entity/src/shared/entity.service.ts
+++ b/packages/common/entity/src/shared/entity.service.ts
@@ -117,13 +117,15 @@ export class EntityService {
     const path = relation.choiceList?.path;
 
     const items = path?.list
-      ? ObjectUtils.resolve(options, path.list)
+      ? (ObjectUtils.resolve(options, path.list) as SelectOption[])
       : options;
 
     return items.map((item) => {
-      const id = path?.id ? ObjectUtils.resolve(item, path.id) : item.id;
+      const id = path?.id
+        ? (ObjectUtils.resolve(item, path.id) as SelectOption['id'])
+        : item.id;
       const value = path?.value
-        ? ObjectUtils.resolve(item, path.value)
+        ? (ObjectUtils.resolve(item, path.value) as SelectOption['value'])
         : item.value;
       return { id, value } satisfies SelectOption;
     });

--- a/packages/common/table/src/table-datasource.ts
+++ b/packages/common/table/src/table-datasource.ts
@@ -67,7 +67,7 @@ export class TableDataSource extends DataSource<any> {
     });
   }
 
-  getSortedData(data): any[] {
+  getSortedData(data: any[]): any[] {
     if (!this._sort.active || this._sort.direction === '') {
       return data;
     }
@@ -76,11 +76,11 @@ export class TableDataSource extends DataSource<any> {
       const propertyA: number | string = ObjectUtils.resolve(
         a,
         this._sort.active
-      );
+      ) as number | string;
       const propertyB: number | string = ObjectUtils.resolve(
         b,
         this._sort.active
-      );
+      ) as number | string;
 
       return ObjectUtils.naturalCompare(
         propertyB,

--- a/packages/core/config/src/config.service.ts
+++ b/packages/core/config/src/config.service.ts
@@ -56,7 +56,7 @@ export class ConfigService<T extends object = Record<string, any>> {
       value = this.handleDeprecationPossibility(key);
     }
 
-    return value ?? defaultValue;
+    return (value ?? defaultValue) as T;
   }
 
   private handleDeprecatedConfig(key: string): void {
@@ -104,11 +104,11 @@ export class ConfigService<T extends object = Record<string, any>> {
             return throwError(error.error || 'Server error');
           })
         )
-        .subscribe((configResponse: object) => {
+        .subscribe((configResponse) => {
           this.config = ObjectUtils.mergeDeep(
-            ObjectUtils.mergeDeep({ version }, baseConfig),
+            ObjectUtils.mergeDeep({ version }, baseConfig ?? {}),
             configResponse
-          );
+          ) as T;
           this._isLoaded$.next(true);
           resolve(true);
         });

--- a/packages/geo/src/lib/catalog/shared/catalog.service.ts
+++ b/packages/geo/src/lib/catalog/shared/catalog.service.ts
@@ -584,13 +584,12 @@ export class CatalogService {
             return items;
           }
 
-          const layerItem: CatalogItemLayer<ImageLayerOptions> =
-            this.prepareCatalogItemLayer(
-              layer,
-              idGroup,
-              layersQueryFormat,
-              catalog
-            );
+          const layerItem = this.prepareCatalogItemLayer(
+            layer,
+            idGroup,
+            layersQueryFormat,
+            catalog
+          ) as CatalogItemLayer<ImageLayerOptions>;
 
           items.push(layerItem);
         }
@@ -784,7 +783,7 @@ export class CatalogService {
     );
 
     const items: CatalogItemLayer[] = layers
-      .map((layer: ArcGISRestCapabilitiesLayer) => {
+      .map((layer) => {
         const propertiesToForce = this.computeForcedProperties(
           layer.name,
           catalog.forcedProperties
@@ -851,7 +850,7 @@ export class CatalogService {
           }
         } as CatalogItem);
       })
-      .filter((item: CatalogItemLayer | undefined) => item !== undefined);
+      .filter((item) => item !== undefined) as CatalogItemLayer[];
     const groupHandledLayersIds: string[] = [];
     const groupedItems: CatalogItemLayer[] = groups
       .map((group) => {

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -322,7 +322,7 @@ export class CapabilitiesService {
       }
     }
 
-    const options: WMSDataSourceOptions = ObjectUtils.removeUndefined({
+    const options = ObjectUtils.removeUndefined({
       _layerOptionsFromSource: {
         title: layer.Title,
         maxResolution: getResolutionFromScale(layer.MaxScaleDenominator),
@@ -343,9 +343,9 @@ export class CapabilitiesService {
       minDate: timeFilterable ? timeFilter.min : undefined,
       maxDate: timeFilterable ? timeFilter.max : undefined,
       stepDate: timeFilterable ? timeFilter.step : undefined
-    });
+    }) as unknown as WMSDataSourceOptions;
 
-    return ObjectUtils.mergeDeep(options, baseOptions);
+    return ObjectUtils.mergeDeep<WMSDataSourceOptions>(options, baseOptions);
   }
 
   private parseWMTSOptions(
@@ -364,9 +364,12 @@ export class CapabilitiesService {
       _layerOptionsFromSource: {
         title: layer.Title
       }
-    });
+    }) as unknown as WMTSDataSourceOptions;
 
-    return ObjectUtils.mergeDeep(sourceOptions, ouputOptions);
+    return ObjectUtils.mergeDeep<WMTSDataSourceOptions>(
+      sourceOptions,
+      ouputOptions
+    );
   }
 
   private parseCartoOptions(
@@ -387,7 +390,7 @@ export class CapabilitiesService {
         version: params.version,
         layers
       }
-    });
+    }) as CartoDataSourceOptions;
     return ObjectUtils.mergeDeep(options, baseOptions);
   }
 
@@ -439,7 +442,7 @@ export class CapabilitiesService {
         time: timeExtent
       }
     );
-    const options = ObjectUtils.removeUndefined({
+    const options = ObjectUtils.removeUndefined<Record<string, unknown>>({
       params,
       _layerOptionsFromSource: {
         title,
@@ -456,8 +459,11 @@ export class CapabilitiesService {
       sourceFields: arcgisOptions.fields,
       queryTitle: arcgisOptions.displayField
     });
-    options.attributions = attributions;
-    return ObjectUtils.mergeDeep(options, baseOptions);
+    options['attributions'] = attributions;
+    return ObjectUtils.mergeDeep(
+      options,
+      baseOptions
+    ) as unknown as ArcGISRestDataSourceOptions;
   }
 
   private parseTileOrImageArcgisOptions(
@@ -499,7 +505,7 @@ export class CapabilitiesService {
         time: timeExtent
       }
     );
-    const options = ObjectUtils.removeUndefined({
+    const options = ObjectUtils.removeUndefined<Record<string, unknown>>({
       params,
       _layerOptionsFromSource: {
         title,
@@ -516,7 +522,7 @@ export class CapabilitiesService {
       sourceFields: arcgisOptions.fields,
       queryTitle: arcgisOptions.displayField
     });
-    options.attributions = attributions;
+    options['attributions'] = attributions;
     return ObjectUtils.mergeDeep(options, baseOptions);
   }
 

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -343,7 +343,11 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   private handleStopDiff(stops: Stop[]) {
     const simplifiedStops = stops.map((stop) => {
       return ObjectUtils.removeUndefined({
-        ...{ id: stop.id, text: stop.text, coordinates: stop.coordinates }
+        ...({
+          id: stop.id,
+          text: stop.text,
+          coordinates: stop.coordinates
+        } as Stop)
       });
     });
     const diff = ChangeUtils.findChanges(this.previousStops, simplifiedStops, [

--- a/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
+++ b/packages/geo/src/lib/layer/shared/layers/vector-layer.ts
@@ -292,7 +292,7 @@ export class VectorLayer extends Layer {
 
   private maintainOptionsInIdb() {
     this.options.igoStyle.igoStyleObject = olStyleToBasicIgoStyle(this.ol);
-    const layerData: LayerDBData = ObjectUtils.removeUndefined({
+    const layerData = ObjectUtils.removeUndefined({
       layerId: this.id,
       detailedContextUri: this.options.idbInfo?.contextUri,
       sourceOptions: {
@@ -315,7 +315,7 @@ export class VectorLayer extends Layer {
         })
       },
       insertEvent: `${this.title}-${this.id}-${new Date()}`
-    });
+    }) as LayerDBData;
     const layerDB = new LayerDB();
     layerDB.update(layerData).pipe(first()).subscribe();
   }

--- a/packages/geo/src/lib/workspace/shared/workspace.utils.ts
+++ b/packages/geo/src/lib/workspace/shared/workspace.utils.ts
@@ -22,7 +22,11 @@ import {
   SourceFieldsOptionsParams
 } from '../../datasource/shared/datasources/datasource.interface';
 import { Feature } from '../../feature/shared/feature.interfaces';
-import { LayerService, VectorLayer } from '../../layer/shared';
+import {
+  AnyLayerItemOptions,
+  LayerService,
+  VectorLayer
+} from '../../layer/shared';
 import { IgoMap } from '../../map/shared/map';
 import { generateIdFromSourceOptions } from '../../utils/id-generator';
 import { FeatureWorkspace } from './feature-workspace';
@@ -88,9 +92,9 @@ export function addOrRemoveLayer(
   layerName: string,
   layerService: LayerService
 ) {
-  const so = ObjectUtils.removeUndefined({
+  const so = ObjectUtils.removeUndefined<AnyLayerItemOptions>({
     sourceOptions: {
-      type: type,
+      type: type as any,
       url,
       optionsFromCapabilities: true,
       optionsFromApi: true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write ./src/**/*.{ts,js,html,scss,css,json}",
     "lint": "ng lint utils",
     "lint.fix": "ng lint utils --fix",
+    "types": "tsc -p ./tsconfig.lib.json --noEmit",
     "test": "ng test utils --watch=false",
     "watch": "ng build utils --watch"
   },

--- a/packages/utils/src/lib/change.interface.ts
+++ b/packages/utils/src/lib/change.interface.ts
@@ -6,11 +6,13 @@ export enum ChangeType {
 
 export interface Change {
   type: ChangeType;
-  keysChanged?: {
-    key: string;
-    newValue: any;
-    oldValue: any;
-  }[];
+  keysChanged?: KeyChange[];
+}
+
+export interface KeyChange {
+  key: string;
+  oldValue: unknown;
+  newValue: unknown;
 }
 
 export interface GroupingChanges {

--- a/packages/utils/src/lib/change.ts
+++ b/packages/utils/src/lib/change.ts
@@ -1,4 +1,5 @@
-import { ChangeType, GroupingChanges } from './change.interface';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ChangeType, GroupingChanges, KeyChange } from './change.interface';
 import { StringUtils } from './string-utils';
 
 export class ChangeUtils {
@@ -17,8 +18,8 @@ export class ChangeUtils {
       return items;
     }
 
-    const obj1Clone: any = [...obj1];
-    const obj2Clone: any = [...obj2];
+    const obj1Clone: Record<string, unknown>[] = [...obj1];
+    const obj2Clone: Record<string, unknown>[] = [...obj2];
 
     for (const fromItem of obj1Clone) {
       const index = obj2Clone.findIndex((s) => s.id === fromItem.id);
@@ -65,15 +66,20 @@ export class ChangeUtils {
     return items;
   }
 
-  private static compareObject(fromItem, toItem, baseKey?, ignoreKeys = []) {
+  private static compareObject(
+    fromItem: any,
+    toItem: any,
+    baseKey?: string,
+    ignoreKeys: string[] = []
+  ): KeyChange[] {
     const fromItemClone = JSON.parse(JSON.stringify(fromItem));
     const toItemClone = JSON.parse(JSON.stringify(toItem));
 
-    const keys: any = new Set([
+    const keys: Set<string> = new Set([
       ...Object.keys(fromItem),
       ...Object.keys(toItem)
     ]);
-    let keysChanged = [];
+    let keysChanged: KeyChange[] = [];
     keys.forEach((key) => {
       const keyString = baseKey ? `${baseKey}.${key}` : key;
       if (ignoreKeys.indexOf(keyString) !== -1) {

--- a/packages/utils/src/lib/compression/compression.utils.ts
+++ b/packages/utils/src/lib/compression/compression.utils.ts
@@ -1,4 +1,4 @@
-import { Observable, Observer } from 'rxjs';
+import { Observable, Observer, of } from 'rxjs';
 
 import { CompressedData } from './compressedData.interface';
 
@@ -39,16 +39,16 @@ export class Compression {
     this.indexBase64.set(63, '/');
   }
 
-  compressBlob(blob: Blob): Observable<CompressedData> {
+  compressBlob(blob: Blob): Observable<CompressedData | null> {
     if (!blob) {
-      return;
+      return of(null);
     }
 
     const observable = new Observable((observer: Observer<CompressedData>) => {
       const reader = new FileReader();
       reader.readAsDataURL(blob);
       reader.onload = () => {
-        const base64 = reader.result.valueOf() as string;
+        const base64 = reader.result?.valueOf() as string;
         const text64 = base64.substr(base64.indexOf(',') + 1);
         const compressed = this.compressStringBase64(text64);
         const compressedData: CompressedData = {
@@ -83,6 +83,9 @@ export class Compression {
     let rem: number;
     for (const c of s) {
       const value = this.base64Index.get(c);
+      if (value === undefined) {
+        continue;
+      }
       if (bits > 6) {
         bits -= 6;
         chr += value << bits;
@@ -101,10 +104,6 @@ export class Compression {
   }
 
   private decompressStringBase64(c: string, length: number): string {
-    if (!c) {
-      return;
-    }
-
     if (c.charCodeAt(0) !== 9731) {
       return c;
     }

--- a/packages/utils/src/lib/date.utils.ts
+++ b/packages/utils/src/lib/date.utils.ts
@@ -25,9 +25,9 @@ export function isTimeFrame(
   );
 }
 
-export function resolveDate(input?: Date | TimeFrame): Date | undefined {
+export function resolveDate(input: Date | TimeFrame): Date | null {
   if (isTimeFrame(input)) {
     return new Date();
   }
-  return input instanceof Date ? input : undefined;
+  return input instanceof Date ? input : null;
 }

--- a/packages/utils/src/lib/dom.utils.ts
+++ b/packages/utils/src/lib/dom.utils.ts
@@ -7,7 +7,8 @@ export class DomUtils {
     const el = doc.createElement(tagName);
 
     for (const key in options) {
-      el[key] = options[key];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any)[key] = options[key as keyof typeof options];
     }
 
     return el;

--- a/packages/utils/src/lib/files/excel.ts
+++ b/packages/utils/src/lib/files/excel.ts
@@ -16,7 +16,7 @@ export async function createExcelWorkBook(
 }
 export async function addExcelSheetToWorkBook<T = Record<string, unknown>>(
   title: string,
-  rows: T[],
+  rows: T[] | string,
   workBook: WorkBook,
   opts?: {
     json2SheetOpts?: JSON2SheetOpts;
@@ -25,11 +25,13 @@ export async function addExcelSheetToWorkBook<T = Record<string, unknown>>(
 ): Promise<void> {
   const { utils } = await import('xlsx');
 
-  const worksheet = utils.json_to_sheet(rows, opts?.json2SheetOpts);
+  const values = typeof rows === 'string' ? JSON.parse(rows) : rows;
+
+  const worksheet = utils.json_to_sheet(values, opts?.json2SheetOpts);
 
   /* calculate column width */
   if (rows?.length) {
-    worksheet['!cols'] = getColumnsInfo(rows);
+    worksheet['!cols'] = getColumnsInfo(values);
   }
 
   const SHEET_NAME_MAX_LENGTH = 31;
@@ -62,14 +64,16 @@ export async function writeExcelFile(
   writeFile(workBook, `${cleanedFileName}.xlsx`, opts);
 }
 
-function getColumnsInfo<T = Record<string, unknown>>(rows: T[]): ColInfo[] {
+function getColumnsInfo<T extends Record<string, unknown>>(
+  rows: T[]
+): ColInfo[] {
   const columns = Object.keys(rows[0]);
   return columns.map((column) => ({
     wch: getColumnMaxWidth(column, rows)
   }));
 }
 
-function getColumnMaxWidth<T = Record<string, unknown>>(
+function getColumnMaxWidth<T extends Record<string, unknown>>(
   column: string,
   rows: T[]
 ): number {

--- a/packages/utils/src/lib/object-utils.ts
+++ b/packages/utils/src/lib/object-utils.ts
@@ -1,21 +1,26 @@
 /* eslint-disable no-prototype-builtins */
 export class ObjectUtils {
-  static resolve(obj: object, key: string): any {
-    const keysArray = key.replace(/\[/g, '.').replace(/\]/g, '').split('.');
-    let current = obj;
+  static resolve<T, K extends keyof T>(obj: T, key: K | string): unknown {
+    const keysArray = String(key)
+      .replace(/\[/g, '.')
+      .replace(/\]/g, '')
+      .split('.');
+    let current: unknown = obj;
+    let value: unknown = undefined;
     while (keysArray.length) {
-      if (typeof current !== 'object') {
+      if (typeof current !== 'object' || current === null) {
         return undefined;
       }
-      current = current[keysArray.shift()];
+      const k = keysArray.shift() as string;
+      value = current = (current as Record<string, unknown>)[k];
     }
 
-    return current;
+    return value;
   }
 
-  static isObject(item: object) {
+  static isObject(item: unknown): item is Record<string, unknown> {
     return (
-      item &&
+      !!item &&
       typeof item === 'object' &&
       !Array.isArray(item) &&
       item !== null &&
@@ -23,11 +28,13 @@ export class ObjectUtils {
     );
   }
 
-  static mergeDeep(
-    target: object,
-    source: object,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static mergeDeep<T = any>(
+    target: T,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    source: any,
     ignoreUndefined = false
-  ): any {
+  ): T {
     const output = Object.assign({}, target);
     if (ObjectUtils.isObject(target) && ObjectUtils.isObject(source)) {
       Object.keys(source)
@@ -37,9 +44,9 @@ export class ObjectUtils {
             if (!(key in target)) {
               Object.assign(output, { [key]: source[key] });
             } else {
-              output[key] = ObjectUtils.mergeDeep(
-                target[key],
-                source[key],
+              (output as Record<string, unknown>)[key] = ObjectUtils.mergeDeep(
+                target[key] as Record<string, unknown>,
+                source[key] as Record<string, unknown>,
                 ignoreUndefined
               );
             }
@@ -51,25 +58,36 @@ export class ObjectUtils {
     return output;
   }
 
-  static copyDeep(src): any {
-    const target = Array.isArray(src) ? [] : {};
-    for (const prop in src) {
-      if (src.hasOwnProperty(prop)) {
-        const value = src[prop];
-        if (value && typeof value === 'object') {
-          target[prop] = this.copyDeep(value);
-        } else {
-          target[prop] = value;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static copyDeep<T = any>(src: T): T {
+    if (Array.isArray(src)) {
+      return src.map((item) =>
+        typeof item === 'object' && item !== null
+          ? this.copyDeep(item as Record<string, unknown>)
+          : item
+      ) as T;
+    } else if (this.isObject(src)) {
+      const target = {} as T;
+      for (const prop in src) {
+        if (src.hasOwnProperty(prop)) {
+          const value = (src as Record<string, unknown>)[prop];
+          (target as Record<string, unknown>)[prop] =
+            value && typeof value === 'object' && value !== null
+              ? this.copyDeep(value as Record<string, unknown>)
+              : value;
         }
       }
+      return target;
     }
-    return target;
+    return src;
   }
 
-  static removeDuplicateCaseInsensitive(obj: object) {
-    const summaryCapitalizeObject = {};
-    const capitalizeObject = {};
-    const upperCaseCount = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static removeDuplicateCaseInsensitive(obj: any) {
+    const summaryCapitalizeObject: Record<string, { [k: string]: unknown }[]> =
+      {};
+    const capitalizeObject: Record<string, unknown> = {};
+    const upperCaseCount: { key: string; count: number }[] = [];
 
     for (const property in obj) {
       if (obj.hasOwnProperty(property)) {
@@ -83,7 +101,7 @@ export class ObjectUtils {
             [property]: obj[property]
           });
         }
-        // counting the number of uppercase lettersMna
+        // counting the number of uppercase letters
         upperCaseCount.push({
           key: property,
           count: property.replace(/[^A-Z]/g, '').length
@@ -92,26 +110,24 @@ export class ObjectUtils {
     }
     for (const capitalizedProperty in summaryCapitalizeObject) {
       if (summaryCapitalizeObject.hasOwnProperty(capitalizedProperty)) {
-        if (summaryCapitalizeObject.hasOwnProperty(capitalizedProperty)) {
-          const capitalizedPropertyObject =
-            summaryCapitalizeObject[capitalizedProperty];
-          if (capitalizedPropertyObject.length === 1) {
-            // for single params (no duplicates)
-            const singlePossibility = capitalizedPropertyObject[0];
-            capitalizeObject[capitalizedProperty] =
-              singlePossibility[Object.keys(singlePossibility)[0]];
-          } else if (capitalizedPropertyObject.length > 1) {
-            // defining the closest to lowercase property
-            const paramClosestToLowercase = upperCaseCount
-              .filter(
-                (f) => f.key.toLowerCase() === capitalizedProperty.toLowerCase()
-              )
-              .reduce((prev, current) => {
-                return prev.y < current.y ? prev : current;
-              });
-            capitalizeObject[paramClosestToLowercase.key.toUpperCase()] =
-              obj[paramClosestToLowercase.key];
-          }
+        const capitalizedPropertyObject =
+          summaryCapitalizeObject[capitalizedProperty];
+        if (capitalizedPropertyObject.length === 1) {
+          // for single params (no duplicates)
+          const singlePossibility = capitalizedPropertyObject[0];
+          capitalizeObject[capitalizedProperty] =
+            singlePossibility[Object.keys(singlePossibility)[0]];
+        } else if (capitalizedPropertyObject.length > 1) {
+          // defining the closest to lowercase property
+          const paramClosestToLowercase = upperCaseCount
+            .filter(
+              (f) => f.key.toLowerCase() === capitalizedProperty.toLowerCase()
+            )
+            .reduce((prev, current) => {
+              return prev.count < current.count ? prev : current;
+            });
+          capitalizeObject[paramClosestToLowercase.key.toUpperCase()] =
+            obj[paramClosestToLowercase.key];
         }
       }
     }
@@ -128,55 +144,74 @@ export class ObjectUtils {
     }
   }
 
-  static removeUndefined(obj: object): any {
-    const output = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static removeUndefined<T = any>(obj: T): T {
+    if (Array.isArray(obj)) {
+      return obj
+        .filter((item) => item !== undefined)
+        .map((item) =>
+          typeof item === 'object'
+            ? ObjectUtils.removeUndefined(item as Record<string, unknown>)
+            : item
+        ) as T;
+    }
+
     if (ObjectUtils.isObject(obj)) {
+      const output: Record<string, unknown> = {};
       Object.keys(obj)
         .filter((key) => obj[key] !== undefined)
         .forEach((key) => {
-          if (ObjectUtils.isObject(obj[key]) || Array.isArray(obj[key])) {
-            output[key] = ObjectUtils.removeUndefined(obj[key]);
-          } else {
-            output[key] = obj[key];
-          }
+          output[key] =
+            typeof obj[key] === 'object'
+              ? ObjectUtils.removeUndefined(obj[key] as Record<string, unknown>)
+              : obj[key];
         });
-
-      return output;
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.map((o) => ObjectUtils.removeUndefined(o));
+      return output as T;
     }
 
     return obj;
   }
 
-  static removeNull(obj: object): any {
-    const output = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static removeNull<T = any>(obj: T): T {
+    if (Array.isArray(obj)) {
+      return obj
+        .filter((item) => item !== null)
+        .map((item) =>
+          typeof item === 'object'
+            ? ObjectUtils.removeNull(item as Record<string, unknown>)
+            : item
+        ) as T;
+    }
+
     if (ObjectUtils.isObject(obj)) {
+      const output: Record<string, unknown> = {};
       Object.keys(obj)
         .filter((key) => obj[key] !== null)
         .forEach((key) => {
           if (ObjectUtils.isObject(obj[key]) || Array.isArray(obj[key])) {
-            output[key] = ObjectUtils.removeNull(obj[key]);
+            output[key] = ObjectUtils.removeNull(
+              obj[key] as Record<string, unknown>
+            );
           } else {
             output[key] = obj[key];
           }
         });
 
-      return output;
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.map((o) => ObjectUtils.removeNull(o));
+      return output as T;
     }
 
     return obj;
   }
 
-  static naturalCompare(a, b, direction = 'asc', nullsFirst?: boolean) {
+  static naturalCompare(
+    a: unknown,
+    b: unknown,
+    direction = 'asc',
+    nullsFirst?: boolean
+  ): number {
     if (direction === 'desc') {
-      b = [a, (a = b)][0];
+      [a, b] = [b, a];
     }
 
     // nullsFirst = undefined : end if direction = 'asc', first if direction = 'desc'
@@ -210,22 +245,24 @@ export class ObjectUtils {
       return nullsFirst === true ? nullScore * -1 : nullScore;
     }
 
-    const ax = [];
-    const bx = [];
-    a = '' + a;
-    b = '' + b;
+    const ax: [number, string][] = [];
+    const bx: [number, string][] = [];
+    const aStr = '' + a;
+    const bStr = '' + b;
 
-    a.replace(/(\d+)|(\D+)/g, (_, $1, $2) => {
-      ax.push([$1 || Infinity, $2 || '']);
+    aStr.replace(/(\d+)|(\D+)/g, (_, $1, $2) => {
+      ax.push([$1 ? Number($1) : Infinity, $2 ?? '']);
+      return '';
     });
 
-    b.replace(/(\d+)|(\D+)/g, (_, $1, $2) => {
-      bx.push([$1 || Infinity, $2 || '']);
+    bStr.replace(/(\d+)|(\D+)/g, (_, $1, $2) => {
+      bx.push([$1 ? Number($1) : Infinity, $2 ?? '']);
+      return '';
     });
 
     while (ax.length && bx.length) {
-      const an = ax.shift();
-      const bn = bx.shift();
+      const an = ax.shift()!;
+      const bn = bx.shift()!;
       const nn = an[0] - bn[0] || an[1].localeCompare(bn[1]);
       if (nn) {
         return nn;
@@ -241,9 +278,12 @@ export class ObjectUtils {
    * if all of their properties (first-level only) share the same value.
    * @param obj1 First object
    * @param obj2 Second object
-   * @returns Whether two objects arer equivalent
+   * @returns Whether two objects are equivalent
    */
-  static objectsAreEquivalent(obj1: object, obj2: object): boolean {
+  static objectsAreEquivalent(
+    obj1: Record<string, unknown>,
+    obj2: Record<string, unknown>
+  ): boolean {
     if (obj1 === obj2) {
       return true;
     }
@@ -269,18 +309,22 @@ export class ObjectUtils {
    * @param keys Keys to remove
    * @returns A new object
    */
-  static removeKeys(obj: object, keys: string[]): object {
-    const newObj = Object.keys(obj)
+  static removeKeys(
+    obj: Record<string, unknown>,
+    keys: string[]
+  ): Record<string, unknown> {
+    return Object.keys(obj)
       .filter((key) => keys.indexOf(key) < 0)
-      .reduce((_obj, key) => {
-        _obj[key] = obj[key];
-        return _obj;
-      }, {});
-
-    return newObj;
+      .reduce(
+        (_obj, key) => {
+          _obj[key] = obj[key];
+          return _obj;
+        },
+        {} as Record<string, unknown>
+      );
   }
 
-  static isEmpty(obj: object): boolean {
+  static isEmpty(obj: Record<string, unknown>): boolean {
     return Object.keys(obj).length === 0;
   }
 }

--- a/packages/utils/src/lib/object-utils.ts
+++ b/packages/utils/src/lib/object-utils.ts
@@ -72,7 +72,7 @@ export class ObjectUtils {
         if (src.hasOwnProperty(prop)) {
           const value = (src as Record<string, unknown>)[prop];
           (target as Record<string, unknown>)[prop] =
-            value && typeof value === 'object' && value !== null
+            value && typeof value === 'object'
               ? this.copyDeep(value as Record<string, unknown>)
               : value;
         }

--- a/packages/utils/src/lib/string-utils.ts
+++ b/packages/utils/src/lib/string-utils.ts
@@ -1,3 +1,19 @@
+interface ChangeData {
+  fis: number;
+  fil: number;
+  sbs: string;
+  mtc: string;
+  del: string;
+  ins: string;
+}
+
+interface SubData {
+  fis: number;
+  fil?: number;
+  sbs: string;
+  mtc: string;
+}
+
 export class StringUtils {
   static diff(s1: string, s2: string, p = 4): string {
     if (!s1 && !s2) {
@@ -33,7 +49,7 @@ export class StringUtils {
     return result;
   }
 
-  private static getMatchingSubstring(s, l, m) {
+  private static getMatchingSubstring(s: string, l: string[], m: string) {
     // returns the first matching substring in-between the two strings
     let i = 0;
     let match = false;
@@ -55,32 +71,40 @@ export class StringUtils {
     return o;
   }
 
-  private static getChanges(s1, s2, m, p) {
+  private static getChanges(
+    s1: string,
+    s2: string,
+    m: string,
+    p: number
+  ): ChangeData {
     const isThisLonger = s1.length >= s1.length ? true : false;
-    let [longer, shorter] = isThisLonger ? [s1, s2] : [s2, s1]; // assignment of longer and shorter by es6 destructuring
+    const [longer, shorter_init] = isThisLonger ? [s1, s2] : [s2, s1]; // assignment of longer and shorter by es6 destructuring
+    let shorter = shorter_init;
     let bi = 0; // base index designating the index of first mismacthing character in both strings
 
     while (shorter[bi] === longer[bi] && bi < shorter.length) {
       ++bi;
     } // make bi the index of first mismatching character
-    longer = longer.split('').slice(bi); // as the longer string will be rotated it is converted into array
+    const longerArr = longer.split('').slice(bi); // as the longer string will be rotated it is converted into array
     shorter = shorter.slice(bi); // shorter and longer now starts from the first mismatching character
 
-    const len = longer.length; // length of the longer string
-    let cd: any = {
+    const len = longerArr.length; // length of the longer string
+    let cd: ChangeData = {
       fis: shorter.length, // the index of matching string in the shorter string
       fil: len, // the index of matching string in the longer string
       sbs: '', // the matching substring itself
-      mtc: m + s2.slice(0, bi)
+      mtc: m + s2.slice(0, bi),
+      del: '',
+      ins: ''
     }; // if exists mtc holds the matching string at the front
-    let sub: any = { sbs: '' }; // returned substring per 1 character rotation of the longer string
+    let sub: SubData = { fis: cd.fis, fil: cd.fil, sbs: '', mtc: cd.mtc }; // returned substring per 1 character rotation of the longer string
 
     if (shorter !== '') {
       for (let rc = 0; rc < len && sub.sbs.length < p; rc++) {
         // rc -> rotate count, p -> precision factor
         sub = StringUtils.getMatchingSubstring(
           shorter,
-          StringUtils.rotateArray(longer, rc),
+          StringUtils.rotateArray(longerArr, rc),
           cd.mtc
         ); // rotate longer string 1 char and get substring
         sub.fil =
@@ -88,14 +112,14 @@ export class StringUtils {
             ? sub.fis + rc // mismatch is longer than the mismatch in short
             : sub.fis - len + rc; // mismatch is shorter than the mismatch in short
         if (sub.sbs.length > cd.sbs.length) {
-          cd = sub; // only keep the one with the longest substring.
+          cd = { ...cd, ...sub }; // only keep the one with the longest substring.
         }
       }
     }
     // insert the mismatching delete subsrt and insert substr to the cd object and attach the previous substring
     [cd.del, cd.ins] = isThisLonger
-      ? [longer.slice(0, cd.fil).join(''), shorter.slice(0, cd.fis)]
-      : [shorter.slice(0, cd.fis), longer.slice(0, cd.fil).join('')];
+      ? [longerArr.slice(0, cd.fil).join(''), shorter.slice(0, cd.fis)]
+      : [shorter.slice(0, cd.fis), longerArr.slice(0, cd.fil).join('')];
     return cd.del.indexOf(' ') === -1 ||
       cd.ins.indexOf(' ') === -1 ||
       cd.del === '' ||
@@ -105,7 +129,7 @@ export class StringUtils {
       : StringUtils.getChanges(cd.del, cd.ins, cd.mtc, p);
   }
 
-  private static rotateArray(array, n) {
+  private static rotateArray(array: string[], n: number) {
     const len = array.length;
     const res = new Array(array.length);
     if (n % len === 0) {

--- a/packages/utils/src/lib/tree/tree.ts
+++ b/packages/utils/src/lib/tree/tree.ts
@@ -63,13 +63,17 @@ export class Tree<T> {
    * @param node
    * @param beforeTo The position of index into the tree. If -1 move at the end
    */
-  moveTo(beforeTo: number[], ...nodes: T[]): T[] {
+  moveTo(beforeTo: number[], ...nodes: T[]): T[] | undefined {
     const clonedBeforeTo = [...beforeTo];
-    const lastIndex = clonedBeforeTo.pop();
+    const lastIndex = clonedBeforeTo.pop()!;
     const recipient = this.getAncestorAtPosition(clonedBeforeTo);
+    if (!recipient) {
+      return;
+    }
+
     const beforeId =
       lastIndex === -1 || lastIndex >= recipient.length
-        ? null
+        ? undefined
         : this.getId(recipient[lastIndex]);
 
     const nodesToMove = nodes.filter((node) => beforeId !== this.getId(node));
@@ -101,12 +105,12 @@ export class Tree<T> {
     return nodes.reduce((acc: T[], node) => {
       const ancestor = this.getNodeAncestor(node);
       if (!ancestor) {
-        return;
+        return acc;
       }
 
       const index = this.getIndex(this.getId(node), ancestor);
       if (index === -1) {
-        return;
+        return acc;
       }
       ancestor.splice(index, 1);
 
@@ -156,7 +160,7 @@ export class Tree<T> {
 
       return false;
     });
-    return indexList;
+    return indexList!;
   }
 
   private getAncestorAtPosition(position: number[]) {
@@ -164,6 +168,9 @@ export class Tree<T> {
       return this._data;
     }
     const node = this.getNodeByPosition(position);
+    if (!node) {
+      return;
+    }
     return this.getChildren(node);
   }
 
@@ -184,8 +191,8 @@ export class Tree<T> {
   }
 
   /** Recursive */
-  private _getNodeById(id: string, data = this._data): T {
-    let node: T;
+  private _getNodeById(id: string, data = this._data): T | undefined {
+    let node: T | undefined;
     data.some((item) => {
       if (this.getId(item) === id) {
         node = item;
@@ -205,14 +212,14 @@ export class Tree<T> {
     return node;
   }
 
-  getNodeByPosition(indexes: number[]): T {
+  getNodeByPosition(indexes: number[]): T | undefined {
     if (indexes.length > 1) {
-      return indexes.reduce((previousValue: T, index) => {
+      return indexes.reduce((previousValue: T | undefined, index) => {
         const ancestor = previousValue
           ? this.getChildren(previousValue)
           : this._data;
-        return this._getByIndex(index, ancestor);
-      }, null);
+        return this._getByIndex(index, ancestor ?? undefined);
+      }, undefined);
     } else {
       return this._getByIndex(indexes[0]);
     }
@@ -222,14 +229,14 @@ export class Tree<T> {
     return ancestor[index];
   }
 
-  private getNodeAncestor(node: T): T[] {
+  private getNodeAncestor(node: T): T[] | undefined {
     const id = this.getId(node);
     return this.getAncestorById(id);
   }
 
   /** Recursive */
   private getAncestorById(id: TreeId, data = this._data): T[] | undefined {
-    let ancestor: T[];
+    let ancestor: T[] | undefined;
     data.some((item) => {
       if (this.getId(item) === id) {
         ancestor = data;

--- a/packages/utils/src/lib/watcher.ts
+++ b/packages/utils/src/lib/watcher.ts
@@ -10,23 +10,23 @@ export enum SubjectStatus {
 
 export abstract class Watcher {
   public status$ = new Subject<SubjectStatus>();
-  protected status$$: Subscription;
+  protected status$$!: Subscription;
 
-  get status(): SubjectStatus {
+  get status(): SubjectStatus | undefined {
     return this._status;
   }
   set status(value: SubjectStatus) {
     this._status = value;
     this.status$.next(value);
   }
-  private _status: SubjectStatus;
+  private _status?: SubjectStatus;
 
-  protected abstract watch();
+  protected abstract watch(): void;
 
-  protected abstract unwatch();
+  protected abstract unwatch(): void;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  subscribe(callback: Function, scope?: any) {
+  subscribe(callback: Function, scope?: unknown) {
     this.watch();
 
     this.status$$ = this.status$.pipe(distinctUntilChanged()).subscribe(() => {
@@ -36,10 +36,7 @@ export abstract class Watcher {
 
   unsubscribe() {
     this.unwatch();
-    if (this.status$$ !== undefined) {
-      this.status$$.unsubscribe();
-      this.status$$ = undefined;
-    }
+    this.status$$?.unsubscribe();
     this.status = SubjectStatus.Waiting;
   }
 }

--- a/packages/utils/tsconfig.lib.json
+++ b/packages/utils/tsconfig.lib.json
@@ -5,10 +5,8 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": [],
-    "paths": {
-      "@igo2/*": ["dist/*"]
-    }
+    "strict": true,
+    "types": []
   },
   "exclude": ["**/*.spec.ts"],
   "angularCompilerOptions": {

--- a/packages/utils/tsconfig.lib.prod.json
+++ b/packages/utils/tsconfig.lib.prod.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@igo2/*": ["dist/*"]
+    }
   }
 }


### PR DESCRIPTION
Nous activons le mode strict pour renforcer la qualité du code et détecter davantage de cas limites dès la phase de développement.

Note sur la démarche : Les premières PR ne corrigeront pas l'intégralité des erreurs. Pour éviter un blocage prolongé, plusieurs avertissements seront temporairement ignorés (via des any ou @ts-ignore). C’est une première étape essentielle qui sera complétée progressivement.

C'est la première étape d'une série de 8 Pull Request pour assainir l'ensemble de la base de code.

(cherry picked from commit c5af215f553fb13d5953f4deffbf3c2b1e8bbe2a)
