### PR TITLE
fix(poi-button): handle potential undefined value for selected POI

### DIFF
--- a/packages/context/src/lib/context-map-button/poi-button/poi-button.component.html
+++ b/packages/context/src/lib/context-map-button/poi-button/poi-button.component.html
@@ -6,7 +6,7 @@
   [(value)]="selected"
 >
   <mat-select-trigger>
-    {{ selected.title || '' }}
+    {{ selected?.title || '' }}
   </mat-select-trigger>
   <mat-option (click)="createPoi()" class="poi-option">
     <div

--- a/packages/context/src/lib/context-map-button/poi-button/poi-button.component.ts
+++ b/packages/context/src/lib/context-map-button/poi-button/poi-button.component.ts
@@ -49,12 +49,12 @@ export class PoiButtonComponent implements OnInit, OnDestroy {
   private messageService = inject(MessageService);
   private languageService = inject(LanguageService);
   private confirmDialogService = inject(ConfirmDialogService);
-  selected!: Poi;
+  selected?: Poi;
 
   readonly map = input.required<IgoMap>();
   readonly color = input<string>();
 
-  public pois!: Poi[];
+  public pois: Poi[] = [];
   private authenticate$$!: Subscription;
 
   ngOnInit() {


### PR DESCRIPTION
When igo2-api is used, with no pois, the app crash!

<img width="562" height="242" alt="image" src="https://github.com/user-attachments/assets/0f29cb1c-2b82-4b6f-93b4-f80b000cb72a" />
