### PR TITLE
chore: add git.scanRepositories setting for client project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "angular.enable-strict-mode-prompt": false,
   "eslint.useFlatConfig": true,
+  "git.scanRepositories": ["projects/client"],
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,


### PR DESCRIPTION
Vscode ne détecte plus automatiquement le sous-répertoire Git comme celui pour le client. 