### PR TITLE
chore(husky): move from pre-commit to pre-push code validation

### DIFF
--- a/.config/husky/pre-commit
+++ b/.config/husky/pre-commit
@@ -1,3 +1,0 @@
-. "$(dirname "$0")/node-path.sh"
-
-npx lint-staged

--- a/.config/husky/pre-push
+++ b/.config/husky/pre-push
@@ -1,0 +1,5 @@
+. "$(dirname "$0")/node-path.sh"
+
+npm run lint
+npm run types
+npm run format


### PR DESCRIPTION
Par souci de performance, on déplace les validations de code dans les pre-push plutot qu'en pré-commit.
