### PR TITLE
fix(integration): search clear overlays and selected results in search results tool

### DIFF
--- a/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
+++ b/packages/integration/src/lib/search/search-results-tool/search-results-tool.component.ts
@@ -230,6 +230,8 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
         this.term = searchTerm;
         this.debouncedEmpty.set(false);
       } else if (searchTerm === '') {
+        this.clearResultOverlays();
+        this.searchState.clearSelectedResult();
         this.debouncedEmpty.set(true);
       }
     });
@@ -351,8 +353,7 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
    * @param result A search result that could be a feature or some layer options
    */
   onResultSelect(result: SearchResult) {
-    this.searchResultsOverlayFocused.clear();
-    this.searchResultsOverlaySelected.clear();
+    this.clearResultOverlays();
     this.addResultToOverlay(
       result,
       this.searchResultsOverlaySelected,
@@ -423,6 +424,11 @@ export class SearchResultsToolComponent implements OnInit, OnDestroy {
         }
       });
     }, 250);
+  }
+
+  private clearResultOverlays() {
+    this.searchResultsOverlayFocused?.clear();
+    this.searchResultsOverlaySelected?.clear();
   }
 
   computeElementRef() {

--- a/packages/integration/src/lib/search/search.state.ts
+++ b/packages/integration/src/lib/search/search.state.ts
@@ -195,6 +195,10 @@ export class SearchState {
     this.selectedResult$.next(result);
   }
 
+  clearSelectedResult() {
+    this.selectedResult$.next(undefined);
+  }
+
   setSearchResultsGeometryStatus(value: boolean) {
     this.storageService.set('searchResultsGeometryEnabled', value);
     this.searchResultsGeometryEnabled$.next(value);


### PR DESCRIPTION
Pour tester, sélectionnez un élément dans les résultats de recherche qui devrait afficher sa location sur la carte via une pin. Cliquer dans le search bar sur le X pour effacer le résultat de recherche, cela devrait aussi effacer la pin sur la carte.