### PR TITLE
fix(geo): update export service for ogre API compatibility and improve EPSG detection regex

### DIFF
--- a/packages/geo/src/lib/import-export/import-export/import-export.component.ts
+++ b/packages/geo/src/lib/import-export/import-export/import-export.component.ts
@@ -545,10 +545,10 @@ export class ImportExportComponent implements OnDestroy, OnInit {
 
       if (!isCSV || !data.combineLayers) {
         geomTypes.forEach((geomType) => {
-          if (geomType.type) {
-            fileName += geomType.type;
-          }
-          this.handleExport(geomType.features, data, fileName);
+          const formattedFilename = geomType.type
+            ? `${fileName}_${geomType.type}`
+            : fileName;
+          this.handleExport(geomType.features, data, formattedFilename);
         });
       }
       this.loading$.next(false);

--- a/packages/geo/src/lib/import-export/shared/export.service.ts
+++ b/packages/geo/src/lib/import-export/shared/export.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 
 import { EntityRecord } from '@igo2/common/entity';
@@ -63,9 +63,9 @@ export class ExportService {
   private tableDataService = inject(TableDataService);
 
   static ogreFormats: Record<ExportOgreFormat, string> = {
-    GML: 'gml',
-    GPX: 'gpx',
-    KML: 'kml',
+    GML: 'GML',
+    GPX: 'GPX',
+    KML: 'KML',
     Shapefile: 'ESRI Shapefile',
     CSV: 'CSV',
     /** @deprecated use CSV */
@@ -210,7 +210,7 @@ export class ExportService {
           title,
           projectionIn,
           projectionOut
-        ).subscribe({
+        )?.subscribe({
           complete: () => observer.complete(),
           error: (error) => observer.error(error)
         });
@@ -359,53 +359,78 @@ export class ExportService {
     projectionIn: string,
     projectionOut: string
   ) {
-    const featuresText = new olformat.GeoJSON().writeFeatures(olFeatures, {
+    if (!format) {
+      return;
+    }
+
+    const features = new olformat.GeoJSON().writeFeaturesObject(olFeatures, {
       dataProjection: projectionOut,
       featureProjection: projectionIn
     });
 
-    const sizeError = this.checkOgrePayloadSize(featuresText);
+    const sizeError = this.checkOgrePayloadSize(JSON.stringify(features));
     if (sizeError) return sizeError;
 
     const url = `${this.ogreUrl}/convertJson`;
 
-    const formData = new FormData();
+    let outputName = title;
+    let ogreFormat = ExportService.ogreFormats[format as ExportOgreFormat];
 
-    formData.append('json', featuresText);
+    let params = new HttpParams();
 
-    let outputName =
-      format === 'Shapefile'
-        ? `${title}.zip`
-        : `${title}.${format!.toLowerCase()}`;
-    let ogreFormat = ExportService.ogreFormats[format! as ExportOgreFormat];
-
-    if (isCsvExport(format!)) {
-      outputName = `${title}.csv`;
+    if (isCsvExport(format)) {
+      outputName = title;
 
       if (format === 'CSVcomma' || format === 'CSVsemicolon') {
         ogreFormat = 'CSV';
       }
 
-      formData.append('lco', `SEPARATOR=${csvSeparator}`);
-
-      if (format === 'CSVsemicolon') {
-        formData.append('lco', `SEPARATOR=${csvSeparator}`);
-      }
+      params = params.append('lco', `SEPARATOR=${csvSeparator}`);
     }
 
-    formData.append('outputName', this.formatFilename(outputName));
-    formData.append('format', ogreFormat);
-    formData.append('forceUTF8', 'true');
+    params = params
+      .set('name', this.formatFilename(outputName))
+      .set('format', ogreFormat)
+      .set('forceUTF8', 'true');
 
     return this.httpClient
-      .post(url, formData, {
-        responseType: 'blob'
+      .post(url, features, {
+        params,
+        responseType: 'blob',
+        observe: 'response'
       })
       .pipe(
-        tap((value) => {
-          downloadBlob(value, outputName);
+        tap((response) => {
+          if (!response.body) {
+            return;
+          }
+
+          const filename = this.getFileName(
+            response.headers,
+            outputName,
+            format
+          );
+          downloadBlob(response.body, filename);
         })
       );
+  }
+
+  private getFileName(
+    headers: HttpHeaders,
+    outputName: string,
+    format: AnyExportFormat
+  ): string {
+    const contentDisposition = headers.get('content-disposition');
+    const filenameMatch = contentDisposition?.match(/filename="?([^";\n]+)"?/);
+    if (filenameMatch?.[1]) {
+      return filenameMatch[1];
+    }
+
+    let extension = format.toLowerCase();
+    if (format === 'Shapefile') {
+      extension = 'zip';
+    }
+    return `${outputName}.${extension}`;
   }
 
   private formatFilename(name: string): string {
@@ -413,7 +438,7 @@ export class ExportService {
       .replaceAll(' ', '_')
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
-      .replace(/’/g, "'");
+      .replace(/[^a-zA-Z0-9_-]/g, '');
   }
 
   private nothingToExport(
@@ -595,12 +620,12 @@ export class ExportService {
   }
 
   /**
-   * Checks if the given payload exceeds the OGRE maximum allowed size (2MB).
+   * Checks if the given payload exceeds the OGRE maximum allowed size (50MB).
    * @param payload The GeoJSON payload as a string.
    * @returns An Observable that throws an error if the payload is too large, or undefined if the size is acceptable.
    */
   private checkOgrePayloadSize(payload: string): Observable<never> | undefined {
-    const OGRE_MAX_SIZE = 2 * 1024 * 1024; // 2MB
+    const OGRE_MAX_SIZE = 50 * 1024 * 1024; // 50MB
     const byteLength = new TextEncoder().encode(payload).length;
     if (byteLength > OGRE_MAX_SIZE) {
       const error = new Error();

--- a/packages/geo/src/lib/map/shared/projection.utils.ts
+++ b/packages/geo/src/lib/map/shared/projection.utils.ts
@@ -116,9 +116,9 @@ export function detectFileEPSG(options: {
           const text = reader.result as string;
           const lines = (text as string).split('\n');
           for (let line = 0; line <= nbLines; line++) {
-            const epsg = lines[line].match(/EPSG:\d{0,6}/gm);
+            const epsg = lines[line].match(/EPSG:{1,2}\d{1,6}/gm);
             if (epsg !== null && epsg.length) {
-              resolve(epsg[0]);
+              resolve(epsg[0].replace(/::/g, ':'));
               break;
             } else {
               resolve(undefined);


### PR DESCRIPTION
Nouvelle URL pour OGRE, l'outil de conversion de données spatiales: https://ogre.geo.msp.gouv.qc.ca
Cette PR contient les ajustements nécessaire selon les breaking changes de l'API