### PR TITLE
refactor(geo)!: initialize projections through provider

### DIFF
--- a/packages/geo/src/lib/map/shared/index.ts
+++ b/packages/geo/src/lib/map/shared/index.ts
@@ -8,6 +8,7 @@ export * from './mapOffline.directive';
 export * from './map-pointer-position.directive';
 export * from './hover-feature.directive';
 export * from './projection.interfaces';
+export * from './projection.provider';
 export * from './projection.service';
 export * from './controllers';
 export * from './projection.utils';

--- a/packages/geo/src/lib/map/shared/projection.provider.ts
+++ b/packages/geo/src/lib/map/shared/projection.provider.ts
@@ -1,0 +1,26 @@
+import {
+  EnvironmentProviders,
+  inject,
+  makeEnvironmentProviders,
+  provideAppInitializer
+} from '@angular/core';
+
+import {
+  PROJECTION_PROVIDER_OPTIONS,
+  ProjectionProviderOptions,
+  ProjectionService
+} from './projection.service';
+
+export function provideProjection(
+  options: ProjectionProviderOptions = {}
+): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: PROJECTION_PROVIDER_OPTIONS,
+      useValue: options
+    },
+    provideAppInitializer(() => {
+      inject(ProjectionService);
+    })
+  ]);
+}

--- a/packages/geo/src/lib/map/shared/projection.service.spec.ts
+++ b/packages/geo/src/lib/map/shared/projection.service.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from '@igo2/core/config';
+
+import * as olproj from 'ol/proj';
+
+import { BehaviorSubject } from 'rxjs';
+
+import { Projection } from './projection.interfaces';
+import { provideProjection } from './projection.provider';
+import { ProjectionService } from './projection.service';
+
+describe('ProjectionService', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('can be instantiated without ConfigService', () => {
+    TestBed.configureTestingModule({
+      providers: [ProjectionService]
+    });
+
+    expect(TestBed.inject(ProjectionService)).toBeInstanceOf(ProjectionService);
+  });
+
+  it('registers projections provided through provideProjection', () => {
+    const projection: Projection = {
+      code: 'EPSG:99990',
+      def: '+proj=longlat +datum=WGS84 +no_defs'
+    };
+
+    TestBed.configureTestingModule({
+      providers: [provideProjection({ projections: [projection] })]
+    });
+
+    TestBed.inject(ProjectionService);
+
+    expect(projection.alias).toBe(projection.code);
+    expect(olproj.get(projection.code)).not.toBeNull();
+  });
+
+  it('registers configured projections after configuration is loaded', () => {
+    const isLoaded$ = new BehaviorSubject(false);
+    const projection: Projection = {
+      code: 'EPSG:99991',
+      def: '+proj=longlat +datum=WGS84 +no_defs'
+    };
+    let configRead = false;
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            isLoaded$,
+            getConfig: () => {
+              configRead = true;
+              return [projection];
+            }
+          }
+        }
+      ]
+    });
+
+    TestBed.inject(ProjectionService);
+    expect(configRead).toBe(false);
+
+    isLoaded$.next(true);
+
+    expect(configRead).toBe(true);
+    expect(projection.alias).toBe(projection.code);
+    expect(olproj.get(projection.code)).not.toBeNull();
+  });
+});

--- a/packages/geo/src/lib/map/shared/projection.service.ts
+++ b/packages/geo/src/lib/map/shared/projection.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, InjectionToken, inject } from '@angular/core';
 
 import { ConfigService } from '@igo2/core/config';
 
@@ -6,8 +6,16 @@ import * as olproj from 'ol/proj';
 import * as olproj4 from 'ol/proj/proj4';
 
 import proj4 from 'proj4';
+import { filter, take } from 'rxjs';
 
 import { Projection } from './projection.interfaces';
+
+export interface ProjectionProviderOptions {
+  projections?: Projection[];
+}
+
+export const PROJECTION_PROVIDER_OPTIONS =
+  new InjectionToken<ProjectionProviderOptions>('PROJECTION_PROVIDER_OPTIONS');
 
 /**
  * When injected, this service automatically registers and
@@ -18,15 +26,15 @@ import { Projection } from './projection.interfaces';
   providedIn: 'root'
 })
 export class ProjectionService {
-  private config = inject(ConfigService);
+  private config = inject(ConfigService, { optional: true });
+  private options = inject(PROJECTION_PROVIDER_OPTIONS, { optional: true });
 
   constructor() {
-    const projections: Projection[] =
-      this.config.getConfig('projections') || [];
-    projections.forEach((projection) => {
-      projection.alias = projection.alias ? projection.alias : projection.code;
-      this.registerProjection(projection);
-    });
+    this.registerProjections(this.options?.projections ?? []);
+
+    this.config?.isLoaded$
+      .pipe(filter(Boolean), take(1))
+      .subscribe(() => this.registerConfiguredProjections());
 
     // register all utm zones
     for (let utmZone = 1; utmZone < 61; utmZone++) {
@@ -60,6 +68,19 @@ export class ProjectionService {
       };
       this.registerProjection(proj);
     }
+  }
+
+  private registerConfiguredProjections(): void {
+    const projections: Projection[] =
+      this.config?.getConfig('projections') || [];
+    this.registerProjections(projections);
+  }
+
+  private registerProjections(projections: Projection[]): void {
+    projections.forEach((projection) => {
+      projection.alias = projection.alias ? projection.alias : projection.code;
+      this.registerProjection(projection);
+    });
   }
 
   /**

--- a/packages/integration/src/lib/map/map.state.ts
+++ b/packages/integration/src/lib/map/map.state.ts
@@ -2,12 +2,7 @@ import { Injectable, inject } from '@angular/core';
 
 import { ConfigService } from '@igo2/core/config';
 import { StorageService } from '@igo2/core/storage';
-import {
-  IgoMap,
-  MapService,
-  OverlayService,
-  ProjectionService
-} from '@igo2/geo';
+import { IgoMap, MapService, OverlayService } from '@igo2/geo';
 
 /**
  * Service that holds the state of the map module
@@ -17,8 +12,6 @@ import {
 })
 export class MapState {
   private mapService = inject(MapService);
-  // eslint-disable-next-line @typescript-eslint/no-unused-private-class-members
-  private projectionService = inject(ProjectionService);
   private storageService = inject(StorageService);
   private configService = inject(ConfigService);
   private overlayService = inject(OverlayService);

--- a/projects/demo/src/app/app.config.ts
+++ b/projects/demo/src/app/app.config.ts
@@ -32,7 +32,12 @@ import { IgoCoreModule } from '@igo2/core';
 import { provideConfig } from '@igo2/core/config';
 import { provideTranslation, withStaticConfig } from '@igo2/core/language';
 import { provideSentryMonitoring } from '@igo2/core/monitoring';
-import { provideStyle, withGeostyler, withMapbox } from '@igo2/geo';
+import {
+  provideProjection,
+  provideStyle,
+  withGeostyler,
+  withMapbox
+} from '@igo2/geo';
 import { provideOffline, withIndexedDb } from '@igo2/geo/offline';
 
 import { environment } from '../environments/environment';
@@ -56,6 +61,7 @@ export const appConfig: ApplicationConfig = {
     provideConfig({
       default: environment.igo
     }),
+    provideProjection(),
     provideTranslation(withStaticConfig(environment.igo.language!)),
     provideAuthentification(),
     provideIcon(),

--- a/projects/demo/src/app/geo/layer/layer.component.ts
+++ b/projects/demo/src/app/geo/layer/layer.component.ts
@@ -18,7 +18,6 @@ import {
   MAP_DIRECTIVES,
   METADATA_DIRECTIVES,
   MapViewOptions,
-  ProjectionService,
   VectorLayerOptions,
   VectorTileLayerOptions,
   WFSDataSourceOptions
@@ -46,8 +45,6 @@ import { ExampleViewerComponent } from '../../components/example/example-viewer/
 })
 export class AppLayerComponent {
   private layerService = inject(LayerService);
-  // eslint-disable-next-line @typescript-eslint/no-unused-private-class-members
-  private projectionService = inject(ProjectionService);
 
   public map: IgoMap = new IgoMap({
     controls: {


### PR DESCRIPTION
BREAKING CHANGE: projections must now be explicitly provided with provideProjections().