### PR TITLE
fix(geo): improve datasources type handling and streamline saveableOp…

### DIFF
--- a/packages/geo/src/lib/datasource/shared/capabilities.service.ts
+++ b/packages/geo/src/lib/datasource/shared/capabilities.service.ts
@@ -562,7 +562,11 @@ export class CapabilitiesService {
       queryTitle: arcgisOptions.displayField
     });
     options['attributions'] = attributions;
-    return ObjectUtils.mergeDeep(options, baseOptions);
+    return ObjectUtils.mergeDeep(
+      options as unknown as
+        TileArcGISRestDataSourceOptions | ArcGISRestImageDataSourceOptions,
+      baseOptions
+    );
   }
 
   private findDataSourceInCapabilities(

--- a/packages/geo/src/lib/datasource/shared/datasource.service.ts
+++ b/packages/geo/src/lib/datasource/shared/datasource.service.ts
@@ -93,7 +93,7 @@ export class DataSourceService {
         break;
       case 'tiledebug':
         dataSource$ = this.createTileDebugDataSource(
-          options as TileDebugDataSource
+          options as TileDebugDataSourceOptions
         );
         break;
       case 'carto':
@@ -344,9 +344,12 @@ export class DataSourceService {
     observables.push(of(options));
     return forkJoin(observables).pipe(
       map((opts) => {
-        const optionsMerged = opts.reduce((a, b) =>
-          ObjectUtils.mergeDeep(a, b)
-        );
+        const [firstOptions, ...remainingOptions] = opts;
+        const optionsMerged =
+          remainingOptions.reduce<ArcGISRestDataSourceOptions>(
+            (a, b) => ObjectUtils.mergeDeep(a, b),
+            firstOptions as ArcGISRestDataSourceOptions
+          );
         return new ArcGISRestDataSource(optionsMerged);
       }),
       catchError(() => {
@@ -401,9 +404,12 @@ export class DataSourceService {
     observables.push(of(options));
     return forkJoin(observables).pipe(
       map((opts) => {
-        const optionsMerged = opts.reduce((a, b) =>
-          ObjectUtils.mergeDeep(a, b)
-        );
+        const [firstOptions, ...remainingOptions] = opts;
+        const optionsMerged =
+          remainingOptions.reduce<ArcGISRestImageDataSourceOptions>(
+            (a, b) => ObjectUtils.mergeDeep(a, b),
+            firstOptions as ArcGISRestImageDataSourceOptions
+          );
         return new ImageArcGISRestDataSource(optionsMerged);
       }),
       catchError(() => {
@@ -457,9 +463,12 @@ export class DataSourceService {
     observables.push(of(options));
     return forkJoin(observables).pipe(
       map((opts) => {
-        const optionsMerged = opts.reduce((a, b) =>
-          ObjectUtils.mergeDeep(a, b)
-        );
+        const [firstOptions, ...remainingOptions] = opts;
+        const optionsMerged =
+          remainingOptions.reduce<TileArcGISRestDataSourceOptions>(
+            (a, b) => ObjectUtils.mergeDeep(a, b),
+            firstOptions as TileArcGISRestDataSourceOptions
+          );
         return new TileArcGISRestDataSource(optionsMerged);
       }),
       catchError(() => {

--- a/packages/geo/src/lib/datasource/shared/datasources/arcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/arcgisrest-datasource.ts
@@ -14,7 +14,7 @@ export class ArcGISRestDataSource extends DataSource {
   declare public ol: olSourceVector;
   declare public options: ArcGISRestDataSourceOptions;
 
-  get saveableOptions(): Partial<ArcGISRestDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/carto-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/carto-datasource.ts
@@ -29,7 +29,7 @@ export class CartoDataSource extends DataSource {
       : QueryHtmlTarget.BLANK;
   }
 
-  get saveableOptions(): Partial<CartoDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/cluster-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/cluster-datasource.ts
@@ -9,7 +9,7 @@ export class ClusterDataSource extends FeatureDataSource {
   declare public options: ClusterDataSourceOptions;
   declare public ol: olSourceCluster;
 
-  get saveableOptions(): Partial<ClusterDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.interface.ts
@@ -8,22 +8,24 @@ import type { Observable } from 'rxjs';
 import { DownloadOptions } from '../../../download/shared/download.interface';
 import { OgcFilterOperatorType } from '../../../filter/shared/ogc-filter.enum';
 
+export type DataSourceType =
+  | 'wms'
+  | 'wfs'
+  | 'vector'
+  | 'wmts'
+  | 'xyz'
+  | 'osm'
+  | 'tiledebug'
+  | 'carto'
+  | 'arcgisrest'
+  | 'imagearcgisrest'
+  | 'tilearcgisrest'
+  | 'websocket'
+  | 'mvt'
+  | 'cluster';
+
 export interface DataSourceOptions {
-  type?:
-    | 'wms'
-    | 'wfs'
-    | 'vector'
-    | 'wmts'
-    | 'xyz'
-    | 'osm'
-    | 'tiledebug'
-    | 'carto'
-    | 'arcgisrest'
-    | 'imagearcgisrest'
-    | 'tilearcgisrest'
-    | 'websocket'
-    | 'mvt'
-    | 'cluster';
+  type: DataSourceType;
   optionsFromCapabilities?: boolean;
   optionsFromApi?: boolean;
   _layerOptionsFromSource?: Record<string, string>;

--- a/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/datasource.ts
@@ -23,7 +23,7 @@ export abstract class DataSource {
   private legend: Legend[] = [];
   private destroyed = false;
 
-  get saveableOptions(): Partial<DataSourceOptions> {
+  get saveableOptions(): DataSourceOptions {
     return {
       id: this.id,
       type: this.options.type,
@@ -36,7 +36,7 @@ export abstract class DataSource {
   properties = new DatasourceProperties();
 
   constructor(
-    public options: DataSourceOptions = {},
+    public options: DataSourceOptions,
     protected dataService?: DataService
   ) {
     this.options = options;

--- a/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/feature-datasource.ts
@@ -8,7 +8,11 @@ export class FeatureDataSource extends DataSource {
   declare public options: FeatureDataSourceOptions;
   declare public ol: olSourceVector;
 
-  get saveableOptions(): Partial<FeatureDataSourceOptions> {
+  constructor(options: FeatureDataSourceOptions = { type: 'vector' }) {
+    super(options);
+  }
+
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/imagearcgisrest-datasource.ts
@@ -29,7 +29,7 @@ export class ImageArcGISRestDataSource extends DataSource {
       : QueryHtmlTarget.BLANK;
   }
 
-  get saveableOptions(): Partial<ArcGISRestImageDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/mvt-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/mvt-datasource.ts
@@ -13,7 +13,7 @@ export class MVTDataSource extends DataSource {
   declare public options: MVTDataSourceOptions;
   declare public ol: olSourceVectorTile;
 
-  get saveableOptions(): Partial<MVTDataSourceOptions> {
+  get saveableOptions() {
     return super.saveableOptions;
   }
 

--- a/packages/geo/src/lib/datasource/shared/datasources/osm-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/osm-datasource.ts
@@ -7,6 +7,10 @@ export class OSMDataSource extends DataSource {
   declare public options: OSMDataSourceOptions;
   declare public ol: olSourceOSM;
 
+  constructor(options: OSMDataSourceOptions = { type: 'osm' }) {
+    super(options);
+  }
+
   protected createOlSource(): olSourceOSM {
     if (!this.options.url) {
       this.options.url = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';

--- a/packages/geo/src/lib/datasource/shared/datasources/tilearcgisrest-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/tilearcgisrest-datasource.ts
@@ -30,7 +30,7 @@ export class TileArcGISRestDataSource extends DataSource {
       : QueryHtmlTarget.BLANK;
   }
 
-  get saveableOptions(): Partial<TileArcGISRestDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wfs-datasource.ts
@@ -65,7 +65,7 @@ export class WFSDataSource extends DataSource {
     return (this.options as OgcFilterableDataSourceOptions).ogcFilters;
   }
 
-  get saveableOptions(): Partial<WFSDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions;
     return {
       ...baseOptions,

--- a/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
+++ b/packages/geo/src/lib/datasource/shared/datasources/wms-datasource.ts
@@ -79,7 +79,7 @@ export class WMSDataSource extends DataSource {
     undefined
   );
 
-  get saveableOptions(): Partial<WMSDataSourceOptions> {
+  get saveableOptions() {
     const baseOptions = super.saveableOptions as WMSDataSourceOptions;
 
     if (

--- a/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
+++ b/packages/geo/src/lib/filter/ogc-filterable-item/ogc-filterable-item.component.ts
@@ -13,10 +13,7 @@ import { IgoLanguageModule } from '@igo2/core/language';
 
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import {
-  WFSDataSourceOptions,
-  WFSDataSourceOptionsParams
-} from '../../datasource/shared/datasources/wfs-datasource.interface';
+import { WFSDataSourceOptions } from '../../datasource/shared/datasources/wfs-datasource.interface';
 import { WMSDataSource } from '../../datasource/shared/datasources/wms-datasource';
 import { OgcFilterOperator } from '../../filter/shared/ogc-filter.enum';
 import { Layer } from '../../layer';
@@ -165,18 +162,10 @@ export class OgcFilterableItemComponent implements OnInit, OnDestroy {
       firstFieldName =
         includedFields[0].name === undefined ? '' : includedFields[0].name;
     }
-    let fieldNameGeometry;
-    const datasourceOptions = this.datasource
-      .options as WFSDataSourceOptionsParams;
-    if (datasourceOptions.fieldNameGeometry) {
-      fieldNameGeometry = datasourceOptions.fieldNameGeometry;
-    } else if (
-      (this.datasource.options as any).paramsWFS &&
-      (this.datasource.options as any).paramsWFS.fieldNameGeometry
-    ) {
-      fieldNameGeometry = (this.datasource.options as any).paramsWFS
-        .fieldNameGeometry;
-    }
+    const paramsWFS = (this.datasource.options as Partial<WFSDataSourceOptions>)
+      .paramsWFS;
+    const fieldNameGeometry =
+      this.datasource.options.fieldNameGeometry ?? paramsWFS?.fieldNameGeometry;
     const allowedOperators = this.ogcFilterWriter.computeAllowedOperators(
       this.datasource.options.sourceFields,
       firstFieldName,

--- a/packages/geo/src/lib/layer/layer-unavailable/layer-unavailable.component.ts
+++ b/packages/geo/src/lib/layer/layer-unavailable/layer-unavailable.component.ts
@@ -32,14 +32,16 @@ export class LayerUnavailableComponent {
   readonly remove = output<AnyLayerOptions>();
 
   get title(): string | undefined {
-    const sourceOptions = this.layerOptions()?.sourceOptions as Record<
-      string,
-      Record<string, unknown>
-    >;
+    const sourceOptions = this.layerOptions()?.sourceOptions as
+      | {
+          params?: Record<string, unknown>;
+          layer?: string;
+        }
+      | undefined;
     return (this.layerOptions()?.title ??
-      sourceOptions?.['params']?.['LAYERS'] ??
-      sourceOptions?.['params']?.['layers'] ??
-      sourceOptions?.['layer']) as string | undefined;
+      sourceOptions?.params?.['LAYERS'] ??
+      sourceOptions?.params?.['layers'] ??
+      sourceOptions?.layer) as string | undefined;
   }
 
   handleRemove(layerOptions: AnyLayerOptions): void {

--- a/packages/geo/src/lib/layer/utils/layer-options.utils.ts
+++ b/packages/geo/src/lib/layer/utils/layer-options.utils.ts
@@ -72,6 +72,10 @@ export function mergeLayersOptions(
 }
 
 function handleExternalDataSource(options: AnyLayerItemOptions): void {
+  if (!options.sourceOptions) {
+    return;
+  }
+
   options.sourceOptions = {
     ...options.sourceOptions,
     optionsFromCapabilities: true,

--- a/packages/geo/src/lib/search/shared/sources/ilayer.ts
+++ b/packages/geo/src/lib/search/shared/sources/ilayer.ts
@@ -36,6 +36,12 @@ import {
 export const ILAYER_SEARCH_SOURCE_OPTIONS =
   new InjectionToken<SearchSourceOptions>('ILayerSearchSourceOptions');
 
+type ILayerDataWithFormat = ILayerData & {
+  properties: ILayerData['properties'] & {
+    format: NonNullable<ILayerData['properties']['format']>;
+  };
+};
+
 @Injectable()
 export class ILayerSearchResultFormatter {
   private languageService = inject(LanguageService);
@@ -308,13 +314,16 @@ export class ILayerSearchSource extends SearchSource implements TextSearch {
     response: ILayerServiceResponse,
     term: string
   ): SearchResult<ILayerItemResponse>[] {
-    return response.items.map((data: ILayerData) =>
-      this.dataToResult(data, term, response)
-    );
+    return response.items
+      .filter(
+        (data): data is ILayerDataWithFormat =>
+          data.properties.format !== undefined
+      )
+      .map((data) => this.dataToResult(data, term, response));
   }
 
   private dataToResult(
-    data: ILayerData,
+    data: ILayerDataWithFormat,
     term: string,
     response?: ILayerServiceResponse
   ): SearchResult<ILayerItemResponse> {
@@ -345,9 +354,9 @@ export class ILayerSearchSource extends SearchSource implements TextSearch {
     };
   }
 
-  private computeLayerOptions(data: ILayerData): ILayerItemResponse {
+  private computeLayerOptions(data: ILayerDataWithFormat): ILayerItemResponse {
     const url = data.properties.url;
-    const queryParams: QueryableDataSourceOptions =
+    const queryParams: Partial<QueryableDataSourceOptions> =
       this.extractQueryParamsFromSourceUrl(url ?? '');
     return ObjectUtils.removeUndefined({
       sourceOptions: {

--- a/packages/geo/src/lib/utils/id-generator.ts
+++ b/packages/geo/src/lib/utils/id-generator.ts
@@ -30,9 +30,8 @@ export function generateIdFromSourceOptions(
 
     tiledebug: () => 'tiledebug'
   };
-  const generator = options.type
-    ? (generators[options.type as keyof typeof generators] ?? generateId)
-    : generateId;
+  const generator =
+    generators[options.type as keyof typeof generators] ?? generateId;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return generator(options as any);
 }


### PR DESCRIPTION
L'objectif est de renforcir le typage du type dans les options du Datasource.

Dans l'état précédent, on ne pouvait même pas définir avec confiance si les options était pour un type "wms". Vu que le "type" était optionnel, on devait vérifier la présence de d'autres propriété clé pour discerner un type. Alors que si on analyse le DatasourceService.createAsyncDataSource, on remarque que le type est bel et bien obligatoire et qu'on devrait pouvoir s'y fier pour discerner le type des DatasourceOptions.