### PR TITLE
fix(geo): add overflow-wrap to igo-layer-title for better text handling

### DIFF
--- a/packages/geo/src/lib/layer/layer-item/layer-item.component.scss
+++ b/packages/geo/src/lib/layer/layer-item/layer-item.component.scss
@@ -50,6 +50,7 @@
   -webkit-box-orient: vertical;
   line-clamp: 2;
   -webkit-line-clamp: 2;
+  overflow-wrap: anywhere;
 }
 
 .igo-layer-list-item {


### PR DESCRIPTION
Lorsque le nom de la couche n'a pas d'espace l'interpolation sur l'overflow n'est pas fonctionnel avec les "..."
Par exemple: NOM_DU_FICHIER_TRÈS_LONG_AVEC_MULTIPOLYGON_SANS_ESPACE
