### PR TITLE
fix(geo): original sort for feature-details properties

### DIFF
--- a/packages/geo/src/lib/feature/feature-details/feature-details.component.html
+++ b/packages/geo/src/lib/feature/feature-details/feature-details.component.html
@@ -5,7 +5,7 @@
   <table class="igo-striped">
     <tbody>
       @for (
-        property of filterFeatureProperties(feature()!) | keyvalue;
+        property of filterFeatureProperties(feature()!) | keyvalue: null;
         track property
       ) {
         <tr>


### PR DESCRIPTION
Régression au niveau des attributs des entités sont en ordre alphabétique au lieu d'être en ordre d'importance. On remet le comportement par défaut, on respect l'ordre d'entrée

<img width="550" height="364" alt="image" src="https://github.com/user-attachments/assets/942fe0f3-3d77-4959-b372-708770489551" />
