### PR TITLE
feat(geo): datasource allow to disable options-api via config

### DIFF
--- a/packages/geo/src/lib/datasource/shared/options/options-api.interface.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options-api.interface.ts
@@ -1,4 +1,6 @@
 export interface OptionsApiOptions {
   url?: string;
   provideContextUri?: boolean;
+  /** Default to true */
+  enabled?: boolean;
 }

--- a/packages/geo/src/lib/datasource/shared/options/options-api.service.ts
+++ b/packages/geo/src/lib/datasource/shared/options/options-api.service.ts
@@ -30,7 +30,7 @@ export class OptionsApiService extends OptionsService {
     const options = config.getConfig<OptionsApiOptions>('optionsApi');
 
     super();
-    this.urlApi = options?.url;
+    this.urlApi = options?.enabled === false ? undefined : options?.url;
     this.provideContextUri = options?.provideContextUri ?? false;
   }
 


### PR DESCRIPTION
On veut permettre la désactivation des appels aux APIS de options-api via une configuration. Cela permettra aux application qui nécessitait auparavant l'API du MSI pour augmenter leurs options de désactivé ces requêtes tout en bénéficiant de la recherche de couche et autres services du MSI.