### PR TITLE
fix(geo/context): capabilities, share - add support for mapServerUrl …

### DIFF
--- a/packages/context/src/lib/share-map/shared/share-map-legacy.service.ts
+++ b/packages/context/src/lib/share-map/shared/share-map-legacy.service.ts
@@ -1,11 +1,14 @@
 import { HttpParams } from '@angular/common/http';
 import { Params } from '@angular/router';
 
-import { RouteServiceOptions } from '@igo2/core/route';
 import { LayerOptions, generateIdFromSourceOptions } from '@igo2/geo';
-import { ObjectUtils } from '@igo2/utils';
+import { ObjectUtils, resolveUrl } from '@igo2/utils';
 
-import { PositionParams, ServiceType } from './share-map.interface';
+import {
+  PositionParams,
+  ServiceType,
+  ShareMapParserOptions
+} from './share-map.interface';
 import { buildDataSourceOptions } from './share-map.utils';
 
 interface SharedLayerConfig {
@@ -14,7 +17,7 @@ interface SharedLayerConfig {
 }
 
 export class ShareMapLegacyParser {
-  constructor(private options: RouteServiceOptions) {}
+  constructor(private options: ShareMapParserOptions) {}
 
   parseUrl(params: Params): LayerOptions[] {
     const layerOptions = ServiceType.flatMap((type) =>
@@ -25,10 +28,10 @@ export class ShareMapLegacyParser {
   }
 
   parsePosition(params: Params): PositionParams {
-    const center = params[this.options.centerKey!];
-    const projection = params[this.options.projectionKey!];
-    const zoom = params[this.options.zoomKey!];
-    const rotation = params[this.options.rotationKey!];
+    const center = params[this.options.legacyOptions.centerKey!];
+    const projection = params[this.options.legacyOptions.projectionKey!];
+    const zoom = params[this.options.legacyOptions.zoomKey!];
+    const rotation = params[this.options.legacyOptions.rotationKey!];
 
     return ObjectUtils.removeUndefined({
       center: center?.split(',').map(Number),
@@ -90,7 +93,7 @@ export class ShareMapLegacyParser {
       iarcgisLayersKey,
       tarcgisUrlKey,
       tarcgisLayersKey
-    } = this.options;
+    } = this.options.legacyOptions;
 
     switch (type) {
       case 'wms':
@@ -146,6 +149,9 @@ export class ShareMapLegacyParser {
     if (url.endsWith('?')) {
       url = url.substring(0, url.length - 1);
     }
+
+    url = resolveUrl(url, this.options.serverUrl);
+
     return [url, version];
   }
 

--- a/packages/context/src/lib/share-map/shared/share-map-legacy.spec.ts
+++ b/packages/context/src/lib/share-map/shared/share-map-legacy.spec.ts
@@ -84,7 +84,9 @@ describe('ShareMapLegacyParser', () => {
   let service: ShareMapLegacyParser;
 
   beforeEach(() => {
-    service = new ShareMapLegacyParser(ROUTE_OPTION_LEGACY_MOCK);
+    service = new ShareMapLegacyParser({
+      legacyOptions: ROUTE_OPTION_LEGACY_MOCK
+    });
   });
 
   it('should be created', () => {

--- a/packages/context/src/lib/share-map/shared/share-map-parser.spec.ts
+++ b/packages/context/src/lib/share-map/shared/share-map-parser.spec.ts
@@ -102,7 +102,9 @@ describe('ShareMapParseUrl', () => {
   beforeEach(() => {
     const optionsLegacy = ROUTE_OPTION_LEGACY_MOCK;
     SHARE_MAP_DEFS = shareMapKeyDefs(SHARE_MAP_KEYS_DEFAULT_OPTIONS_MOCK);
-    shareMapParseUrl = new ShareMapParser(SHARE_MAP_DEFS, optionsLegacy);
+    shareMapParseUrl = new ShareMapParser(SHARE_MAP_DEFS, {
+      legacyOptions: optionsLegacy
+    });
   });
 
   it('should be created', () => {

--- a/packages/context/src/lib/share-map/shared/share-map-parser.ts
+++ b/packages/context/src/lib/share-map/shared/share-map-parser.ts
@@ -1,19 +1,19 @@
 import { Params } from '@angular/router';
 
-import { RouteServiceOptions } from '@igo2/core/route';
 import type {
   AnyLayerOptions,
   LayerGroupOptions,
   LayerOptions
 } from '@igo2/geo';
-import { ObjectUtils, OptionalRequired } from '@igo2/utils';
+import { ObjectUtils, OptionalRequired, resolveUrl } from '@igo2/utils';
 
 import { ShareMapLegacyParser } from './share-map-legacy.service';
 import {
   LayerProperties,
   PositionParams,
   ServiceType,
-  ShareMapKeysDefinitions
+  ShareMapKeysDefinitions,
+  ShareMapParserOptions
 } from './share-map.interface';
 import {
   buildDataSourceOptions,
@@ -41,15 +41,15 @@ export class ShareMapParser {
 
   constructor(
     private keysDefinitions: ShareMapKeysDefinitions,
-    private legacyOptions: RouteServiceOptions
+    private options: ShareMapParserOptions
   ) {
-    this.legacy = new ShareMapLegacyParser(legacyOptions);
+    this.legacy = new ShareMapLegacyParser(this.options);
   }
 
   parseLayers(params: Params): AnyLayerOptions[] {
     if (
       !hasModernShareParams(params, this.keysDefinitions) &&
-      hasLegacyParams(params, this.legacyOptions)
+      hasLegacyParams(params, this.options.legacyOptions)
     ) {
       return this.legacy.parseUrl(params);
     }
@@ -123,7 +123,7 @@ export class ShareMapParser {
       const urlIndex = this.extractUrlIndex(layer);
       if (urlIndex === undefined) return undefined;
 
-      const url = urls[urlIndex];
+      const url = resolveUrl(urls[urlIndex], this.options.serverUrl);
       const version = this.extractVersionFromUrl(url);
 
       const sourceOptions = buildDataSourceOptions(

--- a/packages/context/src/lib/share-map/shared/share-map.interface.ts
+++ b/packages/context/src/lib/share-map/shared/share-map.interface.ts
@@ -137,3 +137,8 @@ export const SHARE_MAP_KEYS_DEFAULT_OPTIONS: ShareMapRouteKeysOptions = {
   rotation: 'r',
   opacity: 'o'
 };
+
+export interface ShareMapParserOptions {
+  legacyOptions: RouteServiceOptions;
+  serverUrl?: string;
+}

--- a/packages/context/src/lib/share-map/shared/share-map.service.ts
+++ b/packages/context/src/lib/share-map/shared/share-map.service.ts
@@ -2,6 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { Injectable, inject } from '@angular/core';
 import { Params } from '@angular/router';
 
+import { ConfigService } from '@igo2/core/config';
 import { RouteService, RouteServiceOptions } from '@igo2/core/route';
 import { AnyLayerOptions, IgoMap } from '@igo2/geo';
 
@@ -22,6 +23,7 @@ import {
 export class ShareMapService {
   routeService = inject(RouteService);
   document = inject<Document>(DOCUMENT);
+  config = inject(ConfigService);
 
   get language(): string {
     return this._language;
@@ -50,10 +52,10 @@ export class ShareMapService {
 
     this.encoder = new ShareMapEncoder(this.keysDefinitions, this.document);
 
-    this.parser = new ShareMapParser(
-      this.keysDefinitions,
-      this.routeService.legacyOptions
-    );
+    this.parser = new ShareMapParser(this.keysDefinitions, {
+      legacyOptions: this.routeService.legacyOptions,
+      serverUrl: this.config.getConfig('mapServerUrl')
+    });
 
     this.routeService.queryParams.subscribe((params) => {
       const language = params[this.keysDefinitions.languageKey];

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.spec.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.spec.ts
@@ -99,10 +99,14 @@ describe('CapabilitiesService', () => {
 
       service.getCapabilities('wms', url).subscribe({ error: () => {} });
 
-      // The URL should not be prefixed with the server origin
-      const req = httpMock.expectOne(
-        (r) => !r.url.startsWith('https://server.example.com')
-      );
+      // The URL should not resolve to the configured server host
+      const req = httpMock.expectOne((r) => {
+        try {
+          return new URL(r.url).host !== 'server.example.com';
+        } catch {
+          return true;
+        }
+      });
       expect(req.request.url).not.toContain('server.example.com');
       req.flush('');
     });

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.spec.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.spec.ts
@@ -1,12 +1,110 @@
-import { inject } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from '@igo2/core/config';
 
 import { CapabilitiesService } from './capabilities.service';
 
 describe('CapabilitiesService', () => {
-  it('should create', inject(
-    [CapabilitiesService],
-    (service: CapabilitiesService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  let service: CapabilitiesService;
+  let httpMock: HttpTestingController;
+
+  function setup(serverUrl?: string) {
+    const configServiceSpy = {
+      getConfig: vi.fn().mockReturnValue(serverUrl)
+    } as unknown as ConfigService;
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: ConfigService, useValue: configServiceSpy }]
+    });
+
+    service = TestBed.inject(CapabilitiesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  }
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    setup();
+    expect(service).toBeTruthy();
+  });
+
+  describe('getCapabilities — URL resolution', () => {
+    it('should request an absolute URL unchanged when no serverUrl is configured', () => {
+      setup(undefined);
+      const url = 'https://geo.example.com/wms-abs-no-config';
+
+      service.getCapabilities('wms', url).subscribe({ error: () => {} });
+
+      const req = httpMock.expectOne((r) => r.url === url);
+      expect(req.request.url).toBe(url);
+      req.flush('');
+    });
+
+    it('should request an absolute URL unchanged when serverUrl is configured', () => {
+      setup('https://server.example.com/igo2');
+      const url = 'https://geo.example.com/wms-abs-with-config';
+
+      service.getCapabilities('wms', url).subscribe({ error: () => {} });
+
+      const req = httpMock.expectOne((r) => r.url === url);
+      expect(req.request.url).toBe(url);
+      req.flush('');
+    });
+
+    it('should keep a relative URL unchanged when no serverUrl is configured', () => {
+      setup(undefined);
+      const url = '/api/wms-rel-no-config';
+
+      service.getCapabilities('wms', url).subscribe({ error: () => {} });
+
+      const req = httpMock.expectOne((r) => r.url === url);
+      expect(req.request.url).toBe(url);
+      req.flush('');
+    });
+
+    it('should resolve a relative URL to absolute using the origin of serverUrl', () => {
+      setup('https://server.example.com/igo2/app');
+      const relativeUrl = '/api/wms-rel-with-config';
+      const expectedUrl = 'https://server.example.com/api/wms-rel-with-config';
+
+      service
+        .getCapabilities('wms', relativeUrl)
+        .subscribe({ error: () => {} });
+
+      const req = httpMock.expectOne((r) => r.url === expectedUrl);
+      expect(req.request.url).toBe(expectedUrl);
+      req.flush('');
+    });
+
+    it('should use only the origin (no path) from serverUrl when resolving', () => {
+      setup('https://server.example.com/some/deep/path?foo=bar');
+      const relativeUrl = '/wms-rel-origin-only';
+      const expectedUrl = 'https://server.example.com/wms-rel-origin-only';
+
+      service
+        .getCapabilities('wms', relativeUrl)
+        .subscribe({ error: () => {} });
+
+      const req = httpMock.expectOne((r) => r.url === expectedUrl);
+      expect(req.request.url).toBe(expectedUrl);
+      req.flush('');
+    });
+
+    it('should not modify a protocol-relative URL (starts with //)', () => {
+      setup('https://server.example.com/igo2');
+      const url = '//other.example.com/wms-proto-rel';
+
+      service.getCapabilities('wms', url).subscribe({ error: () => {} });
+
+      // The URL should not be prefixed with the server origin
+      const req = httpMock.expectOne(
+        (r) => !r.url.startsWith('https://server.example.com')
+      );
+      expect(req.request.url).not.toContain('server.example.com');
+      req.flush('');
+    });
+  });
 });

--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -1,7 +1,8 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 
-import { ObjectUtils } from '@igo2/utils';
+import { ConfigService } from '@igo2/core/config';
+import { ObjectUtils, resolveUrl } from '@igo2/utils';
 
 import olAttribution from 'ol/control/Attribution';
 import { EsriJSON, WMSCapabilities, WMTSCapabilities } from 'ol/format';
@@ -41,6 +42,7 @@ import {
 } from '../../query/shared/query.enums';
 import { EsriStyleGenerator } from '../../style/shared/esri-style-generator';
 import {
+  GetCapabilitiesParams,
   TypeCapabilities,
   TypeCapabilitiesStrings
 } from './capabilities.interface';
@@ -57,12 +59,18 @@ import { WMTSDataSourceOptions } from './datasources/wmts-datasource.interface';
 export class CapabilitiesService {
   private http = inject(HttpClient);
   private mapService = inject(MapService);
+  private configService = inject(ConfigService);
+  private mapServerUrl?: string;
 
   private parsers = {
     wms: new WMSCapabilities(),
     wmts: new WMTSCapabilities(),
     esriJSON: new EsriJSON()
   };
+
+  constructor() {
+    this.mapServerUrl = this.configService.getConfig<string>('mapServerUrl');
+  }
 
   getWMSOptions(
     baseOptions: WMSDataSourceOptions
@@ -209,20 +217,21 @@ export class CapabilitiesService {
     baseUrl: string,
     version?: string
   ): Observable<any> {
-    const params = new HttpParams({
-      fromObject: {
-        request: 'GetCapabilities',
-        service: service.toUpperCase(),
-        version: version || '1.3.0',
-        _i: 'true'
-      }
-    });
+    const resolvedUrl = resolveUrl(baseUrl, this.mapServerUrl);
+
+    const fullParams: Record<GetCapabilitiesParams | '_i', string> = {
+      request: 'GetCapabilities',
+      service: service.toUpperCase(),
+      version: version || '1.3.0',
+      _i: 'true'
+    };
+    const params = this.buildHttpParams(resolvedUrl, fullParams);
 
     let request;
     if (TypeCapabilities[service] === 'esriJSON') {
-      request = this.http.get(baseUrl + '?f=json');
+      request = this.http.get(resolvedUrl + '?f=json');
     } else {
-      request = this.http.get(baseUrl, {
+      request = this.http.get(resolvedUrl, {
         params,
         responseType: 'text'
       });
@@ -633,5 +642,29 @@ export class CapabilitiesService {
     } as LegendOptions;
 
     return legendOptions;
+  }
+
+  /**
+   * Builds HttpParams by excluding keys already present in the base URL's query string.
+   * This avoids duplicate parameters when appending to an existing URL.
+   */
+  private buildHttpParams(
+    url: string,
+    params: Record<string, string>
+  ): HttpParams {
+    const [, queryString] = url.split('?');
+
+    const existingKeys = new Set(
+      (queryString ?? '')
+        .split('&')
+        .map((pair) => pair.split('=')[0].trim())
+        .filter(Boolean)
+    );
+
+    const filteredParams = Object.fromEntries(
+      Object.entries(params).filter(([key]) => !existingKeys.has(key))
+    );
+
+    return new HttpParams({ fromObject: filteredParams });
   }
 }

--- a/packages/geo/src/lib/environment/environment.interface.ts
+++ b/packages/geo/src/lib/environment/environment.interface.ts
@@ -27,6 +27,7 @@ export interface EnvironmentOptions {
     contextListFile?: string;
     defaultContextUri?: string;
   };
+  mapServerUrl?: string;
   layer?: LayerConfig;
   depot?: DepotOptions;
   directionsSources?: DirectionsSourceOptions;

--- a/packages/utils/src/lib/url.utils.ts
+++ b/packages/utils/src/lib/url.utils.ts
@@ -15,3 +15,16 @@ export function removeQueryParameters(url: string, keys: string[]): string {
   const newQuery = newParams.toString();
   return newQuery ? `${path}?${newQuery}` : path;
 }
+
+export function resolveUrl(url: string, host?: string): string {
+  const isRelative = url.startsWith('/') && !url.startsWith('//');
+  if (isRelative && host) {
+    try {
+      const { origin } = new URL(host);
+      return `${origin}${url}`;
+    } catch {
+      return url;
+    }
+  }
+  return url;
+}


### PR DESCRIPTION
S'assurer de la compatibilité des liens de partage statiques. Ajouter la possibilité de résoudre des URL relatives et de leur fournir le complément d'URL à ajouter en suffixe. Concrètement, cela permettra de corriger un bogue dû à notre migration des URL relatives vers les URL absolues. Ce bogue affecte certains M/O qui utilisaient nos services avec des URL relatives ; ils pourront désormais spécifier l'URL du serveur cartographique avec laquelle ils souhaitent résoudre ces URL relatives.