### PR TITLE
fix(geo): spatial-filter zone regression for the condition to load item

### DIFF
--- a/packages/geo/src/lib/filter/shared/spatial-filter.service.ts
+++ b/packages/geo/src/lib/filter/shared/spatial-filter.service.ts
@@ -185,7 +185,7 @@ export class SpatialFilterService {
   ): Observable<Feature> | undefined {
     const featureType = this.urlFilterList[type];
     const featureCode = feature.properties.code;
-    if (featureType && featureCode) {
+    if (!featureType || !featureCode) {
       return undefined;
     }
     return this.http


### PR DESCRIPTION
Régression, la zone devrait être sélectionnable
<img width="1901" height="935" alt="image" src="https://github.com/user-attachments/assets/9147403c-1926-4fea-8df0-90e12ba2cda1" />
