### PR TITLE
feat(geo): implement OGC API Routes support

### DIFF
--- a/packages/geo/src/lib/directions/directions-sources/directions-source.interface.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.interface.ts
@@ -1,15 +1,17 @@
 import { Provider } from '@angular/core';
 
-export interface DirectionsSourceOptions extends BaseDirectionsSourceOptions {
+export interface DirectionsSourceOptions {
   osrm?: OsrmDirectionsSourceOptions;
   logo?: string;
+  defaultSourceId?: string;
 }
 
 export type OsrmDirectionsSourceOptions = BaseDirectionsSourceOptions;
 
-interface BaseDirectionsSourceOptions {
+export interface BaseDirectionsSourceOptions {
+  id: string;
+  baseUrl: string;
   name?: string;
-  baseUrl?: string;
   profiles?: BaseDirectionsSourceOptionsProfile[];
 }
 

--- a/packages/geo/src/lib/directions/directions-sources/directions-source.interface.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.interface.ts
@@ -2,11 +2,19 @@ import { Provider } from '@angular/core';
 
 export interface DirectionsSourceOptions {
   osrm?: OsrmDirectionsSourceOptions;
+  ogcApiRoutes?: OgcApiRoutesDirectionsSourceOptions;
   logo?: string;
   defaultSourceId?: string;
 }
 
 export type OsrmDirectionsSourceOptions = BaseDirectionsSourceOptions;
+export interface OgcApiRoutesDirectionsSourceOptions extends BaseDirectionsSourceOptions {
+  routePath?: string;
+  httpMethod?: 'GET' | 'POST';
+  waypointsParam?: string;
+  coordinateSeparator?: string;
+  waypointSeparator?: string;
+}
 
 export interface BaseDirectionsSourceOptions {
   id: string;
@@ -32,5 +40,6 @@ export interface DirectionSourceFeature<KindT extends DirectionSourceKind> {
 }
 
 export enum DirectionSourceKind {
-  OSRM = 0
+  OSRM = 0,
+  OGC_API_ROUTES = 1
 }

--- a/packages/geo/src/lib/directions/directions-sources/directions-source.provider.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.provider.ts
@@ -3,6 +3,7 @@ import {
   DirectionSourceFeature,
   DirectionSourceKind
 } from './directions-source.interface';
+import { OgcApiRoutesDirectionsSource } from './ogc-api-routes-directions-source';
 import { OsrmDirectionsSource } from './osrm-directions-source';
 
 export function osrmDirectionsSourcesFactory() {
@@ -21,5 +22,24 @@ export function withOsrmSource(): DirectionSourceFeature<DirectionSourceKind.OSR
   return {
     kind: DirectionSourceKind.OSRM,
     providers: [provideOsrmDirectionsSource()]
+  };
+}
+
+export function ogcApiRoutesDirectionsSourcesFactory() {
+  return new OgcApiRoutesDirectionsSource();
+}
+
+export function provideOgcApiRoutesDirectionsSource() {
+  return {
+    provide: DirectionsSource,
+    useFactory: ogcApiRoutesDirectionsSourcesFactory,
+    multi: true
+  };
+}
+
+export function withOgcApiRoutesSource(): DirectionSourceFeature<DirectionSourceKind.OGC_API_ROUTES> {
+  return {
+    kind: DirectionSourceKind.OGC_API_ROUTES,
+    providers: [provideOgcApiRoutesDirectionsSource()]
   };
 }

--- a/packages/geo/src/lib/directions/directions-sources/directions-source.ts
+++ b/packages/geo/src/lib/directions/directions-sources/directions-source.ts
@@ -6,6 +6,7 @@ import { BaseDirectionsSourceOptionsProfile } from './directions-source.interfac
 
 export abstract class DirectionsSource {
   abstract profiles: BaseDirectionsSourceOptionsProfile[];
+  abstract getSourceId(): string;
   abstract getSourceName(): string;
   abstract getEnabledProfile(): BaseDirectionsSourceOptionsProfile;
   abstract getProfileWithAuthorization(): BaseDirectionsSourceOptionsProfile;

--- a/packages/geo/src/lib/directions/directions-sources/index.ts
+++ b/packages/geo/src/lib/directions/directions-sources/index.ts
@@ -1,4 +1,5 @@
 export * from './directions-source';
 export * from './directions-source.interface';
 export * from './osrm-directions-source';
+export * from './ogc-api-routes-directions-source';
 export * from './directions-source.provider';

--- a/packages/geo/src/lib/directions/directions-sources/ogc-api-routes-directions-source.ts
+++ b/packages/geo/src/lib/directions/directions-sources/ogc-api-routes-directions-source.ts
@@ -1,0 +1,399 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+
+import { ConfigService } from '@igo2/core/config';
+import { uuid } from '@igo2/utils';
+
+import { Position } from 'geojson';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  DirectionsFormat,
+  SourceDirectionsType
+} from '../shared/directions.enum';
+import {
+  DirectionOptions,
+  Directions,
+  DirectionsGeometry
+} from '../shared/directions.interface';
+import {
+  OgcApiRoutesApiResponse,
+  OgcApiRoutesBooleanQueryValue,
+  OgcApiRoutesFeature,
+  OgcApiRoutesFeatureType,
+  OgcApiRoutesPostBody,
+  OgcApiRoutesQueryParams
+} from '../shared/ogc-api-routes-rem.interface';
+import { DirectionsSource } from './directions-source';
+import {
+  BaseDirectionsSourceOptionsProfile,
+  OgcApiRoutesDirectionsSourceOptions
+} from './directions-source.interface';
+
+@Injectable()
+export class OgcApiRoutesDirectionsSource extends DirectionsSource {
+  private _http = inject(HttpClient);
+  private _config = inject(ConfigService);
+
+  get options(): OgcApiRoutesDirectionsSourceOptions {
+    return this._options;
+  }
+
+  set options(value: OgcApiRoutesDirectionsSourceOptions) {
+    this._options = value;
+  }
+
+  get sourceName(): string {
+    return this._options.name!;
+  }
+
+  set sourceName(value: string) {
+    this._options.name = value;
+  }
+
+  get sourceId(): string {
+    return this._options.id;
+  }
+
+  set sourceId(value: string) {
+    this._options.id = value;
+  }
+
+  get baseUrl(): string {
+    return this._options.baseUrl!;
+  }
+
+  set baseUrl(value: string) {
+    this._options.baseUrl = value;
+  }
+
+  get profiles(): BaseDirectionsSourceOptionsProfile[] {
+    return this._options.profiles!;
+  }
+
+  set profiles(value: BaseDirectionsSourceOptionsProfile[]) {
+    this._options.profiles = value;
+  }
+
+  private _options: OgcApiRoutesDirectionsSourceOptions;
+
+  constructor() {
+    super();
+    this._options =
+      this._config.getConfig('directionsSources.ogcApiRoutes') ??
+      ({
+        id: 'ogc-api-routes',
+        baseUrl: '/apis/routes'
+      } as OgcApiRoutesDirectionsSourceOptions);
+
+    if (!this.baseUrl) {
+      this.baseUrl = '/apis/routes';
+    }
+
+    if (!this.sourceName) {
+      this.sourceName = 'OGC API Routes';
+    }
+
+    if (!this.profiles || this.profiles.length === 0) {
+      this.profiles = [{ enabled: true, name: 'default' }];
+    } else if (!this.profiles.find((profile) => profile.enabled)) {
+      this.profiles[0].enabled = true;
+    }
+
+    if (!this.options.routePath) {
+      this.options.routePath = '/routes';
+    }
+    if (!this.options.httpMethod) {
+      this.options.httpMethod = 'POST';
+    }
+    if (!this.options.waypointsParam) {
+      this.options.waypointsParam = 'waypoints';
+    }
+    if (!this.options.coordinateSeparator) {
+      this.options.coordinateSeparator = ',';
+    }
+    if (!this.options.waypointSeparator) {
+      this.options.waypointSeparator = ';';
+    }
+  }
+
+  getSourceName(): string {
+    return this.sourceName;
+  }
+
+  getSourceId(): string {
+    return this.sourceId;
+  }
+
+  getEnabledProfile(): BaseDirectionsSourceOptionsProfile {
+    return this.profiles.find((profile) => profile.enabled)!;
+  }
+
+  getProfileWithAuthorization(): BaseDirectionsSourceOptionsProfile {
+    return this.profiles.find((profile) => profile.authorization)!;
+  }
+
+  route(
+    coordinates: Position[],
+    directionsOptions: DirectionOptions = {}
+  ): Observable<Directions[]> {
+    const endpoint = this.buildEndpoint();
+
+    if (this.options.httpMethod === 'POST') {
+      return this._http
+        .post<OgcApiRoutesApiResponse>(
+          endpoint,
+          this.buildPostBody(coordinates, directionsOptions)
+        )
+        .pipe(map((response) => this.extractRoutesData(response)));
+    }
+
+    const params = this.buildParams(coordinates, directionsOptions);
+    return this._http
+      .get<OgcApiRoutesApiResponse>(endpoint, { params })
+      .pipe(map((response) => this.extractRoutesData(response)));
+  }
+
+  private buildEndpoint(): string {
+    const baseUrl = this.baseUrl.replace(/\/+$/, '');
+    const routePath = (this.options.routePath ?? '/routes').replace(/^\/+/, '');
+    return `${baseUrl}/${routePath}`;
+  }
+
+  private buildParams(
+    coordinates: Position[],
+    directionsOptions: DirectionOptions
+  ): HttpParams {
+    const waypointsParam = this.options.waypointsParam ?? 'waypoints';
+    const overview: OgcApiRoutesBooleanQueryValue =
+      directionsOptions.overview !== false ? 'true' : 'false';
+    const steps: OgcApiRoutesBooleanQueryValue =
+      directionsOptions.steps !== false ? 'true' : 'false';
+    const alternatives: OgcApiRoutesBooleanQueryValue =
+      directionsOptions.alternatives === true ? 'true' : 'false';
+
+    const fromObject: OgcApiRoutesQueryParams = {
+      [waypointsParam]: this.formatWaypoints(coordinates),
+      overview,
+      steps,
+      alternatives,
+      profile: this.getEnabledProfile().name
+    };
+
+    return new HttpParams({ fromObject });
+  }
+
+  private formatCoordinate(position: Position): string {
+    const sep = this.options.coordinateSeparator ?? ',';
+    return [position[0], position[1]].join(sep);
+  }
+
+  private buildPostBody(
+    coordinates: Position[],
+    directionsOptions: DirectionOptions
+  ): OgcApiRoutesPostBody {
+    const profileName = this.getEnabledProfile().name;
+    const start = coordinates[0];
+    const end = coordinates[coordinates.length - 1];
+    const intermediate = coordinates.slice(1, -1);
+
+    return {
+      inputs: {
+        waypoints: {
+          value: {
+            type: 'MultiPoint',
+            coordinates
+          }
+        },
+        // mode is part of OGC API Routes mode extension (/inputs/mode).
+        mode: profileName,
+        // Keep explicit route-definition fields for servers supporting them.
+        start: start ? { value: start } : undefined,
+        end: end ? { value: end } : undefined,
+        intermediate:
+          intermediate.length > 0 ? { value: intermediate } : undefined,
+        preference:
+          directionsOptions.alternatives === true ? 'shortest' : 'fastest'
+      }
+    };
+  }
+
+  private formatWaypoints(coordinates: Position[]): string {
+    const waypointSeparator = this.options.waypointSeparator ?? ';';
+    return coordinates
+      .map((c) => this.formatCoordinate(c))
+      .join(waypointSeparator);
+  }
+
+  private extractRoutesData(response: OgcApiRoutesApiResponse): Directions[] {
+    if (!this.isRemFeatureCollection(response)) {
+      return [];
+    }
+
+    const features = response.features;
+    if (!this.hasRequiredRemComponents(features)) {
+      return [];
+    }
+
+    const overviewFeatures = features.filter((feature) =>
+      this.isOverviewFeature(feature)
+    );
+
+    return overviewFeatures
+      .map((feature, index) =>
+        this.mapFeatureToDirection(feature, response.name, index)
+      )
+      .filter((direction): direction is Directions => direction !== undefined);
+  }
+
+  private mapFeatureToDirection(
+    feature: OgcApiRoutesFeature,
+    collectionName: string | undefined,
+    index: number
+  ): Directions | undefined {
+    const geometry = feature.geometry;
+    if (!geometry) {
+      return;
+    }
+
+    const { type } = geometry;
+    const coordinates = (geometry as { coordinates?: unknown }).coordinates;
+    if (
+      !(type === 'LineString' || type === 'MultiLineString') ||
+      !Array.isArray(coordinates)
+    ) {
+      return;
+    }
+
+    const { properties } = feature;
+
+    const title =
+      collectionName ??
+      this.readString(properties, 'name') ??
+      `Route ${index + 1}`;
+
+    const distance = this.readNumber(properties, 'length_m');
+
+    const duration = this.readNumber(properties, 'duration_s');
+
+    const directionGeometry: DirectionsGeometry = {
+      type: type as 'LineString' | 'MultiLineString',
+      coordinates: coordinates as unknown as DirectionsGeometry['coordinates']
+    };
+
+    return {
+      id: uuid(),
+      title,
+      source: this.buildEndpoint(),
+      sourceType: SourceDirectionsType.Route,
+      order: index + 1,
+      format: DirectionsFormat.GeoJSON,
+      icon: 'directions',
+      projection: 'EPSG:4326',
+      distance,
+      duration,
+      geometry: directionGeometry,
+      steps: []
+    };
+  }
+
+  private readString(
+    input: Record<string, unknown>,
+    key: string
+  ): string | undefined {
+    const value = input[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+
+  private readNumber(
+    input: Record<string, unknown>,
+    key: string
+  ): number | undefined {
+    const value = input[key];
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : undefined;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private isRemFeatureCollection(
+    response: unknown
+  ): response is OgcApiRoutesApiResponse {
+    if (!this.isRecord(response)) {
+      return false;
+    }
+
+    if (response['type'] !== 'FeatureCollection') {
+      return false;
+    }
+
+    if (!Array.isArray(response['features'])) {
+      return false;
+    }
+
+    return response['features'].every((feature) =>
+      this.isOgcApiRoutesFeature(feature)
+    );
+  }
+
+  private isOgcApiRoutesFeature(
+    feature: unknown
+  ): feature is OgcApiRoutesFeature {
+    if (!this.isRecord(feature)) {
+      return false;
+    }
+
+    if (feature['type'] !== 'Feature') {
+      return false;
+    }
+
+    const geometry = feature['geometry'];
+    const properties = feature['properties'];
+    if (!this.isRecord(geometry) || !this.isRecord(properties)) {
+      return false;
+    }
+
+    return typeof geometry['type'] === 'string' && 'coordinates' in geometry;
+  }
+
+  private hasRequiredRemComponents(features: OgcApiRoutesFeature[]): boolean {
+    return (
+      features.some((feature) => this.isOverviewFeature(feature)) &&
+      features.some((feature) => this.getFeatureType(feature) === 'start') &&
+      features.some((feature) => this.getFeatureType(feature) === 'end') &&
+      features.some((feature) => this.getFeatureType(feature) === 'segment')
+    );
+  }
+
+  private isOverviewFeature(feature: OgcApiRoutesFeature): boolean {
+    const geometryType = feature.geometry?.type;
+    const featureType = this.getFeatureType(feature);
+
+    return featureType === 'overview' && geometryType === 'LineString';
+  }
+
+  private getFeatureType(
+    feature: OgcApiRoutesFeature
+  ): OgcApiRoutesFeatureType | undefined {
+    const featureType = feature.properties.featureType;
+    return this.isOgcApiRoutesFeatureType(featureType)
+      ? featureType
+      : undefined;
+  }
+
+  private isOgcApiRoutesFeatureType(
+    value: unknown
+  ): value is OgcApiRoutesFeatureType {
+    return (
+      value === 'overview' ||
+      value === 'start' ||
+      value === 'waypoint' ||
+      value === 'end' ||
+      value === 'segment'
+    );
+  }
+}

--- a/packages/geo/src/lib/directions/directions-sources/osrm-directions-source.ts
+++ b/packages/geo/src/lib/directions/directions-sources/osrm-directions-source.ts
@@ -47,6 +47,14 @@ export class OsrmDirectionsSource extends DirectionsSource {
     this._options.name = value;
   }
 
+  get sourceId(): string {
+    return this._options.id;
+  }
+
+  set sourceId(value: string) {
+    this._options.id = value;
+  }
+
   get baseUrl(): string {
     return this._options.baseUrl!;
   }
@@ -75,6 +83,9 @@ export class OsrmDirectionsSource extends DirectionsSource {
     if (!this.baseUrl) {
       this.baseUrl = '/apis/itineraire/route/v1/';
     }
+    if (!this.sourceId) {
+      this.sourceId = 'osrmQc';
+    }
 
     if (!this.sourceName) {
       this.sourceName = 'OSRM Québec';
@@ -93,8 +104,12 @@ export class OsrmDirectionsSource extends DirectionsSource {
     }
   }
 
+  getSourceId(): string {
+    return this.sourceId;
+  }
+
   getSourceName(): string {
-    return this.sourceName;
+    return this.sourceName ?? this.sourceId;
   }
 
   getEnabledProfile(): BaseDirectionsSourceOptionsProfile {

--- a/packages/geo/src/lib/directions/directions.component.html
+++ b/packages/geo/src/lib/directions/directions.component.html
@@ -1,4 +1,25 @@
 <div class="directions-options">
+  @if (sources.length > 1) {
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-label>{{
+        'igo.geo.directions.results.routingSource' | translate
+      }}</mat-label>
+      <mat-select
+        [matTooltip]="
+          'igo.geo.directions.results.routingSourceTooltip' | translate
+        "
+        [value]="activeSource"
+        (selectionChange)="onSourceChange($event.value)"
+      >
+        @for (source of sources; track source) {
+          <mat-option [value]="source.getSourceId()">{{
+            source.getSourceName()
+          }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  }
+
   <mat-slide-toggle
     [checked]="directionControlIsActive"
     [labelPosition]="'before'"

--- a/packages/geo/src/lib/directions/directions.component.ts
+++ b/packages/geo/src/lib/directions/directions.component.ts
@@ -7,7 +7,10 @@ import {
   inject,
   input
 } from '@angular/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { EntityStoreWatcher } from '@igo2/common/entity';
 import { LanguageService } from '@igo2/core/language';
@@ -32,6 +35,7 @@ import { SearchService } from '../search/shared/search.service';
 import { DirectionsButtonsComponent } from './directions-buttons/directions-buttons.component';
 import { DirectionsInputsComponent } from './directions-inputs/directions-inputs.component';
 import { DirectionsResultsComponent } from './directions-results/directions-results.component';
+import { DirectionsSource } from './directions-sources/directions-source';
 import { DirectionsSourceService } from './shared/directions-source.service';
 import { DirectionsType, ProposalType } from './shared/directions.enum';
 import {
@@ -61,7 +65,10 @@ import {
   templateUrl: './directions.component.html',
   styleUrls: ['./directions.component.scss'],
   imports: [
+    MatFormFieldModule,
+    MatSelectModule,
     MatSlideToggleModule,
+    MatTooltipModule,
     DirectionsButtonsComponent,
     DirectionsInputsComponent,
     DirectionsResultsComponent,
@@ -78,7 +85,6 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   private queryService = inject(QueryService);
 
   public projection = 'EPSG:4326';
-  public twoSourcesAvailable = false;
 
   private storeEmpty$$!: Subscription;
   private storeChange$$!: Subscription;
@@ -121,6 +127,13 @@ export class DirectionsComponent implements OnInit, OnDestroy {
     return this.directionsSourceService.sources[0].getEnabledProfile()
       .authorization;
   }
+  get activeSource(): DirectionsSource {
+    return this.directionsSourceService.activeSource;
+  }
+
+  get sources(): DirectionsSource[] {
+    return this.directionsSourceService.sources;
+  }
 
   constructor() {
     effect(() => {
@@ -131,10 +144,6 @@ export class DirectionsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.twoSourcesAvailable =
-      this.directionsSourceService.sources[0].profiles.length === 2
-        ? true
-        : false;
     this.queryService.queryEnabled = false;
     this.initEntityStores();
     setTimeout(() => {
@@ -515,5 +524,10 @@ export class DirectionsComponent implements OnInit, OnDestroy {
         ? ol.addInteraction(interaction)
         : ol.removeInteraction(interaction)
     );
+  }
+
+  onSourceChange(sourceId: string): void {
+    this.directionsSourceService.setActiveSource(sourceId);
+    this.getRoutes(this.isTranslating);
   }
 }

--- a/packages/geo/src/lib/directions/directions.provider.ts
+++ b/packages/geo/src/lib/directions/directions.provider.ts
@@ -18,6 +18,12 @@ export function provideDirection(
     provideDirectionsSourceService()
   ];
 
+  if (sources?.length === 0) {
+    throw new Error(
+      'You must at least provide 1 direction source. Ex: provideDirection(withOsrmSource())'
+    );
+  }
+
   for (const source of sources) {
     providers.push(...source.providers);
   }

--- a/packages/geo/src/lib/directions/shared/directions-source.service.ts
+++ b/packages/geo/src/lib/directions/shared/directions-source.service.ts
@@ -1,7 +1,35 @@
+import { inject } from '@angular/core';
+
+import { ConfigService } from '@igo2/core/config';
+
 import { DirectionsSource } from '../directions-sources/directions-source';
 
 export class DirectionsSourceService {
-  constructor(public sources: DirectionsSource[]) {}
+  public activeSource: DirectionsSource;
+  private configService = inject(ConfigService);
+
+  constructor(public sources: DirectionsSource[]) {
+    const preferredSourceId = this.configService.getConfig(
+      'directionsSources.defaultSourceId'
+    ) as string | undefined;
+
+    this.activeSource = this.computeActiveSource(preferredSourceId);
+  }
+
+  setActiveSource(id: string): void {
+    this.activeSource = this.computeActiveSource(id);
+  }
+
+  private computeActiveSource(id: string | undefined): DirectionsSource {
+    if (!id) {
+      return this.sources[0];
+    } else {
+      return (
+        this.sources.find((source) => source.getSourceId() === id) ??
+        this.sources[0]
+      );
+    }
+  }
 }
 
 export function directionsSourceServiceFactory(sources: DirectionsSource[]) {

--- a/packages/geo/src/lib/directions/shared/directions.service.ts
+++ b/packages/geo/src/lib/directions/shared/directions.service.ts
@@ -14,7 +14,6 @@ import { Observable, Subject } from 'rxjs';
 
 import { IgoMap } from '../../map/shared/map';
 import { PrintService } from '../../print/shared/print.service';
-import { DirectionsSource } from '../directions-sources/directions-source';
 import { DirectionOptions, Directions } from '../shared/directions.interface';
 import { DirectionsSourceService } from './directions-source.service';
 import { formatDistance, formatDuration, formatStep } from './directions.utils';
@@ -43,7 +42,7 @@ export class DirectionsService {
     if (coordinates.length === 0) {
       return;
     }
-    const source: DirectionsSource = this.directionsSourceService.sources[0];
+    const source = this.directionsSourceService.activeSource;
     const request = source.route(coordinates, directionsOptions);
     return request;
   }

--- a/packages/geo/src/lib/directions/shared/ogc-api-routes-rem.interface.ts
+++ b/packages/geo/src/lib/directions/shared/ogc-api-routes-rem.interface.ts
@@ -1,0 +1,63 @@
+import {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  Position
+} from 'geojson';
+
+export type OgcApiRoutesFeatureType =
+  | 'overview'
+  | 'start'
+  | 'waypoint'
+  | 'end'
+  | 'segment';
+
+export type OgcApiRoutesProperties = Exclude<GeoJsonProperties, null> & {
+  featureType?: OgcApiRoutesFeatureType;
+  name?: string;
+  length_m?: number;
+  duration_s?: number;
+};
+
+export type OgcApiRoutesFeature = Feature<Geometry, OgcApiRoutesProperties>;
+
+export type OgcApiRoutesApiResponse = FeatureCollection<
+  Geometry,
+  OgcApiRoutesProperties
+> & {
+  name?: string;
+};
+
+export type OgcApiRoutesBooleanQueryValue = 'true' | 'false';
+
+export type OgcApiRoutesQueryParams = Record<string, string> & {
+  overview: OgcApiRoutesBooleanQueryValue;
+  steps: OgcApiRoutesBooleanQueryValue;
+  alternatives: OgcApiRoutesBooleanQueryValue;
+  profile: string;
+};
+
+export interface OgcApiRoutesPostBody {
+  name?: string;
+  inputs: {
+    waypoints: {
+      value: {
+        type: 'MultiPoint';
+        coordinates: Position[];
+      };
+    };
+    mode?: string;
+    preference?: string;
+    start?: {
+      value: Position;
+    };
+    end?: {
+      value: Position;
+    };
+    intermediate?: {
+      value: Position[];
+    };
+    [key: string]: unknown;
+  };
+}

--- a/packages/geo/src/locale/en.geo.json
+++ b/packages/geo/src/locale/en.geo.json
@@ -475,6 +475,8 @@
             }
           },
           "routeOptions": "Route options",
+          "routingSource": "Routing source",
+          "routingSourceTooltip": "Changing source recalculates the route immediately",
           "stepTitleTooltip": "Zoom on location"
         },
         "toggle": {

--- a/packages/geo/src/locale/fr.geo.json
+++ b/packages/geo/src/locale/fr.geo.json
@@ -474,6 +474,8 @@
             }
           },
           "routeOptions": "Choix d'itinéraires",
+          "routingSource": "Source d'itinéraire",
+          "routingSourceTooltip": "Changer de source recalcule immédiatement l'itinéraire",
           "stepTitleTooltip": "Cadrer sur le lieu"
         },
         "toggle": {

--- a/projects/demo/src/environments/environment.prod.ts
+++ b/projects/demo/src/environments/environment.prod.ts
@@ -6,6 +6,7 @@ export const environment: EnvironmentOptions = {
   igo: {
     directionsSources: {
       osrm: {
+        id: 'orsmQc',
         name: 'OSRM Québec',
         baseUrl: '/apis/itineraire/route/v1/',
         profiles: [

--- a/projects/demo/src/environments/environment.ts
+++ b/projects/demo/src/environments/environment.ts
@@ -6,6 +6,7 @@ export const environment: EnvironmentOptions = {
   igo: {
     directionsSources: {
       osrm: {
+        id: 'orsmQc',
         name: 'OSRM Québec',
         baseUrl: '/apis/itineraire/route/v1/',
         profiles: [


### PR DESCRIPTION
Voir l'enjeu https://github.com/infra-geo-ouverte/igo2-lib/issues/1908

Ici, on ajoute une intégration standard basé sur le draft OGC-API routes.

Notre service privé sera arrimé a cette méthode d'appel afin de fournir des itinéraire. 

